### PR TITLE
Make server stream a context manager, implement keepalive

### DIFF
--- a/jumpstarter/common/streams.py
+++ b/jumpstarter/common/streams.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from asyncio import InvalidStateError
 from contextlib import asynccontextmanager
 
@@ -17,8 +18,8 @@ from anyio.streams.stapled import StapledObjectStream
 
 from jumpstarter.v1 import router_pb2, router_pb2_grpc
 
-KEEPALIVE_INTERVAL = 1
-KEEPALIVE_TOLERANCE = 5
+KEEPALIVE_INTERVAL = int(os.environ.get("JMP_KEEPALIVE_INTERVAL", "300"))
+KEEPALIVE_TOLERANCE = int(os.environ.get("JMP_KEEPALIVE_TOLERANCE", "600"))
 
 logger = logging.getLogger(__name__)
 

--- a/jumpstarter/drivers/decorators.py
+++ b/jumpstarter/drivers/decorators.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from inspect import isasyncgenfunction, iscoroutinefunction, isfunction, isgeneratorfunction
 from typing import Final
 from uuid import uuid4
@@ -60,10 +61,11 @@ def exportstream(func):
     Decorator for exporting method as stream
     """
 
-    async def wrapper(self, request_iterator, context):
+    @asynccontextmanager
+    async def wrapper(self, context):
         async with func(self) as stream:
-            async for v in forward_server_stream(request_iterator, stream):
-                yield v
+            async with forward_server_stream(context, stream):
+                yield
 
     setattr(wrapper, MARKER_STREAMCALL, MARKER_MAGIC)
 

--- a/jumpstarter/exporter/session.py
+++ b/jumpstarter/exporter/session.py
@@ -49,10 +49,9 @@ class Session(
         async for v in self[UUID(request.uuid)].StreamingDriverCall(request, context):
             yield v
 
-    async def Stream(self, request_iterator, context):
+    async def Stream(self, _request_iterator, context):
         metadata = dict(context.invocation_metadata())
 
         request = StreamRequest.validate_json(metadata["request"], strict=True)
 
-        async for v in self[request.uuid].Stream(request_iterator, context):
-            yield v
+        await self[request.uuid].Stream(_request_iterator, context)


### PR DESCRIPTION
The continuation of explicit stream cancellation work, now server streams (driver side of the stream) can also be cancelled. This also fully mitigates the pitfall described in https://anyio.readthedocs.io/en/stable/cancellation.html#avoiding-cancel-scope-stack-corruption