### PR TITLE
Add locking and proper error reporting for permissions

### DIFF
--- a/pkg/drivers/dutlink-board/device.go
+++ b/pkg/drivers/dutlink-board/device.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+	"github.com/jumpstarter-dev/jumpstarter/pkg/locking"
 	"go.bug.st/serial"
 )
 
@@ -16,6 +17,7 @@ type JumpstarterDevice struct {
 	version        string
 	serialNumber   string
 	serialPort     serial.Port
+	fileLock       locking.Lock
 	mutex          *sync.Mutex
 	singletonMutex *sync.Mutex
 	name           string

--- a/pkg/drivers/dutlink-board/udev.go
+++ b/pkg/drivers/dutlink-board/udev.go
@@ -121,7 +121,10 @@ func scanUdev() ([]*JumpstarterDevice, error) {
 				panic("expected only one tty device")
 			}
 
-			jp := newJumpstarter(ttynames[0].Name(), version, serial)
+			jp, err := newJumpstarter(ttynames[0].Name(), version, serial)
+			if err != nil {
+				return err
+			}
 			res = append(res, &jp)
 
 		}

--- a/pkg/harness/device.go
+++ b/pkg/harness/device.go
@@ -1,7 +1,6 @@
 package harness
 
 import (
-	"errors"
 	"io"
 	"time"
 )
@@ -33,10 +32,3 @@ type Device interface {
 	Lock() error   // open/lock the device so other instances cannot use it
 	Unlock() error // close the locked device so other instances can use it
 }
-
-// basic errors
-var ErrCannotOpenDevice = errors.New("unable to open device tty")
-var ErrNotImplemented = errors.New("not implemented")
-var ErrCannotSetBaudRate = errors.New("unable to set baud rate")
-var ErrCannotSetDiskImage = errors.New("unable to set disk image")
-var ErrDeviceNotResponding = errors.New("device not responding")

--- a/pkg/harness/errors.go
+++ b/pkg/harness/errors.go
@@ -1,0 +1,11 @@
+package harness
+
+import "errors"
+
+// basic errors
+var ErrDeviceInUse = errors.New("device is in use")
+var ErrCannotOpenDevice = errors.New("unable to open device tty")
+var ErrNotImplemented = errors.New("not implemented")
+var ErrCannotSetBaudRate = errors.New("unable to set baud rate")
+var ErrCannotSetDiskImage = errors.New("unable to set disk image")
+var ErrDeviceNotResponding = errors.New("device not responding")

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -1,0 +1,71 @@
+package locking
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+)
+
+const JUMPSTARTER_LOCK_BASE = "/tmp/jumpstarter-locks/"
+
+func init() {
+	if _, err := os.Stat(JUMPSTARTER_LOCK_BASE); os.IsNotExist(err) {
+		umask := syscall.Umask(0)
+		err := os.Mkdir(JUMPSTARTER_LOCK_BASE, 0777)
+		syscall.Umask(umask)
+
+		if err != nil {
+			fmt.Printf("Error creating %s\n", JUMPSTARTER_LOCK_BASE)
+			os.Exit(1)
+		}
+	}
+}
+
+type Lock struct {
+	fd       int
+	fileName string
+}
+
+func TryLock(devicePath string) (Lock, error) {
+	baseName := filepath.Base(devicePath)
+	fileLock := JUMPSTARTER_LOCK_BASE + "LCK.." + baseName
+
+	umask := syscall.Umask(0)
+	fd, err := syscall.Open(fileLock, syscall.O_CREAT|syscall.O_RDONLY, 0666)
+	syscall.Umask(umask)
+	if err != nil {
+		return Lock{}, fmt.Errorf("TryLock: opening %q:  %w", fileLock, err)
+	}
+
+	err = syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+
+	if err == syscall.EWOULDBLOCK {
+		syscall.Close(fd)
+		return Lock{}, harness.ErrDeviceInUse
+	}
+
+	if err != nil {
+		syscall.Close(fd)
+	}
+
+	return Lock{fd, fileLock}, nil
+}
+
+func (l *Lock) Unlock() error {
+	err := syscall.Flock(l.fd, syscall.LOCK_UN)
+	if err != nil {
+		return fmt.Errorf("Unlock: %w", err)
+	}
+	err = syscall.Close(l.fd)
+	if err != nil {
+		return fmt.Errorf("Unlock: %w", err)
+	}
+	err = os.Remove(l.fileName)
+	if err != nil {
+		return fmt.Errorf("Unlock: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Now two jumpstarter instances can't access the same port concurrently, performing commands on a busy device will return an error, and the busy devices are listed in BUSY state.

If you try to open a serial port and you don't have permissions for the device an error will be reported too.