### PR TITLE
update doc for pyserial

### DIFF
--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -158,9 +158,9 @@ export:
       username: "admin"
       password: "secret"
   serial:
-    type: "jumpstarter.drivers.serial.Pyserial"
+    type: "jumpstarter.drivers.pyserial.driver.PySerial"
     config:
-      port: "/dev/ttyUSB0"
+      url: "/dev/ttyUSB0"
       baudrate: 115200
   custom:
     type: "vendorpackage.CustomDriver"


### PR DESCRIPTION
- Change the driver module path
- Use `url` instead of `port`