### PR TITLE
Rename ClientConfig.name to ClientConfig.alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ build:
 
 clean: clean-docs clean-venv clean-build clean-test
 
-.PHONY: sync docs test test-jumpstarter test-packages build clean-test clean-docs clean-venv clean-build
+.PHONY: sync docs test test-packages build clean-test clean-docs clean-venv clean-build

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create_test.py
@@ -38,7 +38,7 @@ CLIENT_OBJECT = V1Alpha1Client(
 )
 
 UNSAFE_CLIENT_CONFIG = ClientConfigV1Alpha1(
-    name=CLIENT_NAME,
+    alias=CLIENT_NAME,
     metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
     endpoint=CLIENT_ENDPOINT,
     token=CLIENT_TOKEN,
@@ -46,7 +46,7 @@ UNSAFE_CLIENT_CONFIG = ClientConfigV1Alpha1(
 )
 
 CLIENT_CONFIG = ClientConfigV1Alpha1(
-    name=CLIENT_NAME,
+    alias=CLIENT_NAME,
     metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
     endpoint=CLIENT_ENDPOINT,
     token=CLIENT_TOKEN,

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete.py
@@ -54,7 +54,7 @@ async def delete_client(
             if ClientConfigV1Alpha1.exists(name) and (delete or click.confirm("Delete client configuration?")):
                 # If this is the default, clear default
                 user_config = UserConfigV1Alpha1.load_or_create()
-                if user_config.config.current_client is not None and user_config.config.current_client.name == name:
+                if user_config.config.current_client is not None and user_config.config.current_client.alias == name:
                     user_config.config.current_client = None
                     UserConfigV1Alpha1.save(user_config)
                 # Delete the client config

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete_test.py
@@ -29,7 +29,7 @@ CLIENT_ENDPOINT = "grpc://example.com:443"
 CLIENT_TOKEN = "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
 
 CLIENT_CONFIG = ClientConfigV1Alpha1(
-    name=CLIENT_NAME,
+    alias=CLIENT_NAME,
     metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
     endpoint=CLIENT_ENDPOINT,
     token=CLIENT_TOKEN,

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res_test.py
@@ -23,14 +23,14 @@ CLIENT_TOKEN = "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd
 DRIVER_NAME = "jumpstarter.Testing"
 # Create a test client config
 UNSAFE_CLIENT_CONFIG = ClientConfigV1Alpha1(
-    name=CLIENT_NAME,
+    alias=CLIENT_NAME,
     metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
     endpoint=CLIENT_ENDPOINT,
     token=CLIENT_TOKEN,
     drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=True),
 )
 CLIENT_CONFIG = ClientConfigV1Alpha1(
-    name=CLIENT_NAME,
+    alias=CLIENT_NAME,
     metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
     endpoint=CLIENT_ENDPOINT,
     token=CLIENT_TOKEN,

--- a/packages/jumpstarter-cli-client/jumpstarter_cli_client/client_config.py
+++ b/packages/jumpstarter-cli-client/jumpstarter_cli_client/client_config.py
@@ -65,7 +65,7 @@ def create_client_config(
         raise click.ClickException(f"A client with the name '{alias}' already exists.")
 
     config = ClientConfigV1Alpha1(
-        name=alias,
+        alias=alias,
         metadata=ObjectMeta(namespace=namespace, name=name),
         endpoint=endpoint,
         token=token,
@@ -85,12 +85,12 @@ def set_next_client(name: str):
     if (
         user_config is not None
         and user_config.config.current_client is not None
-        and user_config.config.current_client.name == name
+        and user_config.config.current_client.alias == name
     ):
         for c in ClientConfigV1Alpha1.list():
-            if c.name != name:
+            if c.alias != name:
                 # Use the next available client config
-                user_config.use_client(c.name)
+                user_config.use_client(c.alias)
                 return
         # Otherwise, set client to none
         user_config.use_client(None)
@@ -110,7 +110,7 @@ def list_client_configs():
     current_name = None
     if UserConfigV1Alpha1.exists():
         current_client = UserConfigV1Alpha1.load().config.current_client
-        current_name = current_client.name if current_client is not None else None
+        current_name = current_client.alias if current_client is not None else None
 
     configs = ClientConfigV1Alpha1.list()
 
@@ -118,8 +118,8 @@ def list_client_configs():
 
     def make_row(c: ClientConfigV1Alpha1):
         return {
-            "CURRENT": "*" if current_name == c.name else "",
-            "NAME": c.name,
+            "CURRENT": "*" if current_name == c.alias else "",
+            "NAME": c.alias,
             "ENDPOINT": c.endpoint,
             "PATH": str(c.path),
         }

--- a/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/clients.py
+++ b/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/clients.py
@@ -104,7 +104,7 @@ class ClientsV1Alpha1Api(AbstractAsyncCustomObjectApi):
         endpoint = client.status.endpoint
         token = base64.b64decode(secret.data["token"]).decode("utf8")
         return ClientConfigV1Alpha1(
-            name=name,
+            alias=name,
             metadata=ObjectMeta(
                 namespace=client.metadata.namespace,
                 name=client.metadata.name,

--- a/packages/jumpstarter/jumpstarter/config/client.py
+++ b/packages/jumpstarter/jumpstarter/config/client.py
@@ -36,7 +36,7 @@ class ClientConfigV1Alpha1Drivers(BaseModel):
 class ClientConfigV1Alpha1(BaseModel):
     CLIENT_CONFIGS_PATH: ClassVar[Path] = CONFIG_PATH / "clients"
 
-    name: str = Field(default="default", exclude=True)
+    alias: str = Field(default="default", exclude=True)
     path: Path | None = Field(default=None, exclude=True)
 
     apiVersion: Literal["jumpstarter.dev/v1alpha1"] = Field(default="jumpstarter.dev/v1alpha1")
@@ -124,7 +124,7 @@ class ClientConfigV1Alpha1(BaseModel):
     def from_file(cls, path: os.PathLike):
         with open(path) as f:
             v = cls.model_validate(yaml.safe_load(f))
-            v.name = os.path.basename(path).split(".")[0]
+            v.alias = os.path.basename(path).split(".")[0]
             v.path = Path(path)
             return v
 
@@ -157,14 +157,14 @@ class ClientConfigV1Alpha1(BaseModel):
         )
 
     @classmethod
-    def _get_path(cls, name: str) -> Path:
-        """Get the regular path of a client config given a name."""
-        return (cls.CLIENT_CONFIGS_PATH / name).with_suffix(".yaml")
+    def _get_path(cls, alias: str) -> Path:
+        """Get the regular path of a client config given an alias."""
+        return (cls.CLIENT_CONFIGS_PATH / alias).with_suffix(".yaml")
 
     @classmethod
-    def load(cls, name: str) -> Self:
-        """Load a client config by name."""
-        path = cls._get_path(name)
+    def load(cls, alias: str) -> Self:
+        """Load a client config by alias."""
+        path = cls._get_path(alias)
         if path.exists() is False:
             raise FileNotFoundError(f"Client config '{path}' does not exist.")
         return cls.from_file(path)
@@ -176,7 +176,7 @@ class ClientConfigV1Alpha1(BaseModel):
         if path is None:
             cls.ensure_exists()
             # Set the config path before saving
-            config.path = cls._get_path(config.name)
+            config.path = cls._get_path(config.alias)
         else:
             config.path = Path(path)
         with config.path.open(mode="w") as f:
@@ -187,9 +187,9 @@ class ClientConfigV1Alpha1(BaseModel):
         return yaml.safe_dump(config.model_dump(mode="json"), sort_keys=False)
 
     @classmethod
-    def exists(cls, name: str) -> bool:
-        """Check if a client config exists by name."""
-        return cls._get_path(name).exists()
+    def exists(cls, alias: str) -> bool:
+        """Check if a client config exists by alias."""
+        return cls._get_path(alias).exists()
 
     @classmethod
     def list(cls) -> list[Self]:
@@ -209,9 +209,9 @@ class ClientConfigV1Alpha1(BaseModel):
         return list(map(make_config, files))
 
     @classmethod
-    def delete(cls, name: str):
-        """Delete a client config by name."""
-        path = cls._get_path(name)
+    def delete(cls, alias: str):
+        """Delete a client config by alias."""
+        path = cls._get_path(alias)
         if path.exists() is False:
             raise FileNotFoundError(f"Client config '{path}' does not exist.")
         path.unlink()

--- a/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -26,7 +26,7 @@ def test_client_config_try_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(JMP_DRIVERS_ALLOW, "jumpstarter.drivers.*,vendorpackage.*")
 
     config = ClientConfigV1Alpha1.try_from_env()
-    assert config.name == "default"
+    assert config.alias == "default"
     assert config.metadata.namespace == "default"
     assert config.metadata.name == "testclient"
     assert config.token == "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
@@ -48,7 +48,7 @@ def test_client_config_from_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(JMP_DRIVERS_ALLOW, "jumpstarter.drivers.*,vendorpackage.*")
 
     config = ClientConfigV1Alpha1.from_env()
-    assert config.name == "default"
+    assert config.alias == "default"
     assert config.metadata.namespace == "default"
     assert config.metadata.name == "testclient"
     assert config.token == "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
@@ -65,7 +65,7 @@ def test_client_config_from_env_allow_unsafe(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(JMP_DRIVERS_ALLOW, "UNSAFE")
 
     config = ClientConfigV1Alpha1.from_env()
-    assert config.name == "default"
+    assert config.alias == "default"
     assert config.metadata.namespace == "default"
     assert config.metadata.name == "testclient"
     assert config.token == "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
@@ -105,7 +105,7 @@ drivers:
         f.write(CLIENT_CONFIG)
         f.close()
         config = ClientConfigV1Alpha1.from_file(f.name)
-        assert config.name == f.name.split("/")[-1]
+        assert config.alias == f.name.split("/")[-1]
         assert config.metadata.namespace == "default"
         assert config.metadata.name == "testclient"
         assert config.endpoint == "jumpstarter.my-lab.com:1443"
@@ -175,7 +175,7 @@ def test_client_config_load():
                 ClientConfigV1Alpha1,
                 "from_file",
                 return_value=ClientConfigV1Alpha1(
-                    name="another",
+                    alias="another",
                     metadata=ObjectMeta(namespace="default", name="another"),
                     endpoint="abc",
                     token="123",
@@ -183,7 +183,7 @@ def test_client_config_load():
                 ),
             ) as from_file_mock:
                 value = ClientConfigV1Alpha1.load("another")
-                assert value.name == "another"
+                assert value.alias == "another"
                 get_path_mock.assert_called_once_with("another")
                 from_file_mock.assert_called_once_with(Path(f.name))
                 os.unlink(f.name)
@@ -212,7 +212,7 @@ drivers:
   unsafe: false
 """
     config = ClientConfigV1Alpha1(
-        name="testclient",
+        alias="testclient",
         metadata=ObjectMeta(namespace="default", name="testclient"),
         endpoint="jumpstarter.my-lab.com:1443",
         token="dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz",
@@ -247,7 +247,7 @@ drivers:
   unsafe: false
 """
     config = ClientConfigV1Alpha1(
-        name="testclient",
+        alias="testclient",
         metadata=ObjectMeta(namespace="default", name="testclient"),
         endpoint="jumpstarter.my-lab.com:1443",
         token="dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz",
@@ -278,7 +278,7 @@ drivers:
   unsafe: true
 """
     config = ClientConfigV1Alpha1(
-        name="testclient",
+        alias="testclient",
         metadata=ObjectMeta(namespace="default", name="testclient"),
         endpoint="jumpstarter.my-lab.com:1443",
         token="dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz",
@@ -322,7 +322,7 @@ drivers:
         monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", Path(d))
         configs = ClientConfigV1Alpha1.list()
         assert len(configs) == 1
-        assert configs[0].name == "testclient"
+        assert configs[0].alias == "testclient"
 
 
 def test_client_config_list_none(monkeypatch: pytest.MonkeyPatch):

--- a/packages/jumpstarter/jumpstarter/config/user.py
+++ b/packages/jumpstarter/jumpstarter/config/user.py
@@ -12,7 +12,7 @@ from .common import CONFIG_PATH
 
 def _serialize_current_client(v: ClientConfigV1Alpha1 | None) -> str | None:
     if v:
-        return v.name
+        return v.alias
     else:
         return None
 

--- a/packages/jumpstarter/jumpstarter/config/user_config_test.py
+++ b/packages/jumpstarter/jumpstarter/config/user_config_test.py
@@ -32,7 +32,7 @@ config:
         ClientConfigV1Alpha1,
         "load",
         return_value=ClientConfigV1Alpha1(
-            name="testclient",
+            alias="testclient",
             metadata=ObjectMeta(namespace="default", name="testclient"),
             endpoint="abc",
             token="123",
@@ -45,7 +45,7 @@ config:
             monkeypatch.setattr(UserConfigV1Alpha1, "USER_CONFIG_PATH", f.name)
             config = UserConfigV1Alpha1.load()
             mock_load.assert_called_once_with("testclient")
-            assert config.config.current_client.name == "testclient"
+            assert config.config.current_client.alias == "testclient"
             os.unlink(f.name)
 
 
@@ -194,7 +194,7 @@ config:
         config = UserConfigV1Alpha1(
             config=UserConfigV1Alpha1Config(
                 current_client=ClientConfigV1Alpha1(
-                    name="testclient",
+                    alias="testclient",
                     metadata=ObjectMeta(namespace="default", name="testclient"),
                     endpoint="abc",
                     token="123",
@@ -235,7 +235,7 @@ config:
         ClientConfigV1Alpha1,
         "load",
         return_value=ClientConfigV1Alpha1(
-            name="testclient",
+            alias="testclient",
             metadata=ObjectMeta(namespace="default", name="testclient"),
             endpoint="abc",
             token="123",
@@ -247,7 +247,7 @@ config:
             config = UserConfigV1Alpha1(
                 config=UserConfigV1Alpha1Config(
                     current_client=ClientConfigV1Alpha1(
-                        name="another",
+                        alias="another",
                         metadata=ObjectMeta(namespace="default", name="testclient"),
                         endpoint="abc",
                         token="123",
@@ -260,7 +260,7 @@ config:
                 value = loaded.read()
                 assert value == USER_CONFIG
                 mock_load.assert_called_once_with("testclient")
-            assert config.config.current_client.name == "testclient"
+            assert config.config.current_client.alias == "testclient"
             os.unlink(f.name)
 
 
@@ -275,7 +275,7 @@ config:
         config = UserConfigV1Alpha1(
             config=UserConfigV1Alpha1Config(
                 current_client=ClientConfigV1Alpha1(
-                    name="another",
+                    alias="another",
                     metadata=ObjectMeta(namespace="default", name="testclient"),
                     endpoint="abc",
                     token="123",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized client and exporter configuration naming from `name` to `alias` for improved clarity and consistency.
- **Chore**
	- Updated the build configuration by removing an outdated testing target.
- **Tests**
	- Adjusted test cases to align with the updated configuration naming convention, ensuring all references now use `alias`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->