### PR TITLE
add logging back to client cli

### DIFF
--- a/packages/jumpstarter-cli-client/jumpstarter_cli_client/__init__.py
+++ b/packages/jumpstarter-cli-client/jumpstarter_cli_client/__init__.py
@@ -1,6 +1,9 @@
+import logging
+from typing import Optional
+
 import asyncclick as click
 from jumpstarter.common.utils import env
-from jumpstarter_cli_common import AliasedGroup, version
+from jumpstarter_cli_common import AliasedGroup, opt_log_level, version
 
 from .client_config import create_client_config, delete_client_config, list_client_configs, use_client_config
 from .client_shell import client_shell
@@ -8,8 +11,13 @@ from .lease import lease
 
 
 @click.group(cls=AliasedGroup)
-def client():
+@opt_log_level
+def client(log_level: Optional[str]):
     """Jumpstarter client CLI tool"""
+    if log_level:
+        logging.basicConfig(level=log_level.upper())
+    else:
+        logging.basicConfig(level=logging.INFO)
 
 
 def j():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configurable logging level for the CLI tool
	- Users can now specify custom logging verbosity when running the tool

- **Improvements**
	- Default logging level set to INFO if no level is specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->