### PR TITLE
Support setting OIDC username when creating client/exporter objects

### DIFF
--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create.py
@@ -19,6 +19,8 @@ from .k8s import (
 )
 from jumpstarter.config import ClientConfigV1Alpha1, ExporterConfigV1Alpha1, UserConfigV1Alpha1
 
+opt_oidc_username = click.option("--oidc-username", "oidc_username", type=str, default=None, help="OIDC username")
+
 
 @click.group(cls=AliasedGroup)
 @opt_log_level
@@ -57,6 +59,7 @@ def create(log_level: Optional[str]):
 @opt_namespace
 @opt_kubeconfig
 @opt_context
+@opt_oidc_username
 async def create_client(
     name: Optional[str],
     kubeconfig: Optional[str],
@@ -66,12 +69,13 @@ async def create_client(
     allow: Optional[str],
     unsafe: bool,
     out: Optional[str],
+    oidc_username: str | None,
 ):
     """Create a client object in the Kubernetes cluster"""
     try:
         async with ClientsV1Alpha1Api(namespace, kubeconfig, context) as api:
             click.echo(f"Creating client '{name}' in namespace '{namespace}'")
-            await api.create_client(name)
+            await api.create_client(name, oidc_username)
             # Save the client config
             if save or out is not None or click.confirm("Save client configuration?"):
                 click.echo("Fetching client credentials from cluster")
@@ -117,6 +121,7 @@ async def create_client(
 @opt_namespace
 @opt_kubeconfig
 @opt_context
+@opt_oidc_username
 async def create_exporter(
     name: Optional[str],
     kubeconfig: Optional[str],
@@ -124,12 +129,13 @@ async def create_exporter(
     namespace: str,
     save: bool,
     out: Optional[str],
+    oidc_username: str | None,
 ):
     """Create an exporter object in the Kubernetes cluster"""
     try:
         async with ExportersV1Alpha1Api(namespace, kubeconfig, context) as api:
             click.echo(f"Creating exporter '{name}' in namespace '{namespace}'")
-            await api.create_exporter(name)
+            await api.create_exporter(name, oidc_username)
             # Save the client config
             if save or out is not None or click.confirm("Save exporter configuration?"):
                 click.echo("Fetching exporter credentials from cluster")

--- a/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/clients.py
+++ b/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/clients.py
@@ -55,7 +55,7 @@ class ClientsV1Alpha1Api(AbstractAsyncCustomObjectApi):
             else V1Alpha1ClientStatus(credential=None, endpoint=""),
         )
 
-    async def create_client(self, name: str) -> V1Alpha1Client:
+    async def create_client(self, name: str, oidc_username: str | None = None) -> V1Alpha1Client:
         """Create a client object in the cluster async"""
         # Create the namespaced client object
         await self.api.create_namespaced_custom_object(
@@ -63,7 +63,12 @@ class ClientsV1Alpha1Api(AbstractAsyncCustomObjectApi):
             group="jumpstarter.dev",
             plural="clients",
             version="v1alpha1",
-            body={"apiVersion": "jumpstarter.dev/v1alpha1", "kind": "Client", "metadata": {"name": name}},
+            body={
+                "apiVersion": "jumpstarter.dev/v1alpha1",
+                "kind": "Client",
+                "metadata": {"name": name},
+                "spec": {"username": oidc_username} if oidc_username is not None else {},
+            },
         )
         # Wait for the credentials to become available
         # NOTE: Watch is not working here with the Python kubernetes library

--- a/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/exporters.py
+++ b/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/exporters.py
@@ -76,7 +76,7 @@ class ExportersV1Alpha1Api(AbstractAsyncCustomObjectApi):
         )
         return ExportersV1Alpha1Api._deserialize(result)
 
-    async def create_exporter(self, name: str) -> V1Alpha1Exporter:
+    async def create_exporter(self, name: str, oidc_username: str | None = None) -> V1Alpha1Exporter:
         """Create an exporter in the cluster"""
         # Create the namespaced exporter object
         await self.api.create_namespaced_custom_object(
@@ -84,7 +84,12 @@ class ExportersV1Alpha1Api(AbstractAsyncCustomObjectApi):
             group="jumpstarter.dev",
             plural="exporters",
             version="v1alpha1",
-            body={"apiVersion": "jumpstarter.dev/v1alpha1", "kind": "Exporter", "metadata": {"name": name}},
+            body={
+                "apiVersion": "jumpstarter.dev/v1alpha1",
+                "kind": "Exporter",
+                "metadata": {"name": name},
+                "spec": {"username": oidc_username} if oidc_username is not None else {},
+            },
         )
         # Wait for the credentials to become available
         # NOTE: Watch is not working here with the Python kubernetes library

--- a/uv.lock
+++ b/uv.lock
@@ -771,7 +771,6 @@ wheels = [
 
 [[package]]
 name = "jumpstarter"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter" }
 dependencies = [
     { name = "aiohttp" },
@@ -870,7 +869,6 @@ requires-dist = [
 
 [[package]]
 name = "jumpstarter-cli"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-cli" }
 dependencies = [
     { name = "jumpstarter-cli-admin" },
@@ -905,7 +903,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-admin"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-cli-admin" }
 dependencies = [
     { name = "jumpstarter-cli-common" },
@@ -936,7 +933,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-client"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-cli-client" }
 dependencies = [
     { name = "jumpstarter-cli-common" },
@@ -963,7 +959,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-common"
-version = "0.5.1.dev291+g22a21c9"
 source = { editable = "packages/jumpstarter-cli-common" }
 dependencies = [
     { name = "asyncclick" },
@@ -1002,7 +997,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-driver"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-cli-driver" }
 dependencies = [
     { name = "asyncclick" },
@@ -1033,7 +1027,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-cli-exporter"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-cli-exporter" }
 dependencies = [
     { name = "asyncclick" },
@@ -1064,7 +1057,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-can"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-can" }
 dependencies = [
     { name = "can-isotp" },
@@ -1093,7 +1085,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-composite"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-composite" }
 dependencies = [
     { name = "asyncclick" },
@@ -1122,7 +1113,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-dutlink"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-dutlink" }
 dependencies = [
     { name = "asyncclick" },
@@ -1231,7 +1221,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-opendal"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-opendal" }
 dependencies = [
     { name = "asyncclick" },
@@ -1260,7 +1249,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-power"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-power" }
 dependencies = [
     { name = "asyncclick" },
@@ -1291,7 +1279,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-pyserial"
-version = "0.5.1.dev291+g22a21c9"
 source = { editable = "packages/jumpstarter-driver-pyserial" }
 dependencies = [
     { name = "asyncclick" },
@@ -1326,7 +1313,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-raspberrypi"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-raspberrypi" }
 dependencies = [
     { name = "gpiozero" },
@@ -1353,7 +1339,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-sdwire"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-sdwire" }
 dependencies = [
     { name = "jumpstarter" },
@@ -1480,7 +1465,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-ustreamer"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-driver-ustreamer" }
 dependencies = [
     { name = "jumpstarter" },
@@ -1507,7 +1491,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-driver-yepkit"
-version = "0.5.1.dev291+g22a21c9.d20250218"
 source = { editable = "packages/jumpstarter-driver-yepkit" }
 dependencies = [
     { name = "anyio" },
@@ -1572,7 +1555,6 @@ requires-dist = [
 
 [[package]]
 name = "jumpstarter-imagehash"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-imagehash" }
 dependencies = [
     { name = "imagehash" },
@@ -1599,7 +1581,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-kubernetes"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-kubernetes" }
 dependencies = [
     { name = "jumpstarter" },
@@ -1632,7 +1613,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-protocol"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-protocol" }
 dependencies = [
     { name = "grpcio" },
@@ -1663,7 +1643,6 @@ dev = [
 
 [[package]]
 name = "jumpstarter-testing"
-version = "0.5.1.dev261+ga9c72c3.d20250212"
 source = { editable = "packages/jumpstarter-testing" }
 dependencies = [
     { name = "jumpstarter" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option allowing users to specify an OIDC username when creating client and exporter objects.
  - Enhanced the creation process for client and exporter entities so that the provided OIDC username is now incorporated into API interactions with Kubernetes for improved authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->