### PR TITLE
Fix /home/user/.* access in devspaces

### DIFF
--- a/.devfile/Containerfile.client
+++ b/.devfile/Containerfile.client
@@ -26,9 +26,19 @@ RUN rm -rf /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python
 
 RUN dnf -y install make git python3.12 python3.12 libusbx python3-pyusb python3.12-pip golang && dnf clean all
 
-RUN mkdir -p /home/user/.config/jumpstarter/clients && chown 10001:0 -R /home/user/.config && chmod g+rwx -R /home/user/.config
+USER 10001
+
+RUN --mount=from=builder,source=/src/dist,target=/dist python3.12 -m pip install /dist/*.whl
+
+RUN python3.12 -m pip install pytest
+
+# now that all .config/.local/.cache files are available, fix permissions so a devspace
+# user could write to any of those
+
+USER root
+
+RUN mkdir -p /home/user/.config/jumpstarter/clients
+RUN chown 10001:0 -R /home/user/{.config,.local,.cache} && chmod g+rwx -R /home/user/{.config,.local,.cache}
 
 USER 10001
-RUN --mount=from=builder,source=/src/dist,target=/dist python3.12 -m pip install /dist/*.whl
-RUN python3.12 -m pip install pytest
 


### PR DESCRIPTION
This fixes various issues with devspaces:
* Installing additional pip packages on runtime
* Fixing python `jedi` codeserver error: Permission denied: '/home/user/.cache/jedi'