### PR TITLE
Lazily wrap driver method

### DIFF
--- a/jumpstarter/driver/decorators.py
+++ b/jumpstarter/driver/decorators.py
@@ -1,16 +1,5 @@
-from contextlib import asynccontextmanager
 from inspect import isasyncgenfunction, iscoroutinefunction, isfunction, isgeneratorfunction
 from typing import Final
-from uuid import uuid4
-
-from anyio import to_thread
-from google.protobuf import json_format, struct_pb2
-from pydantic import BaseModel
-
-from jumpstarter.common.streams import (
-    forward_server_stream,
-)
-from jumpstarter.v1 import jumpstarter_pb2
 
 MARKER_MAGIC: Final[str] = "07c9b9cc"
 MARKER_DRIVERCALL: Final[str] = "marker_drivercall"
@@ -23,72 +12,17 @@ def export(func):
     Decorator for exporting method as driver call
     """
     if isasyncgenfunction(func) or isgeneratorfunction(func):
-        return streamingdrivercall(func)
+        setattr(func, MARKER_STREAMING_DRIVERCALL, MARKER_MAGIC)
     elif iscoroutinefunction(func) or isfunction(func):
-        return drivercall(func)
+        setattr(func, MARKER_DRIVERCALL, MARKER_MAGIC)
     else:
         raise ValueError(f"unsupported exported function {func}")
-
-
-def encode_value(v):
-    return json_format.ParseDict(
-        v.model_dump(mode="json") if isinstance(v, BaseModel) else v,
-        struct_pb2.Value(),
-    )
-
-
-def drivercall(func):
-    async def wrapper(self, request, context):
-        args = [json_format.MessageToDict(arg) for arg in request.args]
-
-        if iscoroutinefunction(func):
-            result = await func(self, *args)
-        else:
-            result = await to_thread.run_sync(func, self, *args)
-
-        return jumpstarter_pb2.DriverCallResponse(
-            uuid=str(uuid4()),
-            result=encode_value(result),
-        )
-
-    setattr(wrapper, MARKER_DRIVERCALL, MARKER_MAGIC)
-
-    return wrapper
+    return func
 
 
 def exportstream(func):
     """
     Decorator for exporting method as stream
     """
-
-    @asynccontextmanager
-    async def wrapper(self, context):
-        async with func(self) as stream:
-            async with forward_server_stream(context, stream):
-                yield
-
-    setattr(wrapper, MARKER_STREAMCALL, MARKER_MAGIC)
-
-    return wrapper
-
-
-def streamingdrivercall(func):
-    async def wrapper(self, request, context):
-        args = [json_format.MessageToDict(arg) for arg in request.args]
-
-        if isasyncgenfunction(func):
-            async for result in func(self, *args):
-                yield jumpstarter_pb2.StreamingDriverCallResponse(
-                    uuid=str(uuid4()),
-                    result=encode_value(result),
-                )
-        else:
-            for result in await to_thread.run_sync(func, self, *args):
-                yield jumpstarter_pb2.StreamingDriverCallResponse(
-                    uuid=str(uuid4()),
-                    result=encode_value(result),
-                )
-
-    setattr(wrapper, MARKER_STREAMING_DRIVERCALL, MARKER_MAGIC)
-
-    return wrapper
+    setattr(func, MARKER_STREAMCALL, MARKER_MAGIC)
+    return func

--- a/jumpstarter/drivers/power/client_test.py
+++ b/jumpstarter/drivers/power/client_test.py
@@ -1,0 +1,25 @@
+from jumpstarter.common.utils import serve
+from jumpstarter.drivers.power.common import PowerReading
+from jumpstarter.drivers.power.driver import MockPower, SyncMockPower
+
+
+def test_client_mock_power():
+    with serve(MockPower()) as client:
+        assert client.on() == "ok"
+        assert client.off() == "ok"
+
+        assert list(client.read()) == [
+            PowerReading(voltage=0.0, current=0.0),
+            PowerReading(voltage=5.0, current=2.0),
+        ]
+
+
+def test_client_sync_mock_power():
+    with serve(SyncMockPower()) as client:
+        assert client.on() == "ok"
+        assert client.off() == "ok"
+
+        assert list(client.read()) == [
+            PowerReading(voltage=0.0, current=0.0),
+            PowerReading(voltage=5.0, current=2.0),
+        ]

--- a/jumpstarter/drivers/power/driver_test.py
+++ b/jumpstarter/drivers/power/driver_test.py
@@ -1,25 +1,30 @@
-from jumpstarter.common.utils import serve
+import pytest
+
 from jumpstarter.drivers.power.common import PowerReading
 from jumpstarter.drivers.power.driver import MockPower, SyncMockPower
 
-
-def test_drivers_power_mock():
-    with serve(MockPower()) as client:
-        assert client.on() == "ok"
-        assert client.off() == "ok"
-
-        assert list(client.read()) == [
-            PowerReading(voltage=0.0, current=0.0),
-            PowerReading(voltage=5.0, current=2.0),
-        ]
+pytestmark = pytest.mark.anyio
 
 
-def test_drivers_sync_power_mock():
-    with serve(SyncMockPower()) as client:
-        assert client.on() == "ok"
-        assert client.off() == "ok"
+async def test_driver_mock_power():
+    driver = MockPower()
 
-        assert list(client.read()) == [
-            PowerReading(voltage=0.0, current=0.0),
-            PowerReading(voltage=5.0, current=2.0),
-        ]
+    assert await driver.on() == "ok"
+    assert await driver.off() == "ok"
+
+    assert [v async for v in driver.read()] == [
+        PowerReading(voltage=0.0, current=0.0),
+        PowerReading(voltage=5.0, current=2.0),
+    ]
+
+
+def test_driver_sync_mock_power():
+    driver = SyncMockPower()
+
+    assert driver.on() == "ok"
+    assert driver.off() == "ok"
+
+    assert list(driver.read()) == [
+        PowerReading(voltage=0.0, current=0.0),
+        PowerReading(voltage=5.0, current=2.0),
+    ]


### PR DESCRIPTION
This enables drivers to be used directly without going through grpc. Eases testing driver directly.

Depends on https://github.com/jumpstarter-dev/jumpstarter/pull/56