### PR TITLE
Add missing \r to command send via RunCommand

### DIFF
--- a/pkg/tools/run_command.go
+++ b/pkg/tools/run_command.go
@@ -23,7 +23,7 @@ func RunCommand(console harness.ConsoleInterface, cmd string, wait int) (string,
 		}
 	}
 
-	if _, err := console.Write([]byte(cmd + "\n")); err != nil {
+	if _, err := console.Write([]byte(cmd + "\r\n")); err != nil {
 		return "", fmt.Errorf("runCommand %s, sending command: %w", cmd, err)
 	}
 


### PR DESCRIPTION
VT100 implementation in golang[1] expects \r as newline (enter key)[2]. Also brings it in line with other parts of the codebase.

[1] https://pkg.go.dev/golang.org/x/term
[2] https://cs.opensource.google/go/x/term/+/refs/tags/v0.20.0:terminal.go;l=119