### PR TITLE
Implement a mock driver

### DIFF
--- a/pkg/drivers/all/drivers.go
+++ b/pkg/drivers/all/drivers.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	_ "github.com/jumpstarter-dev/jumpstarter/pkg/drivers/dutlink-board"
+	_ "github.com/jumpstarter-dev/jumpstarter/pkg/drivers/mock"
 )
 
 // The purpose of this package is to import all the drivers so that they are

--- a/pkg/drivers/mock/console.go
+++ b/pkg/drivers/mock/console.go
@@ -1,0 +1,94 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"golang.org/x/term"
+)
+
+type MockConsole struct {
+	timeout time.Duration
+	stdin   io.WriteCloser
+	stdout  io.ReadCloser
+}
+
+type ContextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r *ContextReader) Read(p []byte) (n int, err error) {
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+
+	go func() {
+		n, err := r.r.Read(p)
+		ch <- result{n, err}
+	}()
+
+	select {
+	case <-r.ctx.Done():
+		return 0, nil
+	case res := <-ch:
+		return res.n, res.err
+	}
+}
+
+type ReadWriter struct {
+	io.Reader
+	io.Writer
+}
+
+func newMockConsole() (*MockConsole, error) {
+	ir, iw := io.Pipe()
+	or, ow := io.Pipe()
+
+	terminal := term.NewTerminal(ReadWriter{Reader: ir, Writer: ow}, "[mock@jumpstarter:~]$ ")
+
+	go func() {
+		for {
+			line, err := terminal.ReadLine()
+			if err != nil {
+				break
+			}
+			if line == "ip a show dev eth0" {
+				fmt.Fprintf(terminal,
+					`1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
+    inet 192.0.2.2/24 metric 2048 brd 192.0.2.255 scope global dynamic eth0
+       valid_lft forever preferred_lft forever
+`) // FIXME: check err
+			} else {
+				fmt.Fprintf(terminal, "Error: Not Implemented\n") // FIXME: check err
+			}
+		}
+	}()
+
+	return &MockConsole{timeout: time.Second, stdin: iw, stdout: or}, nil
+}
+
+func (c *MockConsole) Read(p []byte) (n int, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	reader := ContextReader{ctx: ctx, r: c.stdout}
+	return reader.Read(p)
+}
+
+func (c *MockConsole) Write(p []byte) (int, error) {
+	return c.stdin.Write(p)
+}
+
+func (c *MockConsole) SetReadTimeout(t time.Duration) error {
+	c.timeout = t
+	return nil
+}
+
+func (c *MockConsole) Close() error {
+	return nil
+}

--- a/pkg/drivers/mock/console.go
+++ b/pkg/drivers/mock/console.go
@@ -1,9 +1,9 @@
 package mock
 
 import (
-	"context"
 	"fmt"
 	"io"
+	"net"
 	"time"
 
 	"golang.org/x/term"
@@ -11,33 +11,8 @@ import (
 
 type MockConsole struct {
 	timeout time.Duration
-	stdin   io.WriteCloser
+	stdin   net.Conn
 	stdout  io.ReadCloser
-}
-
-type ContextReader struct {
-	ctx context.Context
-	r   io.Reader
-}
-
-func (r *ContextReader) Read(p []byte) (n int, err error) {
-	type result struct {
-		n   int
-		err error
-	}
-	ch := make(chan result, 1)
-
-	go func() {
-		n, err := r.r.Read(p)
-		ch <- result{n, err}
-	}()
-
-	select {
-	case <-r.ctx.Done():
-		return 0, nil
-	case res := <-ch:
-		return res.n, res.err
-	}
 }
 
 type ReadWriter struct {
@@ -46,7 +21,7 @@ type ReadWriter struct {
 }
 
 func newMockConsole() (*MockConsole, error) {
-	ir, iw := io.Pipe()
+	ir, iw := net.Pipe()
 	or, ow := io.Pipe()
 
 	terminal := term.NewTerminal(ReadWriter{Reader: ir, Writer: ow}, "[mock@jumpstarter:~]$ ")
@@ -74,10 +49,8 @@ func newMockConsole() (*MockConsole, error) {
 }
 
 func (c *MockConsole) Read(p []byte) (n int, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
-	defer cancel()
-	reader := ContextReader{ctx: ctx, r: c.stdout}
-	return reader.Read(p)
+	c.stdin.SetReadDeadline(time.Now().Add(c.timeout))
+	return c.stdout.Read(p)
 }
 
 func (c *MockConsole) Write(p []byte) (int, error) {

--- a/pkg/drivers/mock/device.go
+++ b/pkg/drivers/mock/device.go
@@ -1,0 +1,194 @@
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+	"github.com/jumpstarter-dev/jumpstarter/pkg/locking"
+)
+
+const JUMPSTARTER_MOCK_PATH = "/tmp/jumpstarter-mock.json"
+
+type MockDeviceData struct {
+	file         *os.File
+	Name         string            `json:"name"`
+	Device       string            `json:"device"`
+	Version      string            `json:"version"`
+	Serial       string            `json:"serial"`
+	Tags         []string          `json:"tags"`
+	Config       map[string]string `json:"config"`
+	Control      map[string]string `json:"control"`
+	Power        string            `json:"power"`
+	ConsoleSpeed int               `json:"console_speed"`
+	UsbConsole   string            `json:"usb_console"`
+	ImagePath    string            `json:"image_path"`
+	ImageOffset  uint64            `json:"image_offset"`
+	Storage      bool              `json:"storage"`
+	Busy         bool              `json:"busy"`
+}
+
+func (d *MockDeviceData) load() error {
+	_, err := d.file.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	return json.NewDecoder(d.file).Decode(d)
+}
+
+func (d *MockDeviceData) save() error {
+	_, err := d.file.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(d.file).Encode(d)
+}
+
+type MockDevice struct {
+	driver   *MockDriver
+	fileLock locking.Lock
+	data     MockDeviceData
+}
+
+func newMockDevice() (*MockDevice, error) {
+	file, err := os.OpenFile(JUMPSTARTER_MOCK_PATH, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	device := &MockDevice{
+		driver: &MockDriver{},
+		data: MockDeviceData{
+			file:         file,
+			Name:         "mock",
+			Device:       "/dev/jumpstarter-mock",
+			Version:      "1.0.0",
+			Serial:       "001",
+			Tags:         []string{},
+			Config:       map[string]string{},
+			Control:      map[string]string{},
+			Power:        "off",
+			ConsoleSpeed: 0,
+			UsbConsole:   "",
+			ImagePath:    "",
+			ImageOffset:  0,
+			Storage:      false,
+			Busy:         false,
+		},
+	}
+	device.data.load() // ignoring error
+	err = device.data.save()
+	if err != nil {
+		return nil, err
+	}
+	return device, nil
+}
+
+func (d *MockDevice) Driver() harness.HarnessDriver {
+	return d.driver
+}
+
+func (d *MockDevice) Version() (string, error) {
+	err := d.data.load()
+	return d.data.Version, err
+}
+
+func (d *MockDevice) Serial() (string, error) {
+	err := d.data.load()
+	return d.data.Serial, err
+}
+
+func (d *MockDevice) Name() string {
+	d.data.load() // FIXME: check err
+	return d.data.Name
+}
+
+func (d *MockDevice) SetName(name string) error {
+	d.data.Name = name
+	return d.data.save()
+}
+
+func (d *MockDevice) Tags() []string {
+	d.data.load() // FIXME: check err
+	return d.data.Tags
+}
+
+func (d *MockDevice) SetTags(tags []string) error {
+	d.data.Tags = tags
+	return d.data.save()
+}
+
+func (d *MockDevice) GetConfig() (map[string]string, error) {
+	err := d.data.load()
+	return d.data.Config, err
+}
+
+func (d *MockDevice) SetConfig(k, v string) error {
+	d.data.Config[k] = v
+	return d.data.save()
+}
+
+func (d *MockDevice) SetControl(key string, value string) error {
+	d.data.Control[key] = value
+	return d.data.save()
+}
+
+func (d *MockDevice) Power(action string) error {
+	d.data.Power = action
+	return d.data.save()
+}
+
+func (d *MockDevice) SetConsoleSpeed(bps int) error {
+	d.data.ConsoleSpeed = bps
+	return d.data.save()
+}
+
+func (d *MockDevice) SetUsbConsole(name string) error {
+	d.data.UsbConsole = name
+	return d.data.save()
+}
+
+func (d *MockDevice) SetDiskImage(path string, offset uint64) error {
+	d.data.ImagePath = path
+	d.data.ImageOffset = offset
+	return d.data.save()
+}
+
+func (d *MockDevice) AttachStorage(connect bool) error {
+	d.data.Storage = connect
+	return d.data.save()
+}
+
+func (d *MockDevice) Device() (string, error) {
+	err := d.data.load()
+	return d.data.Device, err
+}
+
+func (d *MockDevice) IsBusy() (bool, error) {
+	err := d.data.load()
+	return d.data.Busy, err
+}
+
+func (d *MockDevice) Console() (harness.ConsoleInterface, error) {
+	return newMockConsole()
+}
+
+func (d *MockDevice) Lock() error {
+	err := d.data.load()
+	if err != nil {
+		return err
+	}
+
+	lock, err := locking.TryLock(d.data.Device)
+	if err != nil {
+		return fmt.Errorf("Lock: locking %q %w", d.data.Device, err)
+	}
+
+	d.fileLock = lock
+
+	return nil
+}
+
+func (d *MockDevice) Unlock() error {
+	return d.fileLock.Unlock()
+}

--- a/pkg/drivers/mock/driver.go
+++ b/pkg/drivers/mock/driver.go
@@ -1,0 +1,24 @@
+package mock
+
+import (
+	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+)
+
+type MockDriver struct{}
+
+func (d *MockDriver) Name() string {
+	return "mock"
+}
+
+func (d *MockDriver) Description() string {
+	return `Mock harness for testing.`
+}
+
+func (d *MockDriver) FindDevices() ([]harness.Device, error) {
+	device, err := newMockDevice()
+	if err != nil {
+		return nil, err
+	}
+	hdList := []harness.Device{device}
+	return hdList, nil
+}

--- a/pkg/drivers/mock/init.go
+++ b/pkg/drivers/mock/init.go
@@ -1,0 +1,11 @@
+//go:build mock
+
+package mock
+
+import (
+	"github.com/jumpstarter-dev/jumpstarter/pkg/harness"
+)
+
+func init() {
+	harness.RegisterDriver(&MockDriver{})
+}


### PR DESCRIPTION
It provides a stub implementation of the harness.Driver and harness.Device interfaces. And utilizes VT100 emulation[1] to parse and emulate a console for createAnsibleInventory to work.

It stores persistent data (name/tags) in a json file hardcoded at `/tmp/jumpstarter-mock.json`

The mock driver is not enabled by default and can be built with `go build -tags mock`

[1] https://pkg.go.dev/golang.org/x/term

Depends on https://github.com/jumpstarter-dev/jumpstarter/pull/13 and https://github.com/jumpstarter-dev/jumpstarter/pull/14