### PR TITLE
Fix Dutlink timeout handling after refactor

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,6 @@ wheels = [
 
 [[package]]
 name = "jumpstarter"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter" }
 dependencies = [
     { name = "aiohttp" },
@@ -784,7 +783,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-cli" }
 dependencies = [
     { name = "jumpstarter-cli-admin" },
@@ -817,7 +815,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-admin"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-cli-admin" }
 dependencies = [
     { name = "jumpstarter-cli-common" },
@@ -848,7 +845,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-client"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-cli-client" }
 dependencies = [
     { name = "jumpstarter-cli-common" },
@@ -875,7 +871,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-common"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-cli-common" }
 dependencies = [
     { name = "asyncclick" },
@@ -906,7 +901,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-exporter"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-cli-exporter" }
 dependencies = [
     { name = "asyncclick" },
@@ -937,7 +931,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-can"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-can" }
 dependencies = [
     { name = "can-isotp" },
@@ -966,7 +959,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-composite"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-composite" }
 dependencies = [
     { name = "asyncclick" },
@@ -995,7 +987,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-dutlink"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-dutlink" }
 dependencies = [
     { name = "asyncclick" },
@@ -1070,7 +1061,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-network"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-network" }
 dependencies = [
     { name = "fabric" },
@@ -1103,7 +1093,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-opendal"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-opendal" }
 dependencies = [
     { name = "asyncclick" },
@@ -1132,7 +1121,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-power"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-power" }
 dependencies = [
     { name = "asyncclick" },
@@ -1163,7 +1151,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-pyserial"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-pyserial" }
 dependencies = [
     { name = "asyncclick" },
@@ -1194,7 +1181,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-raspberrypi"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-raspberrypi" }
 dependencies = [
     { name = "gpiozero" },
@@ -1221,7 +1207,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-sdwire"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-sdwire" }
 dependencies = [
     { name = "jumpstarter" },
@@ -1289,7 +1274,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-ustreamer"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-driver-ustreamer" }
 dependencies = [
     { name = "jumpstarter" },
@@ -1350,7 +1334,6 @@ requires-dist = [
 
 [[package]]
 name = "jumpstarter-imagehash"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-imagehash" }
 dependencies = [
     { name = "imagehash" },
@@ -1377,7 +1360,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-kubernetes"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-kubernetes" }
 dependencies = [
     { name = "jumpstarter" },
@@ -1410,7 +1392,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-protocol"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-protocol" }
 dependencies = [
     { name = "grpcio" },
@@ -1441,7 +1422,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-testing"
-version = "0.5.1.dev125+g41e837e.d20250124"
 source = { editable = "packages/jumpstarter-testing" }
 dependencies = [
     { name = "jumpstarter" },


### PR DESCRIPTION
Some DUTLink targets have very long-running power on/off commands because those are
scripted internally and can take 10-15s, the timeout_s needs to be passed down to all
objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added a configurable timeout setting for USB operations
	- Default timeout set to 20 seconds
	- Improved timeout handling across USB-related classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->