### PR TITLE
Handle all instances of tls credentials

### DIFF
--- a/jumpstarter/common/grpc.py
+++ b/jumpstarter/common/grpc.py
@@ -6,15 +6,15 @@ from urllib.parse import urlparse
 import grpc
 
 
-def ssl_channel_credentials(target: str, insecure: bool = False, ca_certificate: str = ""):
-    if insecure or os.getenv("JUMPSTARTER_GRPC_INSECURE") == "1":
+def ssl_channel_credentials(target: str, tls_config):
+    if tls_config.insecure or os.getenv("JUMPSTARTER_GRPC_INSECURE") == "1":
         parsed = urlparse(f"//{target}")
         port = parsed.port if parsed.port else 443
         root_certificates = ssl.get_server_certificate((parsed.hostname, port))
         return grpc.ssl_channel_credentials(root_certificates=root_certificates.encode())
-    elif ca_certificate != "":
+    elif tls_config.ca != "":
         # convert ca_certificate base64 encoded to pem encoded string
-        ca_certificate = base64.b64decode(ca_certificate)
+        ca_certificate = base64.b64decode(tls_config.ca)
         return grpc.ssl_channel_credentials(ca_certificate)
     else:
         return grpc.ssl_channel_credentials()

--- a/jumpstarter/common/streams.py
+++ b/jumpstarter/common/streams.py
@@ -32,9 +32,9 @@ class StreamRequestMetadata(BaseModel):
 
 
 @asynccontextmanager
-async def connect_router_stream(endpoint, token, stream):
+async def connect_router_stream(endpoint, token, stream, tls_config):
     credentials = grpc.composite_channel_credentials(
-        ssl_channel_credentials(endpoint),
+        ssl_channel_credentials(endpoint, tls_config),
         grpc.access_token_call_credentials(token),
     )
 

--- a/jumpstarter/config/exporter_test.py
+++ b/jumpstarter/config/exporter_test.py
@@ -5,7 +5,8 @@ from anyio.from_thread import start_blocking_portal
 from jumpstarter.common import MetadataFilter
 
 from .client import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers
-from .exporter import ExporterConfigV1Alpha1, ExporterConfigV1Alpha1DriverInstance, ExporterConfigV1Alpha1TLS
+from .exporter import ExporterConfigV1Alpha1, ExporterConfigV1Alpha1DriverInstance
+from .tls import TLSConfigV1Alpha1
 
 pytestmark = pytest.mark.anyio
 
@@ -39,6 +40,7 @@ async def test_exporter_serve(mock_controller):
         endpoint=mock_controller,
         token="dummy-client-token",
         drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=True),
+        tls=TLSConfigV1Alpha1(insecure=True),
     )
 
     async with create_task_group() as tg:
@@ -100,7 +102,7 @@ export:
         kind="ExporterConfig",
         endpoint="jumpstarter.my-lab.com:1443",
         token="dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz",
-        tls=ExporterConfigV1Alpha1TLS(ca="cacertificatedata", insecure=True),
+        tls=TLSConfigV1Alpha1(ca="cacertificatedata", insecure=True),
         export={
             "power": ExporterConfigV1Alpha1DriverInstance(
                 type="jumpstarter.drivers.power.PduPower",

--- a/jumpstarter/config/tls.py
+++ b/jumpstarter/config/tls.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, Field
+
+
+class TLSConfigV1Alpha1(BaseModel):
+    ca: str = Field(default="")
+    insecure: bool = Field(default=False)

--- a/jumpstarter/testing/pytest.py
+++ b/jumpstarter/testing/pytest.py
@@ -17,9 +17,9 @@ class JumpstarterTest:
 This class provides a client fixture that can be used to interact with
 Jumpstarter services in test cases.
 
-Looks for the JUMPSTARTER_HOST environment variable to connect to an
-established Jumpstarter shell, or otherwise it will try to acquire a
-lease for a single exporter using the filter_labels annotation.
+Looks for the `JUMPSTARTER_HOST` environment variable to connect to an
+established Jumpstarter shell, otherwise it will try to acquire a lease
+for a single exporter using the filter_labels annotation.
 i.e.:
 
 .. code-block:: python


### PR DESCRIPTION
The patch handling tls configuration on exporter/client didn't pass down the tls configuration to the router connections, so when set to insecure, control connection would work, but router connections failed.

Related-Issue: #192 