### PR TITLE
Remove http-docs, otherwise dynamic discovery fails to share route

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -16,10 +16,6 @@ components:
    - name: runtime
      container:
        image: quay.io/jumpstarter-dev/jumpstarter-dev:latest
-       endpoints:
-         - name: http-docs
-           targetPort: 8000
-           protocol: http
        mountSources: true
 
 commands:


### PR DESCRIPTION
Otherwise, the automatic exposure of the route for docs doesn't work.