### PR TITLE
raspberrypi: init device as input

### DIFF
--- a/contrib/drivers/raspberrypi/jumpstarter_driver_raspberrypi/driver.py
+++ b/contrib/drivers/raspberrypi/jumpstarter_driver_raspberrypi/driver.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from gpiozero import DigitalInputDevice, DigitalOutputDevice
+from gpiozero import DigitalInputDevice, DigitalOutputDevice, InputDevice
 
 from jumpstarter.driver import Driver, export
 
@@ -8,7 +8,7 @@ from jumpstarter.driver import Driver, export
 @dataclass(kw_only=True)
 class DigitalOutput(Driver):
     pin: int | str
-    device: DigitalOutputDevice = field(init=False)
+    device: InputDevice = field(init=False)  # Start as input
 
     @classmethod
     def client(cls) -> str:
@@ -16,14 +16,26 @@ class DigitalOutput(Driver):
 
     def __post_init__(self):
         super().__post_init__()
-        self.device = DigitalOutputDevice(pin=self.pin)
+        # Initialize as InputDevice first
+        self.device = InputDevice(pin=self.pin)
+
+    def close(self):
+        if hasattr(self, 'device'):
+            self.device.close()
+        super().close()
 
     @export
     def off(self):
+        if not isinstance(self.device, DigitalOutputDevice):
+            self.device.close()
+            self.device = DigitalOutputDevice(pin=self.pin, initial_value=None)
         self.device.off()
 
     @export
     def on(self):
+        if not isinstance(self.device, DigitalOutputDevice):
+            self.device.close()
+            self.device = DigitalOutputDevice(pin=self.pin, initial_value=None)
         self.device.on()
 
 

--- a/contrib/drivers/raspberrypi/jumpstarter_driver_raspberrypi/driver_test.py
+++ b/contrib/drivers/raspberrypi/jumpstarter_driver_raspberrypi/driver_test.py
@@ -10,15 +10,26 @@ Device.pin_factory = MockFactory()
 
 
 def test_drivers_gpio_digital_output():
-    instance = DigitalOutput(pin=1)
+    pin_factory = MockFactory()
+    Device.pin_factory = pin_factory
+    pin_number = 1
+    mock_pin = pin_factory.pin(pin_number)
+
+    instance = DigitalOutput(pin=pin_number)
+
+    assert not mock_pin.state
 
     with serve(instance) as client:
         client.off()
+        assert not mock_pin.state
+
         client.on()
+        assert mock_pin.state
+
         client.off()
+        assert not mock_pin.state
 
-    instance.device.pin.assert_states((False, True, False))
-
+    mock_pin.assert_states([False, True, False])
 
 def test_drivers_gpio_digital_input():
     instance = DigitalInput(pin=4)


### PR DESCRIPTION
It seems that in gpiozero, initializing an OutputDevice changes its state.

This PR changes the driver implementation to initialize the device as an input device to validate it (for example, the pin number exists). Then, upon usage, it would initialize it as an OutputDevice and perform the operation.

Starting an exporter with an invalid pin number:
```yaml
  gpio:
    type: jumpstarter_driver_raspberrypi.driver.DigitalOutput
    config:
      pin: 70
```

```
gpiozero.exc.PinInvalidPin: 70 is not a valid pin name
```