### PR TITLE
Enable keepalive in gRPC connections.

### DIFF
--- a/packages/jumpstarter/jumpstarter/common/grpc.py
+++ b/packages/jumpstarter/jumpstarter/common/grpc.py
@@ -35,8 +35,12 @@ def ssl_channel_credentials(target: str, tls_config):
 
 
 def aio_secure_channel(target: str, credentials: grpc.ChannelCredentials):
-    return grpc.aio.secure_channel(target, credentials, options=(("grpc.lb_policy_name", "round_robin"),))
-
+    return grpc.aio.secure_channel(target, credentials, options=(
+        ("grpc.lb_policy_name", "round_robin"),
+        ("grpc.keepalive_time_ms", 350000),
+        ("grpc.keepalive_timeout_ms", 5000),
+        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.keepalive_permit_without_calls", 1)))
 
 def configure_grpc_env():
     # disable informative logs by default, i.e.:


### PR DESCRIPTION
The ("grpc.keepalive_time_ms", 350000) setting is intentionally high, because the minimum accepted by server is 300s, under that time, it will start dropping the connections.

To go under 300s we need to configure the server accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced secure connection settings to improve overall connection reliability and performance through updated keepalive and ping configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->