### PR TITLE
Provide a simplified "ref" access to proxy drivers

### DIFF
--- a/docs/source/api-reference/drivers/index.md
+++ b/docs/source/api-reference/drivers/index.md
@@ -9,7 +9,9 @@ Drivers packages from the [drivers](https://github.com/jumpstarter-dev/jumpstart
 ```{toctree}
 :maxdepth: 2
 can.md
+dbus.md
 network.md
+proxy.md
 probe-rs.md
 pyserial.md
 sdwire.md
@@ -18,6 +20,4 @@ snmp.md
 tftp.md
 ustreamer.md
 yepkit.md
-dbus.md
-proxy.md
 ```

--- a/docs/source/api-reference/drivers/proxy.md
+++ b/docs/source/api-reference/drivers/proxy.md
@@ -1,6 +1,10 @@
 # Proxy driver
 
-The Proxy driver is not a real driver, but for creating "proxies" or aliases of other drivers to present a desired view of the tree of devices to the client.
+The Proxy driver is not a real driver, but for creating "proxies" or aliases of
+other drivers to present a desired view of the tree of devices to the client.
+
+It's also useful when several drivers need configured access to a common
+resource, like a serial port or a network connection.
 
 ## Driver configuration
 
@@ -12,7 +16,8 @@ The Proxy driver is not a real driver, but for creating "proxies" or aliases of 
 
 ```{doctest}
 >>> root.foo.bar.power.on() # instead of
->>> root.proxy.on() # you can do
+>>> root.proxy.on()         # you can do
+>>> root.refproxy.on()      # and same for the refproxy
 ```
 
 ```{testsetup} *

--- a/docs/source/api-reference/drivers/proxy.md
+++ b/docs/source/api-reference/drivers/proxy.md
@@ -17,7 +17,6 @@ resource, like a serial port or a network connection.
 ```{doctest}
 >>> root.foo.bar.power.on() # instead of
 >>> root.proxy.on()         # you can do
->>> root.refproxy.on()      # and same for the refproxy
 ```
 
 ```{testsetup} *

--- a/docs/source/api-reference/drivers/proxy.yaml
+++ b/docs/source/api-reference/drivers/proxy.yaml
@@ -2,7 +2,9 @@ children:
   proxy:
     type: "jumpstarter_driver_composite.driver.Proxy"
     config:
-      path: [foo, bar, power] # full path of the underlying driver
+      path: "foo.bar.power" # full path of the underlying driver
+  refproxy: # simplified syntax for Proxy
+    ref: "foo.bar.power"
   foo:
     children:
       bar:

--- a/docs/source/api-reference/drivers/proxy.yaml
+++ b/docs/source/api-reference/drivers/proxy.yaml
@@ -1,9 +1,5 @@
 children:
   proxy:
-    type: "jumpstarter_driver_composite.driver.Proxy"
-    config:
-      path: "foo.bar.power" # full path of the underlying driver
-  refproxy: # simplified syntax for Proxy
     ref: "foo.bar.power"
   foo:
     children:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,9 @@ doctest_test_doctest_blocks = ""
 
 html_js_files = ["js/version_array.js", "js/versions.js"]
 html_static_path = ["_static"]
-html_css_files = ['css/versions.css',]
+html_css_files = [
+    "css/versions.css",
+]
 html_sidebars = {
     "**": [
         "sidebar/brand.html",

--- a/docs/source/introduction/exporters.md
+++ b/docs/source/introduction/exporters.md
@@ -31,13 +31,30 @@ metadata:
 endpoint: grpc.jumpstarter.example.com:443
 token: xxxxx
 export:
-  # a DUTLink interface to the DUT
-  dutlink:
-    type: jumpstarter_driver_dutlink.driver.Dutlink
+  power:
+    type: jumpstarter_driver_yepkit.driver.Ykush
     config:
-      storage_device: "/dev/disk/by-id/usb-SanDisk_3.2_Gen_1_5B4C0AB025C0-0:0"
+      serial: "YK25838"
+      port: "1"
+  serial:
+    type: "jumpstarter_driver_pyserial.driver.PySerial"
+    config:
+      url: "/dev/ttyUSB0"
+      baudrate: 115200
+  storage:
+  type: "jumpstarter_driver_sdwire.driver.SDWire"
+    config:
+      serial: "sdw-00001"
+      storage_device: "/dev/disk/by-path/..."
+  custom:
+    type: "vendorpackage.CustomDriver"
+    config:
+      hello: "world"
+  reference:
+    ref: "power" # reference to another driver, this uses the Proxy driver
 ```
 
+see the [ExporterConfig](../api-reference/exporters/exporterconfig.md) for more details.
 ## Running an Exporter
 
 To run an Exporter on a host system, you must have Python {{requires_python}} installed

--- a/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver.py
+++ b/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver.py
@@ -19,7 +19,7 @@ class Composite(CompositeInterface, Driver):
 
 @dataclass(kw_only=True)
 class Proxy(Driver):
-    path: str
+    ref: str
 
     @classmethod
     def client(cls) -> str:
@@ -27,14 +27,12 @@ class Proxy(Driver):
 
     def __target(self, root, name):
         try:
-            path = self.path.split(".")
+            path = self.ref.split(".")
             if not path:
                 raise ConfigurationError(f"Proxy driver {name} has empty path")
             return reduce(lambda instance, name: instance.children[name], path, root)
         except KeyError:
-            raise ConfigurationError(
-                f"Proxy driver {name} references nonexistent driver {'.'.join(self.path)}"
-            ) from None
+            raise ConfigurationError(f"Proxy driver {name} references nonexistent driver {self.ref}") from None
 
     def report(self, *, root=None, parent=None, name=None):
         return self.__target(root, name).report(root=root, parent=parent, name=name)

--- a/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver.py
+++ b/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver.py
@@ -19,7 +19,7 @@ class Composite(CompositeInterface, Driver):
 
 @dataclass(kw_only=True)
 class Proxy(Driver):
-    path: list[str]
+    path: str
 
     @classmethod
     def client(cls) -> str:
@@ -27,7 +27,10 @@ class Proxy(Driver):
 
     def __target(self, root, name):
         try:
-            return reduce(lambda instance, name: instance.children[name], self.path, root)
+            path = self.path.split(".")
+            if not path:
+                raise ConfigurationError(f"Proxy driver {name} has empty path")
+            return reduce(lambda instance, name: instance.children[name], path, root)
         except KeyError:
             raise ConfigurationError(
                 f"Proxy driver {name} references nonexistent driver {'.'.join(self.path)}"

--- a/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver_test.py
+++ b/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver_test.py
@@ -8,8 +8,9 @@ def test_drivers_composite():
     with serve(
         Composite(
             children={
-                "proxy0": Proxy(path=["composite1", "power1"]),
-                "proxy1": Proxy(path=["composite1"]),
+                "proxy0": Proxy(path="composite1.power1"),
+                "proxy1": Proxy(path="composite1"),
+                "refproxy": Composite(ref="composite1"),
                 "power0": MockPower(),
                 "composite1": Composite(
                     children={
@@ -23,3 +24,4 @@ def test_drivers_composite():
         client.composite1.power1.on()
         client.proxy0.on()
         client.proxy1.power1.on()
+        client.refproxy.on()

--- a/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver_test.py
+++ b/packages/jumpstarter-driver-composite/jumpstarter_driver_composite/driver_test.py
@@ -8,9 +8,8 @@ def test_drivers_composite():
     with serve(
         Composite(
             children={
-                "proxy0": Proxy(path="composite1.power1"),
-                "proxy1": Proxy(path="composite1"),
-                "refproxy": Composite(ref="composite1"),
+                "proxy0": Proxy(ref="composite1.power1"),
+                "proxy1": Proxy(ref="composite1"),
                 "power0": MockPower(),
                 "composite1": Composite(
                     children={
@@ -24,4 +23,3 @@ def test_drivers_composite():
         client.composite1.power1.on()
         client.proxy0.on()
         client.proxy1.power1.on()
-        client.refproxy.on()

--- a/packages/jumpstarter-driver-composite/pyproject.toml
+++ b/packages/jumpstarter-driver-composite/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.entry-points."jumpstarter.drivers"]
 Composite = "jumpstarter_driver_composite.driver:Composite"
+Proxy = "jumpstarter_driver_composite.driver:Proxy"
 
 [dependency-groups]
 dev = [

--- a/packages/jumpstarter-driver-probe-rs/jumpstarter_driver_probe_rs/client.py
+++ b/packages/jumpstarter-driver-probe-rs/jumpstarter_driver_probe_rs/client.py
@@ -59,7 +59,7 @@ class ProbeRsClient(DriverClient):
         data_strs = self.call("read", f"b{int(width)}", "0x%x" % int(address), "%d" % words)
         return [int(data, 16) for data in data_strs]
 
-    def cli(self): # noqa: C901
+    def cli(self):  # noqa: C901
         @click.group
         def base():
             """probe-rs client"""

--- a/packages/jumpstarter-driver-probe-rs/jumpstarter_driver_probe_rs/driver.py
+++ b/packages/jumpstarter-driver-probe-rs/jumpstarter_driver_probe_rs/driver.py
@@ -65,7 +65,6 @@ class ProbeRs(Driver):
             capture_output=True,  # Captures stdout and stderr
             text=True,  # Returns stdout/stderr as strings (not bytes)
             env=self.env_from_cfg(),
-
         )
 
         if result.returncode != 0:

--- a/packages/jumpstarter-driver-probe-rs/jumpstarter_driver_probe_rs/driver_test.py
+++ b/packages/jumpstarter-driver-probe-rs/jumpstarter_driver_probe_rs/driver_test.py
@@ -21,7 +21,8 @@ def test_drivers_probe_rs():
         assert client.reset() == "ok"
         assert client.erase() == "ok"
         assert client.download_file("/dev/null") == "ok"
-        assert client.read(32, 0xf000, 4) == [0xDEADBEEF, 0xCAFEBABE, 0xCAFE0000, 0xDEAD0000]
+        assert client.read(32, 0xF000, 4) == [0xDEADBEEF, 0xCAFEBABE, 0xCAFE0000, 0xDEAD0000]
+
 
 def test_drivers_probe_rs_errors():
     instance = ProbeRs()
@@ -30,4 +31,3 @@ def test_drivers_probe_rs_errors():
     with serve(instance) as client:
         assert client.info() == ""  # Error case
         assert client.reset() == ""  # Error case
-

--- a/packages/jumpstarter/jumpstarter/config/exporter.py
+++ b/packages/jumpstarter/jumpstarter/config/exporter.py
@@ -7,40 +7,54 @@ from typing import Any, ClassVar, Literal, Optional, Self
 import grpc
 import yaml
 from anyio.from_thread import start_blocking_portal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 from .common import ObjectMeta
 from .grpc import call_credentials
 from .tls import TLSConfigV1Alpha1
-from jumpstarter.common.exceptions import ConfigurationError
 from jumpstarter.common.grpc import aio_secure_channel, ssl_channel_credentials
 from jumpstarter.common.importlib import import_class
 from jumpstarter.driver import Driver
 
 
-class ExporterConfigV1Alpha1DriverInstance(BaseModel):
-    type: str = Field(default="jumpstarter_driver_composite.driver.Composite")
+class ExporterConfigV1Alpha1DriverInstanceProxy(BaseModel):
+    ref: str
+
+
+class ExporterConfigV1Alpha1DriverInstanceComposite(BaseModel):
     children: dict[str, ExporterConfigV1Alpha1DriverInstance] = Field(default_factory=dict)
+
+
+class ExporterConfigV1Alpha1DriverInstanceBase(BaseModel):
+    type: str
     config: dict[str, Any] = Field(default_factory=dict)
-    ref: str | None = Field(default=None)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        if self.ref:
-            if self.type != "jumpstarter_driver_composite.driver.Composite":
-                raise ConfigurationError("when using ref, type must not be specified")
-            if len(self.config.keys()) != 0:
-                raise ConfigurationError("when using ref, config must not be specified")
 
-            self.type = "jumpstarter_driver_composite.driver.Proxy"
-            self.config = { "path": self.ref }
+class ExporterConfigV1Alpha1DriverInstance(RootModel):
+    root: (
+        ExporterConfigV1Alpha1DriverInstanceBase
+        | ExporterConfigV1Alpha1DriverInstanceComposite
+        | ExporterConfigV1Alpha1DriverInstanceProxy
+    )
 
     def instantiate(self) -> Driver:
-        children = {name: child.instantiate() for name, child in self.children.items()}
+        match self.root:
+            case ExporterConfigV1Alpha1DriverInstanceBase():
+                driver_class = import_class(self.root.type, [], True)
 
-        driver_class = import_class(self.type, [], True)
+                return driver_class(**self.root.config)
 
-        return driver_class(children=children, **self.config)
+            case ExporterConfigV1Alpha1DriverInstanceComposite():
+                from jumpstarter_driver_composite.driver import Composite
+
+                children = {name: child.instantiate() for name, child in self.root.children.items()}
+
+                return Composite(children=children)
+
+            case ExporterConfigV1Alpha1DriverInstanceProxy():
+                from jumpstarter_driver_composite.driver import Proxy
+
+                return Proxy(ref=self.root.ref)
 
     @classmethod
     def from_path(cls, path: str) -> ExporterConfigV1Alpha1DriverInstance:

--- a/packages/jumpstarter/jumpstarter/config/exporter_test.py
+++ b/packages/jumpstarter/jumpstarter/config/exporter_test.py
@@ -120,7 +120,6 @@ export:
         export={
             "power": ExporterConfigV1Alpha1DriverInstance(
                 type="jumpstarter_driver_power.driver.PduPower",
-                children={},  # missing children defaults to empty
                 config={
                     "host": "192.168.1.111",
                     "port": 1234,
@@ -132,14 +131,12 @@ export:
             ),
             "serial": ExporterConfigV1Alpha1DriverInstance(
                 type="jumpstarter_driver_pyserial.driver.Pyserial",
-                children={},
                 config={
                     "port": "/dev/ttyUSB0",
                     "baudrate": 115200,
                 },
             ),
             "nested": ExporterConfigV1Alpha1DriverInstance(
-                type="jumpstarter_driver_composite.driver.Composite",
                 children={
                     "custom": ExporterConfigV1Alpha1DriverInstance(
                         type="vendorpackage.CustomDriver",
@@ -149,7 +146,6 @@ export:
                         },
                     )
                 },
-                config={},  # missing config defaults to empty
             ),
         },
         config={},


### PR DESCRIPTION
This avoids over-verbose configuration, while maintaining the simplicity of a Proxy driver still provides a better administrator/user experience.

The Exporter config example now includes this and provides a more elaborate example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized driver documentation for improved navigation, including updated ordering and clearer explanations for the Proxy driver.
- **New Features**
  - Introduced a streamlined configuration approach using dot-delimited driver paths.
  - Expanded Exporter settings with additional driver options, including `power`, `serial`, `storage`, and `custom` sections.
  - Added a new optional `ref` attribute in Exporter configuration to simplify driver referencing.
  - Added a new entry point for the Proxy driver in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->