### PR TITLE
Fix doc references to jumpstarter.drivers.*

### DIFF
--- a/docs/source/api-reference/drivers/pyserial.md
+++ b/docs/source/api-reference/drivers/pyserial.md
@@ -1,6 +1,6 @@
 # PySerial
 
-**driver**: `jumpstarter.drivers.pyserial.driver.PySerial`
+**driver**: `jumpstarter_driver_pyserial.driver.PySerial`
 
 The methods of this client are dynamic, and they are generated from
 the `methods` field of the exporter driver configuration.
@@ -9,7 +9,7 @@ the `methods` field of the exporter driver configuration.
 ```yaml
 export:
   my_serial:
-    type: "jumpstarter.drivers.pyserial.driver.PySerial"
+    type: ""jumpstarter_driver_pyserial.driver.PySerial"
     config:
       url: "/dev/ttyUSB0"
       baudrate: 115200
@@ -24,7 +24,7 @@ export:
 
 ## PySerialClient API
 ```{eval-rst}
-.. autoclass:: jumpstarter.drivers.pyserial.client.PySerialClient
+.. autoclass:: "jumpstarter_driver_pyserial.client.PySerialClient
     :members: pexpect, open, stream, open_stream, close
 ```
 

--- a/docs/source/api-reference/drivers/sdwire.md
+++ b/docs/source/api-reference/drivers/sdwire.md
@@ -8,6 +8,6 @@ The SDWire driver implements the `StorageMuxClient` class, which is a generic
 storage class.
 
 ```{eval-rst}
-.. autoclass:: jumpstarter.drivers.storage.client.StorageMuxClient
+.. autoclass:: jumpstarter_driver_opendal.client.StorageMuxClient
     :members:
 ```

--- a/docs/source/cli/exporters.md
+++ b/docs/source/cli/exporters.md
@@ -53,11 +53,11 @@ tls:
     insecure: True
 export:
     storage:
-        type: jumpstarter.drivers.storage.driver.MockStorageMux
+        type: jumpstarter_driver_opendal.driver.MockStorageMux
     power:
-        type: jumpstarter.drivers.power.driver.MockPower
+        type: jumpstarter_driver_power.driver.MockPower
     echonet:
-        type: jumpstarter.drivers.network.driver.EchoNetwork
+        type: jumpstarter_driver_network.driver.EchoNetwork
     can:
         type: jumpstarter_driver_can.driver.Can
         config:

--- a/docs/source/cli/run-tests.md
+++ b/docs/source/cli/run-tests.md
@@ -49,7 +49,7 @@ the base class will attempt to:
 3. Request a lease based on the `filter_labels` provided in the test class.
 
 ```{eval-rst}
-.. autoclass:: jumpstarter.testing.pytest.JumpstarterTest
+.. autoclass:: jumpstarter_testing.pytest.JumpstarterTest
     :members:
 ```
 

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -60,7 +60,7 @@ endpoint: "jumpstarter.my-lab.com:1443"
 token: "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
 drivers:
   # Wildcards are supported
-  allow: ["jumpstarter.drivers.*", "vendorpackage.*"]
+  allow: ["jumpstarter_drivers_*", "vendorpackage.*"]
 ```
 
 - `endpoint` - The gRPC endpoint of the Jumpstarter controller server.
@@ -151,14 +151,14 @@ endpoint: "jumpstarter.my-lab.com:1443"
 token: "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
 export:
   power:
-    type: "jumpstarter.drivers.power.PduPower"
+    type: "jumpstarter_driver_power.driver.PduPower"
     config:
       host: "192.168.1.111"
       port: 1234
       username: "admin"
       password: "secret"
   serial:
-    type: "jumpstarter.drivers.pyserial.driver.PySerial"
+    type: "jumpstarter_driver_pyserial.driver.PySerial"
     config:
       url: "/dev/ttyUSB0"
       baudrate: 115200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation  
  - Updated references and configuration examples to use a consistent naming convention for drivers, clients, and testing components, improving clarity and alignment across the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->