### PR TITLE
Make RunCommand always wait until no new output is produced within timeout

### DIFF
--- a/pkg/tools/run_command.go
+++ b/pkg/tools/run_command.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -8,19 +9,33 @@ import (
 	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
 )
 
-func RunCommand(console harness.ConsoleInterface, cmd string, wait int) (string, error) {
+func readUntil(console harness.ConsoleInterface) ([]byte, error) {
+	// Read the console in a loop until no more data is produced within the read timeout.
+	// Because some devices will only provide a few bytes at a time (i.e. 64),
+	// and a single Read call cannot drain the whole command output.
+	all := bytes.NewBuffer(nil)
 	buf := make([]byte, 1024)
-	// clear the input buffer first, we loop because some devices will only provide
-	// a few bytes at a time (i.e. 64)
 	for {
-		console.SetReadTimeout(100 * time.Millisecond)
 		n, err := console.Read(buf)
 		if err != nil {
-			return "", fmt.Errorf("runCommand %s, clearing input buffer: %w", cmd, err)
+			return nil, err
 		}
 		if n == 0 {
 			break
 		}
+		// not checking as err is always nil for Buffer.Write
+		_, _ = all.Write(buf[:n])
+	}
+	return all.Bytes(), nil
+}
+
+func RunCommand(console harness.ConsoleInterface, cmd string, wait int) (string, error) {
+	console.SetReadTimeout(100 * time.Millisecond)
+
+	// clear the input buffer first
+	_, err := readUntil(console)
+	if err != nil {
+		return "", fmt.Errorf("runCommand %s, clearing input buffer: %w", cmd, err)
 	}
 
 	if _, err := console.Write([]byte(cmd + "\n")); err != nil {
@@ -28,13 +43,13 @@ func RunCommand(console harness.ConsoleInterface, cmd string, wait int) (string,
 	}
 
 	time.Sleep(time.Duration(wait) * time.Second)
-	n, err := console.Read(buf)
+
+	all, err := readUntil(console)
 	if err != nil {
 		return "", fmt.Errorf("runCommand %s, reading response: %w", cmd, err)
 	}
 
-	all := string(buf[:n])
-	lines := strings.Split(all, "\n")
+	lines := strings.Split(string(all), "\n")
 	if len(lines) > 1 {
 		// the first line is the command we just sent, so we skip it
 		return strings.Join(lines[1:], "\n"), nil


### PR DESCRIPTION
Because some devices will only provide a few bytes at a time (i.e. 64), and a single Read call cannot drain the whole command output.