### PR TITLE
Make StorageMuxClient.write_local_file accept relative path

### DIFF
--- a/jumpstarter/drivers/storage/client.py
+++ b/jumpstarter/drivers/storage/client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 from opendal import Operator
 
@@ -23,7 +25,8 @@ class StorageMuxClient(DriverClient):
             return self.call("write", handle)
 
     def write_local_file(self, filepath):
-        with OpendalAdapter(client=self, operator=Operator("fs", root="/"), path=filepath) as handle:
+        absolute = Path(filepath).resolve()
+        with OpendalAdapter(client=self, operator=Operator("fs", root="/"), path=str(absolute)) as handle:
             return self.call("write", handle)
 
     def cli(self):

--- a/jumpstarter/drivers/storage/driver_test.py
+++ b/jumpstarter/drivers/storage/driver_test.py
@@ -9,7 +9,7 @@ from jumpstarter.common.utils import serve
 from jumpstarter.drivers.storage.driver import MockStorageMux
 
 
-def test_drivers_mock_storage_mux_fs():
+def test_drivers_mock_storage_mux_fs(monkeypatch):
     with serve(MockStorageMux()) as client:
         with TemporaryDirectory() as tempdir:
             fs = Operator("fs", root=tempdir)
@@ -17,7 +17,13 @@ def test_drivers_mock_storage_mux_fs():
             fs.write("test", b"testcontent" * 1000)
 
             client.write_file(fs, "test")
+            # absolute path
             client.write_local_file(str(Path(tempdir) / "test"))
+            # relative path
+            with monkeypatch.context() as m:
+                m.chdir(tempdir)
+                client.write_local_file("test")
+                client.write_local_file("./test")
 
 
 def test_drivers_mock_storage_mux_http():


### PR DESCRIPTION
Fixes https://github.com/jumpstarter-dev/jumpstarter/issues/113