### PR TITLE
Set grpc.lb_policy_name to round_robin in all grpc channels

### DIFF
--- a/jumpstarter/common/grpc.py
+++ b/jumpstarter/common/grpc.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 import grpc
 
 
-def ssl_channel_credentials(target: str, insecure=False):
+def ssl_channel_credentials(target: str, insecure: bool = False):
     if insecure or os.getenv("JUMPSTARTER_GRPC_INSECURE") == "1":
         parsed = urlparse(f"//{target}")
         port = parsed.port if parsed.port else 443
@@ -13,3 +13,7 @@ def ssl_channel_credentials(target: str, insecure=False):
         return grpc.ssl_channel_credentials(root_certificates=root_certificates.encode())
     else:
         return grpc.ssl_channel_credentials()
+
+
+def aio_secure_channel(target: str, credentials: grpc.ChannelCredentials):
+    return grpc.aio.secure_channel(target, credentials, options=(("grpc.lb_policy_name", "round_robin"),))

--- a/jumpstarter/common/streams.py
+++ b/jumpstarter/common/streams.py
@@ -5,7 +5,7 @@ from uuid import UUID
 import grpc
 from pydantic import BaseModel, Field, Json
 
-from jumpstarter.common.grpc import ssl_channel_credentials
+from jumpstarter.common.grpc import aio_secure_channel, ssl_channel_credentials
 from jumpstarter.streams import RouterStream, forward_stream
 from jumpstarter.v1 import router_pb2_grpc
 
@@ -38,7 +38,7 @@ async def connect_router_stream(endpoint, token, stream):
         grpc.access_token_call_credentials(token),
     )
 
-    async with grpc.aio.secure_channel(endpoint, credentials) as channel:
+    async with aio_secure_channel(endpoint, credentials) as channel:
         router = router_pb2_grpc.RouterServiceStub(channel)
         context = router.Stream(metadata=())
         async with RouterStream(context=context) as s:

--- a/jumpstarter/config/client.py
+++ b/jumpstarter/config/client.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from jumpstarter.client import Lease
 from jumpstarter.common import MetadataFilter
-from jumpstarter.common.grpc import ssl_channel_credentials
+from jumpstarter.common.grpc import aio_secure_channel, ssl_channel_credentials
 from jumpstarter.v1 import jumpstarter_pb2, jumpstarter_pb2_grpc
 
 from .common import CONFIG_PATH
@@ -53,7 +53,7 @@ class ClientConfigV1Alpha1(BaseModel):
             grpc.access_token_call_credentials(self.token),
         )
 
-        return grpc.aio.secure_channel(self.endpoint, credentials)
+        return aio_secure_channel(self.endpoint, credentials)
 
     @contextmanager
     def lease(self, metadata_filter: MetadataFilter, lease_name: str | None):

--- a/jumpstarter/config/exporter.py
+++ b/jumpstarter/config/exporter.py
@@ -9,7 +9,7 @@ import yaml
 from anyio.from_thread import start_blocking_portal
 from pydantic import BaseModel, Field
 
-from jumpstarter.common.grpc import ssl_channel_credentials
+from jumpstarter.common.grpc import aio_secure_channel, ssl_channel_credentials
 from jumpstarter.common.importlib import import_class
 from jumpstarter.driver import Driver
 from jumpstarter.exporter import Exporter, Session
@@ -97,7 +97,7 @@ class ExporterConfigV1Alpha1(BaseModel):
             grpc.access_token_call_credentials(self.token),
         )
 
-        async with grpc.aio.secure_channel(self.endpoint, credentials) as channel:
+        async with aio_secure_channel(self.endpoint, credentials) as channel:
             async with Exporter(
                 channel=channel,
                 device_factory=ExporterConfigV1Alpha1DriverInstance(children=self.export).instantiate,

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -10,7 +10,7 @@ from anyio.from_thread import start_blocking_portal
 
 from jumpstarter.client import Lease
 from jumpstarter.common import MetadataFilter
-from jumpstarter.common.grpc import ssl_channel_credentials
+from jumpstarter.common.grpc import aio_secure_channel, ssl_channel_credentials
 from jumpstarter.common.streams import connect_router_stream
 from jumpstarter.drivers.power.driver import MockPower
 from jumpstarter.exporter import Exporter, Session
@@ -55,7 +55,7 @@ async def test_unsatisfiable(mock_controller):
     with start_blocking_portal() as portal:
         with pytest.raises(ValueError):
             async with Lease(
-                channel=grpc.aio.secure_channel(mock_controller, ssl_channel_credentials(mock_controller)),
+                channel=aio_secure_channel(mock_controller, ssl_channel_credentials(mock_controller)),
                 metadata_filter=MetadataFilter(labels={"unsatisfiable": "true"}),
                 portal=portal,
                 allow=[],
@@ -69,7 +69,7 @@ async def test_controller(mock_controller):
     uuid = uuid4()
 
     async with Exporter(
-        channel=grpc.aio.secure_channel(mock_controller, ssl_channel_credentials(mock_controller)),
+        channel=aio_secure_channel(mock_controller, ssl_channel_credentials(mock_controller)),
         uuid=uuid,
         labels={},
         device_factory=lambda: MockPower(),
@@ -79,7 +79,7 @@ async def test_controller(mock_controller):
 
             with start_blocking_portal() as portal:
                 async with Lease(
-                    channel=grpc.aio.secure_channel(mock_controller, ssl_channel_credentials(mock_controller)),
+                    channel=aio_secure_channel(mock_controller, ssl_channel_credentials(mock_controller)),
                     metadata_filter=MetadataFilter(),
                     portal=portal,
                     allow=[],


### PR DESCRIPTION
Fixes:
```
INFO:jumpstarter.exporter.exporter:Exporter: connection interrupted, reconnecting after 5 seconds: (<AioRpcError of RPC that terminated with:
        status = StatusCode.UNAVAILABLE
        details = "failed to connect to all addresses; last error: UNKNOWN: ipv6:%5B2a0c:5a81:5301:2100:59a2:f212:8474:22e1%5D:443: connect: Network is unreachable (101)"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2024-10-23T07:31:53.753621252+00:00", grpc_status:14, grpc_message:"failed to connect to all addresses; last error: UNKNOWN: ipv6:%5B2a0c:5a81:5301:2100:59a2:f212:8474:22e1%5D:443: connect: Network is unreachable (101)"}"```

```

When a DNS entry returns multiple addresses, but one of the addresses is not reachable we need to try the next...