### PR TITLE
Fix Service install docs

### DIFF
--- a/docs/source/installation/service-cli.md
+++ b/docs/source/installation/service-cli.md
@@ -10,12 +10,11 @@ the latest release.
 ```{code-block} bash
 :substitutions:
 export VERSION={{controller_version}}
-export ARCH=amd64 # or arm64
+export ARCH=amd64 # or arm64 (Apple Silicon)
+export PLATFORM=linux # or darwin for macOS
 
-curl -L https://github.com/jumpstarter-dev/jumpstarter-controller/releases/download/${VERSION}/jmpctl_${VERSION}_linux_${ARCH} \
-     -o /usr/local/bin/jmpctl
-
-chmod a+x /usr/local/bin/jmpctl
+curl -L https://github.com/jumpstarter-dev/jumpstarter-controller/releases/download/v${VERSION}/jmpctl_${VERSION}_${PLATFORM}_${ARCH} -o jmpctl
+sudo install jmpctl /usr/local/bin/jmpctl && rm jmpctl
 ```
 
 ## Configuration

--- a/docs/source/installation/service/minikube-helm.md
+++ b/docs/source/installation/service/minikube-helm.md
@@ -1,17 +1,14 @@
 # Local cluster with minikube
-```{warning}
-This guide hasn't been tested yet, please report back any issues
-```
 
 If you want to play with the Jumpstarter Controller on your local machine,
-we recommend running a local Kubernetes cluster on your development machine.
+we recommend running a local Kubernetes cluster.
 
 ```{warning}
-We do not recommend a local cluster for a production environment such as a lab.
+We do not recommend a local cluster for a production environment.
 Please use a full Kubernetes installation either on-prem or in the cloud.
 ```
 
-miniKube is a tool for running local Kubernetes clusters using VMs or container nodes,
+minikube is a tool for running local Kubernetes clusters using local VMs or Podman/Docker container “nodes”,
 it works across several platforms and can be used with different hypervisors.
 
 You can find more information on the [minikube website](https://minikube.sigs.k8s.io/docs/start/).
@@ -19,22 +16,30 @@ You can find more information on the [minikube website](https://minikube.sigs.k8
 ## Installation
 
 ### Start a minikube cluster
+
+First, we must start a local minikube cluster with the correct features enabled to support Jumpstarter.
+
 ```bash
-minikube start
+# We must expand the default NodePort range to include the Jumpstarter ports
+minikube start --extra-config=apiserver.service-node-port-range=8000-9000
 ```
 
-### Get the minikube cluster IP
-```bash
-export IP=$(minikube ip)
+### Install Jumpstarter with Helm
+
+```{tip}
+If you do not have Helm installed, please [install the latest release](https://helm.sh/docs/intro/install/).
 ```
 
-### Install Jumpstarter
 ```{code-block} bash
 :substitutions:
+# Get the minikube cluster IP address
+export IP=$(minikube ip)
+# Setup the base domain and endpoints with nip.io
 export BASEDOMAIN="jumpstarter.${IP}.nip.io"
 export GRPC_ENDPOINT="grpc.${BASEDOMAIN}:8082"
 export GRPC_ROUTER_ENDPOINT="router.${BASEDOMAIN}:8083"
 
+# Install the Jumpstarter service in the namespace jumpstarter-lab with Helm
 helm upgrade jumpstarter --install oci://quay.io/jumpstarter-dev/helm/jumpstarter \
             --create-namespace --namespace jumpstarter-lab \
             --set global.baseDomain=${BASEDOMAIN} \
@@ -42,6 +47,8 @@ helm upgrade jumpstarter --install oci://quay.io/jumpstarter-dev/helm/jumpstarte
             --set jumpstarter-controller.grpc.routerEndpoint=${GRPC_ROUTER_ENDPOINT} \
             --set global.metrics.enabled=false \
             --set jumpstarter-controller.grpc.nodeport.enabled=true \
+            --set jumpstarter-controller.grpc.nodeport.port=8082 \
+            --set jumpstarter-controller.grpc.nodeport.routerPort=8083 \
             --set jumpstarter-controller.grpc.mode=nodeport \
             --version={{controller_version}}
 ```


### PR DESCRIPTION
- Fix incorrect URL for installing Service CLI
- Fix instructions to use `sudo install` instead of downloading binary into `/usr/local/bin`
- FIx issues with kind and minikube install docs, tested minikube docs to ensure that it works