### PR TITLE
Add contrib packages as optional dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
         "--cov-report=xml"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.analysis.extraPaths": [
+        "./contrib/*"
+    ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "jumpstarter"
 version = "0.1.0"
 description = ""
 authors = [
-  { name = "Miguel Angel Ajo Pelayo", email = "majopela@redhat.com" },
-  { name = "Nick Cao", email = "ncao@redhat.com" },
-  { name = "Kirk Brauer", email = "kbrauer@hatci.com" },
+    { name = "Miguel Angel Ajo Pelayo", email = "majopela@redhat.com" },
+    { name = "Nick Cao", email = "ncao@redhat.com" },
+    { name = "Kirk Brauer", email = "kbrauer@hatci.com" },
 ]
 readme = "README.md"
 requires-python = ">=3.11"
@@ -34,6 +34,12 @@ docs = [
     "esbonio>=0.16.4",
     "sphinx-autobuild>=2024.4.16",
 ]
+contrib = [
+    "jumpstarter-driver-dutlink",
+    "jumpstarter-driver-raspberrypi",
+    "jumpstarter-driver-ustreamer",
+    "jumpstarter-driver-can",
+]
 
 [project.scripts]
 jmp = "jumpstarter.__main__:main"
@@ -54,6 +60,12 @@ dev-dependencies = [
 [tool.uv.sources.jumpstarter-protocol]
 git = "https://github.com/jumpstarter-dev/jumpstarter-protocol.git"
 subdirectory = "python"
+
+[tool.uv.sources]
+jumpstarter-driver-dutlink = { workspace = true }
+jumpstarter-driver-raspberrypi = { workspace = true }
+jumpstarter-driver-ustreamer = { workspace = true }
+jumpstarter-driver-can = { workspace = true }
 
 [tool.uv.workspace]
 members = ["contrib/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -675,6 +675,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+contrib = [
+    { name = "jumpstarter-driver-can" },
+    { name = "jumpstarter-driver-dutlink" },
+    { name = "jumpstarter-driver-raspberrypi" },
+    { name = "jumpstarter-driver-ustreamer" },
+]
 docs = [
     { name = "esbonio" },
     { name = "furo" },
@@ -702,6 +708,10 @@ requires-dist = [
     { name = "fabric", specifier = ">=3.2.2" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.8.6" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "jumpstarter-driver-can", marker = "extra == 'contrib'", editable = "contrib/can" },
+    { name = "jumpstarter-driver-dutlink", marker = "extra == 'contrib'", editable = "contrib/dutlink" },
+    { name = "jumpstarter-driver-raspberrypi", marker = "extra == 'contrib'", editable = "contrib/raspberrypi" },
+    { name = "jumpstarter-driver-ustreamer", marker = "extra == 'contrib'", editable = "contrib/ustreamer" },
     { name = "jumpstarter-protocol", git = "https://github.com/jumpstarter-dev/jumpstarter-protocol.git?subdirectory=python" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.0" },
     { name = "opendal", specifier = ">=0.45.8" },
@@ -889,8 +899,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/7c/82b729d105dae9f8be500228fdd8cfc1f918a18e285afcbf6d6915146037/msgpack-1.0.8-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:dfe1f0f0ed5785c187144c46a292b8c34c1295c01da12e10ccddfc16def4448a", size = 404763 },
     { url = "https://files.pythonhosted.org/packages/e0/3f/978df03be94c2198be22df5d6e31b69ef7a9759c6cc0cce4ed1d08e2b27b/msgpack-1.0.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3528807cbbb7f315bb81959d5961855e7ba52aa60a3097151cb21956fbc7502b", size = 434775 },
     { url = "https://files.pythonhosted.org/packages/dd/06/adb6c8cdea18f9ba09b7dc1442b50ce222858ae4a85703420349784429d0/msgpack-1.0.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e2f879ab92ce502a1e65fce390eab619774dda6a6ff719718069ac94084098ce", size = 409109 },
-    { url = "https://files.pythonhosted.org/packages/c6/d6/46eec1866b1ff58001a4be192ec43675620392de078fd4baf394f7d03552/msgpack-1.0.8-cp311-cp311-win32.whl", hash = "sha256:26ee97a8261e6e35885c2ecd2fd4a6d38252246f94a2aec23665a4e66d066305", size = 68779 },
-    { url = "https://files.pythonhosted.org/packages/33/e9/f450b8e1243704c0ab656dcd37f6146881d11bbb68588132d8ae673c455b/msgpack-1.0.8-cp311-cp311-win_amd64.whl", hash = "sha256:eadb9f826c138e6cf3c49d6f8de88225a3c0ab181a9b4ba792e006e5292d150e", size = 75180 },
     { url = "https://files.pythonhosted.org/packages/97/73/757eeca26527ebac31d86d35bf4ba20155ee14d35c8619dd96bc80a037f3/msgpack-1.0.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:114be227f5213ef8b215c22dde19532f5da9652e56e8ce969bf0a26d7c419fee", size = 158948 },
     { url = "https://files.pythonhosted.org/packages/11/df/558899a5f90d450e988484be25be0b49c6930858d6fe44ea6f1f66502fe5/msgpack-1.0.8-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d661dc4785affa9d0edfdd1e59ec056a58b3dbb9f196fa43587f3ddac654ac7b", size = 88696 },
     { url = "https://files.pythonhosted.org/packages/99/3e/49d430df1e9abf06bb91e9824422cd6ceead2114662417286da3ddcdd295/msgpack-1.0.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d56fd9f1f1cdc8227d7b7918f55091349741904d9520c65f0139a9755952c9e8", size = 85428 },
@@ -900,8 +908,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/e1/0d18496cbeef771db605b6a14794f9b4235d371f36b43f7223c1613969ec/msgpack-1.0.8-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b5505774ea2a73a86ea176e8a9a4a7c8bf5d521050f0f6f8426afe798689243f", size = 401226 },
     { url = "https://files.pythonhosted.org/packages/03/79/ae000bde2aee4b9f0d50c1ca1ab301ade873b59dd6968c28f918d1cf8be4/msgpack-1.0.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:ef254a06bcea461e65ff0373d8a0dd1ed3aa004af48839f002a0c994a6f72d04", size = 432994 },
     { url = "https://files.pythonhosted.org/packages/cb/46/f97bedf3ab16d38eeea0aafa3ad93cc7b9adf898218961faaea9c3c639f1/msgpack-1.0.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e1dd7839443592d00e96db831eddb4111a2a81a46b028f0facd60a09ebbdd543", size = 410432 },
-    { url = "https://files.pythonhosted.org/packages/8f/59/db5b61c74341b6fdf2c8a5743bb242c395d728666cf3105ff17290eb421a/msgpack-1.0.8-cp312-cp312-win32.whl", hash = "sha256:64d0fcd436c5683fdd7c907eeae5e2cbb5eb872fafbc03a43609d7941840995c", size = 69255 },
-    { url = "https://files.pythonhosted.org/packages/72/5c/5facaa9b5d1b3ead831697daacf37d485af312bbe483ac6ecf43a3dd777f/msgpack-1.0.8-cp312-cp312-win_amd64.whl", hash = "sha256:74398a4cf19de42e1498368c36eed45d9528f5fd0155241e82c4082b7e16cffd", size = 75348 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Problem:** Intellisense tends to break (especially in a clean environment) when running `uv sync --all-extras` and working on a contrib package.

**Proposed Solution:** If we add all contrib packages as optional dependencies under a `contrib` group, when running `uv sync --all-extras` those packages and all their dependencies will also be installed in the virtual environment, providing Intellisense with the correct dependencies to index. 

**Cons:** This creates circular dependencies (even though the workspace root `jumpstarter` does not depend on those packages itself, the `pyproject.toml` does).

This should be fine since `uv run` runs each package in an isolated virtual environment anyways, so we won't break the purity of any of the tests.