### PR TITLE
SD-Wire / smartplug driver

### DIFF
--- a/etc/jumpstarter/sd-wire/device1.yaml
+++ b/etc/jumpstarter/sd-wire/device1.yaml
@@ -1,0 +1,9 @@
+
+serial: device1 # as configured from sd-mux-ctrl -v 0 --set-serial device1
+tags:
+  - rpi4
+usb_console: FTFWYL4G-if00 # /dev/serial/by-id/usb-FTDI_USB__-__Serial_Cable_FTFWYL4G-if00-port0
+smartplug:
+  generic: # generic commands for a shelly plug
+    on_command: curl --digest -u admin:jumpstarter "http://192.168.1.208/relay/0?turn=on"
+    off_command: curl --digest -u admin:jumpstarter "http://192.168.1.208/relay/0?turn=off"

--- a/pkg/drivers/sd-wire/config.go
+++ b/pkg/drivers/sd-wire/config.go
@@ -1,0 +1,44 @@
+package sdwire
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yaml parser
+
+// see etc/jumpstarter/sd-wire/device0.yaml example file
+type SDWireConfig struct {
+	Serial     string           `yaml:"serial"`
+	Tags       []string         `yaml:"tags"`
+	USBConsole string           `yaml:"usb_console"`
+	SmartPlug  *SmartPlugConfig `yaml:"smartplug"`
+}
+
+type SmartPlugConfig struct {
+	Generic *SmartPlugGenericConfig `yaml:"generic"`
+}
+
+type SmartPlugGenericConfig struct {
+	OnCommand  string `yaml:"on_command"`
+	OffCommand string `yaml:"off_command"`
+}
+
+const CONFIG_BASE_PATH = "/etc/jumpstarter/sd-wire"
+
+func ReadConfig(serial string) (*SDWireConfig, error) {
+	yaml_file := CONFIG_BASE_PATH + "/" + serial + ".yaml"
+	script_data, err := os.ReadFile(yaml_file)
+	if err != nil {
+		return nil, fmt.Errorf("ReadConfig(%q): Error reading yaml file: %w", yaml_file, err)
+	}
+	config := SDWireConfig{}
+	if err := yaml.Unmarshal([]byte(script_data), &config); err != nil {
+		return nil, fmt.Errorf("ReadConfig(%q): %w", yaml_file, err)
+	}
+
+	// TODO: Apply sanity checks to configuration
+	return &config, nil
+}

--- a/pkg/drivers/sd-wire/device.go
+++ b/pkg/drivers/sd-wire/device.go
@@ -1,0 +1,117 @@
+package sdwire
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/jumpstarter-dev/jumpstarter/pkg/console"
+	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+	"github.com/jumpstarter-dev/jumpstarter/pkg/locking"
+	"github.com/jumpstarter-dev/jumpstarter/pkg/tools"
+	"go.bug.st/serial"
+)
+
+type SDWireDevice struct {
+	driver         *SDWireDriver
+	config         *SDWireConfig
+	devicePath     string
+	storagePath    string
+	name           string
+	serialPort     serial.Port
+	fileLock       locking.Lock
+	mutex          *sync.Mutex
+	singletonMutex *sync.Mutex
+	busy           bool
+}
+
+func (d *SDWireDevice) Lock() error {
+	lock, err := locking.TryLock(d.devicePath)
+	d.fileLock = lock
+	if err != nil {
+		return fmt.Errorf("Lock: locking %q %w", d.devicePath, err)
+	}
+	return nil
+}
+
+func (d *SDWireDevice) Unlock() error {
+	return d.fileLock.Unlock()
+}
+
+func (d *SDWireDevice) Power(action string) error {
+	if d.config.SmartPlug == nil || d.config.SmartPlug.Generic == nil {
+		return fmt.Errorf("Power: no smart plug configured %+v", d.config)
+	}
+
+	if action == "on" || action == "force-on" {
+		return tools.RunBash(d.config.SmartPlug.Generic.OnCommand, nil, os.Stderr)
+	}
+
+	if action == "off" || action == "force-off" {
+		return tools.RunBash(d.config.SmartPlug.Generic.OffCommand, nil, os.Stderr)
+	}
+
+	return nil
+}
+
+func (d *SDWireDevice) Console() (harness.ConsoleInterface, error) {
+	return console.OpenUSBSerial(d.devicePath)
+}
+
+func (d *SDWireDevice) SetConsoleSpeed(bps int) error {
+	return harness.ErrNotImplemented
+}
+
+func (d *SDWireDevice) Driver() harness.HarnessDriver {
+	return d.driver
+}
+
+func (d *SDWireDevice) Version() (string, error) {
+	return "0.1", nil
+}
+
+func (d *SDWireDevice) Serial() (string, error) {
+	return d.name, nil
+}
+
+func (d *SDWireDevice) SetControl(signal string, value string) error {
+
+	return harness.ErrNotImplemented
+}
+
+func (d *SDWireDevice) Device() (string, error) {
+	return d.devicePath, nil
+}
+
+func (d *SDWireDevice) GetConfig() (map[string]string, error) {
+	config := map[string]string{}
+	return config, nil
+}
+
+func (d *SDWireDevice) SetConfig(k, v string) error {
+	return harness.ErrNotImplemented
+}
+
+func (d *SDWireDevice) SetName(name string) error {
+	return harness.ErrNotImplemented
+}
+
+func (d *SDWireDevice) SetUsbConsole(usb_console string) error {
+	return harness.ErrNotImplemented
+}
+
+func (d *SDWireDevice) SetTags(tags []string) error {
+	return harness.ErrNotImplemented
+}
+
+func (d *SDWireDevice) Tags() []string {
+	return d.config.Tags
+}
+
+func (d *SDWireDevice) IsBusy() (bool, error) {
+	return d.busy, nil
+}
+
+func (d *SDWireDevice) Name() string {
+	return d.name
+}

--- a/pkg/drivers/sd-wire/driver.go
+++ b/pkg/drivers/sd-wire/driver.go
@@ -1,0 +1,39 @@
+package sdwire
+
+import (
+	"fmt"
+
+	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+)
+
+type SDWireDriver struct{}
+
+func (d *SDWireDriver) Name() string {
+	return "sd-wire-splug"
+}
+
+func (d *SDWireDriver) Description() string {
+	return `SD-Wire + smart plug + usb-serial based driver
+	enables the control of Edge and Embedded devices via smart plug and usb-serial,
+	controlling storage via an Open Hardware sd-wire device.
+	   https://shop.3mdeb.com/shop/open-source-hardware/sdwire/
+	It has the following capabilities: power metering, power cycling, and serial console
+	access, and USB storage switching.
+	`
+}
+
+func (d *SDWireDriver) FindDevices() ([]harness.Device, error) {
+	hdList := []harness.Device{}
+	sdwires, err := scanUdev()
+	if err != nil {
+		return nil, fmt.Errorf("FindDevices: %w", err)
+	}
+	for _, jumpstarter := range sdwires {
+		hdList = append(hdList, jumpstarter)
+	}
+	return hdList, nil
+}
+
+func init() {
+	harness.RegisterDriver(&SDWireDriver{})
+}

--- a/pkg/drivers/sd-wire/storage.go
+++ b/pkg/drivers/sd-wire/storage.go
@@ -1,0 +1,64 @@
+package sdwire
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jumpstarter-dev/jumpstarter/pkg/storage"
+	"github.com/jumpstarter-dev/jumpstarter/pkg/tools"
+)
+
+const BASE_DISKSBYID = "/dev/disk/by-id/"
+
+const BLOCK_SIZE = 8 * 1024 * 1024
+
+const WAIT_TIME_USB_STORAGE = 8 * time.Second
+
+type StorageTarget int
+
+const (
+	HOST StorageTarget = iota
+	DUT
+)
+
+func (d *SDWireDevice) SetDiskImage(path string, offset uint64) error {
+
+	err := d.AttachStorage(false) // attach to host, detach from DUT
+	if err != nil {
+		return fmt.Errorf("SetDiskImage: %w", err)
+	}
+	for i := 0; i < 10; i++ {
+		// check if path exists
+		if _, err := os.Stat(d.storagePath); err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if _, err := os.Stat(d.storagePath); err != nil {
+		return fmt.Errorf("SetDiskImage: timeout waiting for device %q to come up", path)
+	}
+
+	fmt.Printf("📋 %s -> %s offset 0x%x: \n", path, d.storagePath, offset)
+
+	if err := storage.WriteImageToDisk(path, d.storagePath, offset, BLOCK_SIZE, false); err != nil {
+		return fmt.Errorf("SetDiskImage: %w", err)
+	}
+
+	return d.AttachStorage(true) // attach to DUT, detach from host
+}
+
+func (d *SDWireDevice) AttachStorage(connected bool) error {
+	var err error
+	switch connected {
+	case true:
+		err = tools.RunBash("sd-mux-ctrl --device-serial="+d.name+" --dut", os.Stdout, os.Stderr)
+	case false:
+		err = tools.RunBash("sd-mux-ctrl --device-serial="+d.name+" --ts", os.Stdout, os.Stderr)
+	}
+	if err != nil {
+		return fmt.Errorf("AttachStorage(%v): %w", connected, err)
+	}
+	return nil
+}

--- a/pkg/drivers/sd-wire/udev.go
+++ b/pkg/drivers/sd-wire/udev.go
@@ -1,0 +1,125 @@
+package sdwire
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jumpstarter-dev/jumpstarter/pkg/console"
+)
+
+const (
+	BASE_UDEVPATH = "/sys/bus/usb/devices/"
+	USB_VID       = "0424"
+	USB_PID       = "2640"
+)
+
+func scanUdev() ([]*SDWireDevice, error) {
+	res := []*SDWireDevice{}
+
+	err := filepath.Walk(BASE_UDEVPATH, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() && info.Name() == "devices" {
+			return nil
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			idProduct, err := readUdevAttribute(path, "idProduct")
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+
+			idVendor, err := readUdevAttribute(path, "idVendor")
+			if err != nil {
+				return err
+			}
+
+			if idVendor != USB_VID || idProduct != USB_PID {
+				return nil
+			}
+
+			usbRootDevice := getUsbRootDevice(path)
+
+			// read serial from the ftdi device inside the hub
+			serial, err := readUdevAttribute(path+"/"+usbRootDevice+".2", "serial")
+			if err != nil {
+				return err
+			}
+
+			// find the block device name
+			bdDir := fmt.Sprintf("%s/%s.1/%s.1:1.0/host2/target2:0:0/2:0:0:0/block/", path, usbRootDevice, usbRootDevice)
+			var bdDev string
+			entries, err := os.ReadDir(bdDir)
+			if err != nil {
+				return fmt.Errorf("scanUdev: scanning for block files in sd-wire device %w", err)
+			}
+
+			for _, entry := range entries {
+				if entry.IsDir() {
+					bdDev = "/dev/" + entry.Name()
+					break
+				}
+			}
+
+			if bdDev == "" {
+				return fmt.Errorf("scanUdev: no block device found in sd-wire device %s", serial)
+			}
+
+			cfg, err := ReadConfig(serial)
+
+			if err != nil && !os.IsNotExist(err) {
+				fmt.Printf("Warning: a sdwire device with serial %q was found but no config file was found: %v\n", serial, err)
+				return nil
+			}
+
+			device, err := console.FindUSBSerialDevice(cfg.USBConsole)
+			if errors.Is(err, console.ErrDeviceNotFound) {
+				fmt.Printf("Warning: a sdwire device with serial %q cannot find serial interface matching: %v\n", cfg.USBConsole, err)
+				return nil
+			}
+			res = append(res, &SDWireDevice{
+				name:        serial,
+				devicePath:  device,
+				storagePath: bdDev,
+				config:      cfg,
+				driver:      &SDWireDriver{},
+			})
+
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("scanUdev: %w", err)
+	}
+	return res, nil
+}
+
+// TODO Refactor into udev utils module
+func readUdevAttribute(path string, attribute string) (string, error) {
+	value, err := os.ReadFile(filepath.Join(path, attribute))
+	if err != nil {
+		return "", err
+	}
+	valueStr := strings.TrimRight(string(value), "\r\n")
+	return valueStr, nil
+}
+
+// TODO Refactor into udev utils module
+// getUsbRootDevice
+// converts something like /sys/bus/usb/devices/1-2.5/ into 1-2.5
+func getUsbRootDevice(path string) string {
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+)
+
+func RunBash(script string, stdout, stderr io.Writer) error {
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script + "\n")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
This driver enables jumpstarter to work with the SD-Wire devices  + an smart
plug + a usb-serial cable attached to the DUT

It requires the sd-mux-ctrl cmdline tool installed on the system.
