### PR TITLE
Avoid exceptions for unknown commands under j

### DIFF
--- a/packages/jumpstarter-cli-client/jumpstarter_cli_client/__init__.py
+++ b/packages/jumpstarter-cli-client/jumpstarter_cli_client/__init__.py
@@ -23,7 +23,7 @@ def client(log_level: Optional[str]):
 
 def j():
     with env() as client:
-        client.cli()(standalone_mode=False)
+        client.cli()(standalone_mode=True)
 
 
 client.add_command(create_client_config)


### PR DESCRIPTION
Without this change an unknown command results into a big exception, with standalone mode, a wrong command will result in a friendly reminder to look at the help output from click.

Fixes: #300 

Now the output looks like:
```
jumpstarter ⚡local ➤ j abcd
Usage: j [OPTIONS] COMMAND [ARGS]...
Try 'j --help' for help.

Error: No such command 'abcd'.
```