### PR TITLE
Add dummy metadata to config examples

### DIFF
--- a/__templates__/driver/examples/exporter.yaml.tmpl
+++ b/__templates__/driver/examples/exporter.yaml.tmpl
@@ -1,5 +1,8 @@
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: grpc.jumpstarter.192.168.0.203.nip.io:8082
 token: "<token>"
 export:

--- a/docs/source/cli/clients.md
+++ b/docs/source/cli/clients.md
@@ -32,6 +32,9 @@ file named `john.yaml`:
 ```yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ClientConfig
+metadata:
+  namespace: jumpstarter-lab
+  name: john
 endpoint: grpc.jumpstarter.192.168.1.10.nip.io:8082
 token: <<token>>
 tls:

--- a/docs/source/cli/exporters.md
+++ b/docs/source/cli/exporters.md
@@ -24,6 +24,9 @@ This creates an exporter named `my-exporter` and produces a YAML configuration f
 ```yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: jumpstarter-lab
+  name: my-exporter
 endpoint: grpc.jumpstarter.example.com:443
 token: <<token>>
 
@@ -40,6 +43,9 @@ will provide a few mock interfaces to play with:
 ```yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: grpc.jumpstarter.192.168.1.10.nip.io:8082
 token: <<token>>
 tls:

--- a/docs/source/getting-started/setup-local-client.md
+++ b/docs/source/getting-started/setup-local-client.md
@@ -8,6 +8,9 @@ Create a text file with the following content
 # /etc/jumpstarter/exporters/demo.yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 # endpoint and token are intentionally left empty
 endpoint: ""
 token: ""

--- a/docs/source/introduction/drivers.md
+++ b/docs/source/introduction/drivers.md
@@ -26,6 +26,9 @@ Here is an example exporter config that loads a driver:
 ```yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: grpc.jumpstarter.example.com:443
 token: xxxxx
 export:

--- a/docs/source/introduction/exporters.md
+++ b/docs/source/introduction/exporters.md
@@ -24,6 +24,9 @@ Here is an example Exporter config file:
 ```yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: grpc.jumpstarter.example.com:443
 token: xxxxx
 export:

--- a/examples/soc-pytest/jumpstarter_example_soc_pytest/exporter.yaml
+++ b/examples/soc-pytest/jumpstarter_example_soc_pytest/exporter.yaml
@@ -1,5 +1,8 @@
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: grpc.jumpstarter.example.com:443
 token: xxxxx
 export:

--- a/packages/jumpstarter-driver-dutlink/examples/exporter.yaml
+++ b/packages/jumpstarter-driver-dutlink/examples/exporter.yaml
@@ -1,6 +1,9 @@
 # /etc/jumpstarter/exporters/dutlink.yaml
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: ""
 token: ""
 export:

--- a/packages/jumpstarter-driver-tftp/examples/exporter.yaml
+++ b/packages/jumpstarter-driver-tftp/examples/exporter.yaml
@@ -1,5 +1,8 @@
 apiVersion: jumpstarter.dev/v1alpha1
 kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
 endpoint: grpc.jumpstarter.192.168.0.203.nip.io:8082
 token: "<token>"
 export:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration setups by adding a metadata section that clearly identifies namespaces and instance names for exporters and clients.

- **Documentation**
  - Updated guides and examples to reflect the new metadata structure, providing clearer configuration instructions and exposing additional options for driver settings and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->