### PR TITLE
Allow specifying existing lease name in jmp client shell

### DIFF
--- a/jumpstarter/cli/client.py
+++ b/jumpstarter/cli/client.py
@@ -176,7 +176,8 @@ def client_use(name: str):
 @click.command("shell", short_help="Spawns a shell connecting to a leased remote exporter")
 @click.argument("name", type=str, default="")
 @click.option("-l", "--label", "labels", type=(str, str), multiple=True)
-def client_shell(name: str, labels):
+@click.option("-n", "--lease", "lease_name", type=str)
+def client_shell(name: str, labels, lease_name):
     """Spawns a shell connecting to a leased remote exporter"""
     if name:
         config = ClientConfigV1Alpha1.load(name)
@@ -185,7 +186,7 @@ def client_shell(name: str, labels):
     if not config:
         raise ValueError("no client specified")
 
-    with config.lease(metadata_filter=MetadataFilter(labels=dict(labels))) as lease:
+    with config.lease(metadata_filter=MetadataFilter(labels=dict(labels)), lease_name=lease_name) as lease:
         with lease.serve_unix() as path:
             launch_shell(path)
 

--- a/jumpstarter/client/lease.py
+++ b/jumpstarter/client/lease.py
@@ -31,7 +31,7 @@ class Lease(AbstractContextManager, AbstractAsyncContextManager):
 
     async def __aenter__(self):
         if self.lease_name:
-            logger.info("Usig existing lease %s", self.lease_name)
+            logger.info("Using existing lease %s", self.lease_name)
         else:
             duration = duration_pb2.Duration()
             duration.FromSeconds(self.timeout)

--- a/jumpstarter/config/client.py
+++ b/jumpstarter/config/client.py
@@ -56,9 +56,9 @@ class ClientConfigV1Alpha1(BaseModel):
         return grpc.aio.secure_channel(self.endpoint, credentials)
 
     @contextmanager
-    def lease(self, metadata_filter: MetadataFilter):
+    def lease(self, metadata_filter: MetadataFilter, lease_name: str | None):
         with start_blocking_portal() as portal:
-            with portal.wrap_async_context_manager(self.lease_async(metadata_filter, portal)) as lease:
+            with portal.wrap_async_context_manager(self.lease_async(metadata_filter, lease_name, portal)) as lease:
                 yield lease
 
     def list_leases(self):
@@ -78,9 +78,10 @@ class ClientConfigV1Alpha1(BaseModel):
         await controller.ReleaseLease(jumpstarter_pb2.ReleaseLeaseRequest(name=name))
 
     @asynccontextmanager
-    async def lease_async(self, metadata_filter: MetadataFilter, portal: BlockingPortal):
+    async def lease_async(self, metadata_filter: MetadataFilter, lease_name: str | None, portal: BlockingPortal):
         async with Lease(
             channel=await self.channel(),
+            lease_name=lease_name,
             metadata_filter=metadata_filter,
             portal=portal,
         ) as lease:

--- a/jumpstarter/config/exporter_test.py
+++ b/jumpstarter/config/exporter_test.py
@@ -45,7 +45,7 @@ async def test_exporter_serve(mock_controller):
         tg.start_soon(exporter.serve_forever)
 
         with start_blocking_portal() as portal:
-            async with client.lease_async(metadata_filter=MetadataFilter(), portal=portal) as lease:
+            async with client.lease_async(metadata_filter=MetadataFilter(), lease_name=None, portal=portal) as lease:
                 async with lease.connect_async() as client:
                     assert await client.power.call_async("on") == "ok"
                     assert hasattr(client.nested, "tcp")


### PR DESCRIPTION
This is for tekton integration.