### PR TITLE
Init UnixPortforwardAdapter

### DIFF
--- a/docs/source/api-reference/adapters/index.md
+++ b/docs/source/api-reference/adapters/index.md
@@ -1,0 +1,5 @@
+# Adapter Packages
+
+```{toctree}
+network.md
+```

--- a/docs/source/api-reference/adapters/network.md
+++ b/docs/source/api-reference/adapters/network.md
@@ -17,6 +17,11 @@ Network adapters are for transforming network connections exposed by drivers
     :members:
 ```
 
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_network.adapters.PexpectAdapter
+    :members:
+```
+
 ## Examples
 ```yaml
 export:
@@ -61,4 +66,14 @@ Connect to a remote TCP port with a web-based VNC client
 with NovncAdapter(client.tcp_port) as url:
     print(url) # https://novnc.com/noVNC/vnc.html?autoconnect=1&reconnect=1&host=127.0.0.1&port=36459
                # open the url in browser to access the VNC client
+```
+
+Interact with a remote TCP port as if it's a serial console
+
+```{testcode}
+with PexpectAdapter(client.tcp_port) as expect:
+    expect.expect("localhost login:")
+    expect.send("root\n")
+    expect.expect("Password:")
+    expect.send("secret\n")
 ```

--- a/docs/source/api-reference/adapters/network.md
+++ b/docs/source/api-reference/adapters/network.md
@@ -1,0 +1,51 @@
+# Network adapters
+
+Network adapters are for transforming network connections exposed by drivers
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_network.adapters.TcpPortforwardAdapter
+    :members:
+```
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_network.adapters.UnixPortforwardAdapter
+    :members:
+```
+
+## Examples
+```yaml
+export:
+  tcp_port:
+    type: "jumpstarter_driver_network.driver.TcpNetwork"
+    config:
+      host: localhost
+      port: 80
+  unix_socket:
+    type: "jumpstarter_driver_network.driver.UnixNetwork"
+    config:
+      path: /tmp/test.sock
+```
+
+Forward a remote TCP port to a local TCP port
+
+```{testcode}
+# random port on localhost
+with TcpPortforwardAdapter(client.tcp_port) as addr:
+    print(addr[0], addr[1]) # 127.0.0.1 38406
+
+# specific address and port
+with TcpPortforwardAdapter(client.tcp_port, local_host="192.0.2.1", local_port=8080) as addr:
+    print(addr[0], addr[1]) # 192.0.2.1 8080
+```
+
+Forward a remote Unix domain socket to a local socket
+
+```{testcode}
+with UnixPortforwardAdapter(client.unix_socket) as addr:
+    print(addr) # /tmp/jumpstarter-w30wxu64/socket
+
+# the type of the remote socket and the local one doesn't have to match
+# e.g. forward a remote Unix domain socket to a local TCP port
+with TcpPortforwardAdapter(client.unix_socket) as addr:
+    print(addr[0], addr[1]) # 127.0.0.1 38406
+```

--- a/docs/source/api-reference/adapters/network.md
+++ b/docs/source/api-reference/adapters/network.md
@@ -75,6 +75,8 @@ with NovncAdapter(client.tcp_port) as url:
 
 Interact with a remote TCP port as if it's a serial console
 
+See [pexpect](https://pexpect.readthedocs.io/en/stable/api/fdpexpect.html) for API documentation
+
 ```{testcode}
 with PexpectAdapter(client.tcp_port) as expect:
     expect.expect("localhost login:")
@@ -84,6 +86,8 @@ with PexpectAdapter(client.tcp_port) as expect:
 ```
 
 Connect to a remote TCP port with the fabric SSH client
+
+See [fabric](https://docs.fabfile.org/en/latest/api/connection.html#fabric.connection.Connection) for API documentation
 
 ```{testcode}
 with FabricAdapter(client=client.tcp_port, connect_kwargs={"password": "secret"}) as conn:

--- a/docs/source/api-reference/adapters/network.md
+++ b/docs/source/api-reference/adapters/network.md
@@ -22,6 +22,11 @@ Network adapters are for transforming network connections exposed by drivers
     :members:
 ```
 
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_network.adapters.FabricAdapter
+    :members:
+```
+
 ## Examples
 ```yaml
 export:
@@ -76,4 +81,11 @@ with PexpectAdapter(client.tcp_port) as expect:
     expect.send("root\n")
     expect.expect("Password:")
     expect.send("secret\n")
+```
+
+Connect to a remote TCP port with the fabric SSH client
+
+```{testcode}
+with FabricAdapter(client=client.tcp_port, connect_kwargs={"password": "secret"}) as conn:
+    conn.run("uname")
 ```

--- a/docs/source/api-reference/adapters/network.md
+++ b/docs/source/api-reference/adapters/network.md
@@ -12,6 +12,11 @@ Network adapters are for transforming network connections exposed by drivers
     :members:
 ```
 
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_network.adapters.NovncAdapter
+    :members:
+```
+
 ## Examples
 ```yaml
 export:
@@ -48,4 +53,12 @@ with UnixPortforwardAdapter(client.unix_socket) as addr:
 # e.g. forward a remote Unix domain socket to a local TCP port
 with TcpPortforwardAdapter(client.unix_socket) as addr:
     print(addr[0], addr[1]) # 127.0.0.1 38406
+```
+
+Connect to a remote TCP port with a web-based VNC client
+
+```{testcode}
+with NovncAdapter(client.tcp_port) as url:
+    print(url) # https://novnc.com/noVNC/vnc.html?autoconnect=1&reconnect=1&host=127.0.0.1&port=36459
+               # open the url in browser to access the VNC client
 ```

--- a/docs/source/api-reference/index.md
+++ b/docs/source/api-reference/index.md
@@ -6,4 +6,5 @@ This section provides details on the Jumpstarter core API and contrib drivers.
 drivers.md
 adapters.md
 drivers/index.md
+adapters/index.md
 ```

--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/__init__.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/__init__.py
@@ -1,6 +1,6 @@
 from .fabric import FabricAdapter
 from .novnc import NovncAdapter
 from .pexpect import PexpectAdapter
-from .portforward import PortforwardAdapter
+from .portforward import TcpPortforwardAdapter, UnixPortforwardAdapter
 
-__all__ = ["FabricAdapter", "NovncAdapter", "PexpectAdapter", "PortforwardAdapter"]
+__all__ = ["FabricAdapter", "NovncAdapter", "PexpectAdapter", "TcpPortforwardAdapter", "UnixPortforwardAdapter"]

--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/fabric.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/fabric.py
@@ -4,11 +4,11 @@ from typing import Any
 from fabric.config import Config
 from fabric.connection import Connection
 
-from .portforward import PortforwardAdapter
+from .portforward import TcpPortforwardAdapter
 
 
 @dataclass(kw_only=True)
-class FabricAdapter(PortforwardAdapter):
+class FabricAdapter(TcpPortforwardAdapter):
     user: str | None = None
     config: Config | None = None
     forward_agent: bool | None = None

--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/novnc.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/novnc.py
@@ -2,12 +2,12 @@ from dataclasses import dataclass
 from urllib.parse import urlencode, urlunparse
 
 from ..streams import WebsocketServerStream
-from .portforward import PortforwardAdapter
+from .portforward import TcpPortforwardAdapter
 from jumpstarter.streams import forward_stream
 
 
 @dataclass(kw_only=True)
-class NovncAdapter(PortforwardAdapter):
+class NovncAdapter(TcpPortforwardAdapter):
     async def __aenter__(self):
         addr = await super().__aenter__()
         return urlunparse(

--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/pexpect.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/pexpect.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass
 
 from pexpect.fdpexpect import fdspawn
 
-from .portforward import PortforwardAdapter
+from .portforward import TcpPortforwardAdapter
 
 
 @dataclass(kw_only=True)
-class PexpectAdapter(PortforwardAdapter):
+class PexpectAdapter(TcpPortforwardAdapter):
     async def __aenter__(self):
         addr = await super().__aenter__()
 

--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/portforward.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/portforward.py
@@ -1,22 +1,13 @@
 from dataclasses import dataclass
 
 from jumpstarter.client.adapters import ClientAdapter
-from jumpstarter.common import TemporaryTcpListener
+from jumpstarter.common import TemporaryTcpListener, TemporaryUnixListener
 from jumpstarter.streams import forward_stream
 
 
 @dataclass(kw_only=True)
 class PortforwardAdapter(ClientAdapter):
-    local_host: str = "127.0.0.1"
-    local_port: int = 0
     method: str = "connect"
-
-    async def __aenter__(self):
-        self.listener = TemporaryTcpListener(
-            self.handler, local_host=self.local_host, local_port=self.local_port, reuse_port=True
-        )
-
-        return await self.listener.__aenter__()
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         return await self.listener.__aexit__(exc_type, exc_value, traceback)
@@ -26,3 +17,24 @@ class PortforwardAdapter(ClientAdapter):
             async with self.client.stream_async(self.method) as stream:
                 async with forward_stream(conn, stream):
                     pass
+
+
+@dataclass(kw_only=True)
+class TcpPortforwardAdapter(PortforwardAdapter):
+    local_host: str = "127.0.0.1"
+    local_port: int = 0
+
+    async def __aenter__(self):
+        self.listener = TemporaryTcpListener(
+            self.handler, local_host=self.local_host, local_port=self.local_port, reuse_port=True
+        )
+
+        return await self.listener.__aenter__()
+
+
+@dataclass(kw_only=True)
+class UnixPortforwardAdapter(PortforwardAdapter):
+    async def __aenter__(self):
+        self.listener = TemporaryUnixListener(self.handler)
+
+        return await self.listener.__aenter__()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `TcpPortforwardAdapter` and `UnixPortforwardAdapter` for enhanced network connectivity options.
  - Added comprehensive documentation for the new network adapters, detailing their usage and configuration.

- **Refactor**
  - Updated existing adapters to inherit from the new TCP-based adapter, improving the structure and functionality.

- **Tests**
  - Expanded test coverage to verify functionality for both TCP and Unix domain socket forwarding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->