### PR TITLE
http: fix http driver test

### DIFF
--- a/contrib/drivers/http/src/jumpstarter_driver_http/driver.py
+++ b/contrib/drivers/http/src/jumpstarter_driver_http/driver.py
@@ -85,7 +85,7 @@ class HttpServer(Driver):
                     async for chunk in src:
                         await dst.send(chunk)
 
-            logger.info(f"File '{filename}' written to '{self.root_dir}'")
+            logger.info(f"File '{filename}' written to '{file_path}'")
             return f"{self.get_url()}/{filename}"
 
         except Exception as e:

--- a/contrib/drivers/http/src/jumpstarter_driver_http/driver_test.py
+++ b/contrib/drivers/http/src/jumpstarter_driver_http/driver_test.py
@@ -10,16 +10,16 @@ from .driver import HttpServer
 
 @pytest.mark.asyncio
 async def test_http_server():
-    with TemporaryDirectory() as temp_dir:
-        server = HttpServer(root_dir=temp_dir)
+    with TemporaryDirectory() as source_dir, TemporaryDirectory() as server_dir:
+        server = HttpServer(root_dir=server_dir)
         await server.start()
 
         with serve(server) as client:
             test_content = b"test content"
-            test_file_path = Path(temp_dir) / "test.txt"
-            test_file_path.write_bytes(test_content)
+            source_file_path = Path(source_dir) / "test.txt"
+            source_file_path.write_bytes(test_content)
 
-            uploaded_filename_url = client.put_local_file(str(test_file_path))
+            uploaded_filename_url = client.put_local_file(str(source_file_path))
             assert uploaded_filename_url == f"{client.get_url()}/test.txt"
 
             files = client.list_files()


### PR DESCRIPTION
The test was using the same file created in the for the client upload functionality, thus overriding the content of the file created in the test, which would lead to test failures. Instead, the test will use a different path for the upload.