### PR TITLE
Retry the run-script until a device is available

### DIFF
--- a/cmd/listDevices.go
+++ b/cmd/listDevices.go
@@ -22,7 +22,7 @@ var listDevicesCmd = &cobra.Command{
 		tags, err := cmd.Flags().GetStringArray("tag")
 		handleErrorAsFatal(err)
 
-		devices, err := harness.FindDevices(driver, tags)
+		devices, _, err := harness.FindDevices(driver, tags)
 		handleErrorAsFatal(err)
 		if cmd.Flag("only-names").Value.String() == "true" {
 			printDeviceNames(devices)

--- a/pkg/harness/driver.go
+++ b/pkg/harness/driver.go
@@ -27,8 +27,9 @@ func GetDrivers() []HarnessDriver {
 // FindDevices iterates over the available drivers and gets a list of devices.
 // If a driver is specified, only devices for that driver are returned.
 
-func FindDevices(driverName string, tags []string) ([]Device, error) {
+func FindDevices(driverName string, tags []string) ([]Device, int, error) {
 	var devices []Device
+	busyCount := 0
 	for _, driver := range drivers {
 		if driverName != "" && driverName != driver.Name() {
 			continue // skip this driver
@@ -36,9 +37,12 @@ func FindDevices(driverName string, tags []string) ([]Device, error) {
 
 		d, err := driver.FindDevices()
 		if err != nil {
-			return nil, fmt.Errorf("(%q).FindDevices: %w", driver.Name(), err)
+			return nil, 0, fmt.Errorf("(%q).FindDevices: %w", driver.Name(), err)
 		}
 		for _, device := range d {
+			if busy, _ := device.IsBusy(); busy {
+				busyCount++
+			}
 			if len(tags) != 0 {
 				deviceTags := device.Tags()
 				if contains_tags(deviceTags, tags) {
@@ -50,7 +54,7 @@ func FindDevices(driverName string, tags []string) ([]Device, error) {
 		}
 
 	}
-	return devices, nil
+	return devices, busyCount, nil
 }
 
 func contains_tags(slice []string, tags []string) bool {
@@ -75,7 +79,7 @@ func contains_tag(slice []string, str string) bool {
 // FindDevice iterates over the available drivers and return a specific Device.
 // If a driver is specified, only devices for that driver are returned.
 func FindDevice(driverName string, deviceId string) (Device, error) {
-	devices, err := FindDevices(driverName, []string{})
+	devices, _, err := FindDevices(driverName, []string{})
 	if err != nil {
 		return nil, fmt.Errorf("FindDevices: %w", err)
 	}

--- a/pkg/runner/errors.go
+++ b/pkg/runner/errors.go
@@ -1,0 +1,8 @@
+package runner
+
+import "errors"
+
+// basic errors
+var ErrNoDevices = errors.New("no suitable devices were found")
+var ErrAllDevicesBusy = errors.New("no available devices found, possible runners but busy")
+var ErrAllDevicesBusyTimeout = errors.New("timed out waiting for devices to become available")

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -1,9 +1,11 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
@@ -23,12 +25,37 @@ func RunScript(device_id, driver, yaml_file string, disableCleanup bool) error {
 
 	var device harness.Device
 
-	// TODO implement retry/wait
-	//      sometimes devices are busy or can happen fail due to a race condition
-	device, err := script.getDevice(device_id, driver)
-	if err != nil {
-		return fmt.Errorf("RunScript: %w", err)
+	// get current time so we can check for timeout later on the loop
+	startTime := time.Now()
+
+	firstAttempt := true
+	for device == nil && time.Since(startTime) < time.Duration(script.Timeout)*time.Second {
+		var err error
+		device, err = script.getDevice(device_id, driver)
+		switch {
+		case errors.Is(err, ErrAllDevicesBusy):
+			if firstAttempt {
+				fmt.Print("⌛ Waiting for available devices: ")
+				firstAttempt = false
+			}
+			fmt.Print("·")
+			time.Sleep(15 * time.Second)
+
+		case err != nil:
+			return fmt.Errorf("RunScript: %w", err)
+		}
 	}
+
+	if device == nil {
+		fmt.Println("❌")
+		return ErrAllDevicesBusyTimeout
+	}
+
+	// if we wrote the line "Waiting for available devices" before, we need to confirm what happened
+	if !firstAttempt {
+		fmt.Println(" a device became available ✅")
+	}
+
 	color.Set(color.FgHiYellow)
 	fmt.Printf("⚙ Using device %q with tags %v\n", device.Name(), device.Tags())
 	color.Unset()
@@ -93,20 +120,24 @@ func (p *JumpstarterScript) getDevice(device_id string, driver string) (harness.
 		return device, nil
 	} else {
 
-		devices, err := harness.FindDevices(driver, p.Selector)
+		devices, busyCount, err := harness.FindDevices(driver, p.Selector)
 		if err != nil {
 			return nil, fmt.Errorf("getDevice: %w", err)
 		}
 
 		nonBusy := filterOutBusy(devices)
 
-		if len(devices) == 0 {
-			return nil, fmt.Errorf("getDevice: no devices found")
+		if len(devices) == 0 && busyCount == 0 {
+			return nil, ErrNoDevices
+		}
+
+		if len(devices) == 0 && busyCount > 0 {
+			// TODO: the dutlink driver cannot really read tags while busy yet
+			return nil, ErrAllDevicesBusy
 		}
 
 		if len(nonBusy) == 0 {
-
-			return nil, fmt.Errorf("getDevice: all devices are busy")
+			return nil, ErrAllDevicesBusy
 		}
 
 		device := nonBusy[rand.Intn(len(nonBusy))]

--- a/pkg/runner/script.go
+++ b/pkg/runner/script.go
@@ -12,6 +12,7 @@ import (
 type JumpstarterScript struct {
 	Name          string            `yaml:"name"`
 	Selector      []string          `yaml:"selector"`
+	Timeout       uint              `default:"1800" yaml:"timeout"`
 	Drivers       []string          `yaml:"drivers"`
 	ExpectTimeout uint              `default:"120" yaml:"expect-timeout"`
 	Steps         []JumpstarterStep `yaml:"steps"`

--- a/website/content/en/docs/Reference/scripting.md
+++ b/website/content/en/docs/Reference/scripting.md
@@ -65,6 +65,8 @@ name: "Name of your script"
 selector:
   - tag
 
+timeout: 1800
+
 expect-timeout: 60
 
 steps:
@@ -75,12 +77,13 @@ cleanup:
 
 ```
 
-A script has a name, a selector, and a expect-timeout as main fields:
+A script has a name, a selector, and a timeout and a expect-timeout as main fields:
 
 | Field             | Description |
 | -----------       | ----------- |
 | name              | Just a descriptive name for the script       |
 | selector          | A list of tags to find a compatible board from those available on the host        |
+| timeout           | This is the selection timeout, when waiting for a valid device based on the selector tags to become available |
 | expect-timeout    | This is the default timeout for expect steps        |
 
 ## Script step commands


### PR DESCRIPTION
Now that we have locking implemented we can detect when another runner or developer is using the jumpstarter system needed for a script. If that's the case we retry for a defined abount of time in the script, the timeout. It defaults to 1800 seconds or 30 minutes.