### PR TITLE
Add missing error check to createAnsibleInventory command

### DIFF
--- a/cmd/createAnsibleInventory.go
+++ b/cmd/createAnsibleInventory.go
@@ -27,7 +27,8 @@ var createAnsibleInventory = &cobra.Command{
 
 		device, err := harness.FindDevice(driver, args[0])
 		handleErrorAsFatal(err)
-		tools.CreateAnsibleInventory(device, os.Stdout, user, sshKey)
+		err = tools.CreateAnsibleInventory(device, os.Stdout, user, sshKey)
+		handleErrorAsFatal(err)
 	},
 }
 


### PR DESCRIPTION
Calls to `CreateAnsibleInventory` can fail silently without producing a inventory file due to the missing error check.