### PR TITLE
Fix JMP_LEASE handling in pytest

### DIFF
--- a/jumpstarter/cli/client.py
+++ b/jumpstarter/cli/client.py
@@ -1,12 +1,11 @@
 import logging
-import os
 from typing import Optional
 
 import click
 
 from jumpstarter.common import MetadataFilter
 from jumpstarter.common.utils import launch_shell
-from jumpstarter.config import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers, UserConfigV1Alpha1, env
+from jumpstarter.config import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers, UserConfigV1Alpha1
 
 from .util import AliasedGroup, make_table
 from .version import version
@@ -223,14 +222,7 @@ def client_shell(name: str, labels, lease_name):
     if not config:
         raise ValueError("no client specified")
 
-    # lease_name can be provided as an argument or via environment variable
-    lease_name = lease_name or os.environ.get(env.JMP_LEASE, "")
-
-    # when no lease name is provided, release the lease on exit
-    release_lease = lease_name == ""
-
-    with config.lease(metadata_filter=MetadataFilter(labels=dict(labels)), lease_name=lease_name,
-                      release=release_lease) as lease:
+    with config.lease(metadata_filter=MetadataFilter(labels=dict(labels)), lease_name=lease_name) as lease:
         with lease.serve_unix() as path:
             launch_shell(path, config.drivers.allow, config.drivers.unsafe)
 

--- a/jumpstarter/testing/pytest.py
+++ b/jumpstarter/testing/pytest.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from typing import ClassVar
 
@@ -59,10 +58,7 @@ i.e.:
         except RuntimeError:
             labels = getattr(self, "filter_labels", {})
             config = ClientConfigV1Alpha1.load("default")
-            lease_name = os.getenv(env.JMP_LEASE, None)
-            if lease_name is not None:
-                log.info(f"Using lease from env var JMP_LEASE: {lease_name}")
-            with config.lease(metadata_filter=MetadataFilter(labels=labels), lease_name=lease_name) as lease:
+            with config.lease(metadata_filter=MetadataFilter(labels=labels)) as lease:
                 with lease.connect() as client:
                     yield client
         # BUG workaround: make sure that grpc servers get the client/lease release properly


### PR DESCRIPTION
1) Import the right module for the env_var name
2) Only release runtime created leases, leases received via JMP_LEASE
   are kept, because those must be manually released.