### PR TITLE
Implement the StorageMuxFlasher interface, and Flasher cli

### DIFF
--- a/packages/jumpstarter-driver-dutlink/jumpstarter_driver_dutlink/driver.py
+++ b/packages/jumpstarter-driver-dutlink/jumpstarter_driver_dutlink/driver.py
@@ -11,7 +11,7 @@ import usb.util
 from anyio import fail_after, sleep
 from anyio.streams.file import FileReadStream, FileWriteStream
 from jumpstarter_driver_composite.driver import CompositeInterface
-from jumpstarter_driver_opendal.driver import StorageMuxInterface
+from jumpstarter_driver_opendal.driver import StorageMuxFlasherInterface
 from jumpstarter_driver_power.driver import PowerInterface, PowerReading
 from jumpstarter_driver_pyserial.driver import PySerial
 from serial.serialutil import SerialException
@@ -156,7 +156,7 @@ class DutlinkPower(DutlinkConfig, PowerInterface, Driver):
 
 
 @dataclass(kw_only=True)
-class DutlinkStorageMux(DutlinkConfig, StorageMuxInterface, Driver):
+class DutlinkStorageMux(DutlinkConfig, StorageMuxFlasherInterface, Driver):
     storage_device: str
 
     def control(self, action):

--- a/packages/jumpstarter-driver-dutlink/jumpstarter_driver_dutlink/driver_test.py
+++ b/packages/jumpstarter-driver-dutlink/jumpstarter_driver_dutlink/driver_test.py
@@ -17,7 +17,7 @@ def power_test(power):
 
 
 def storage_test(storage):
-    storage.write_local_file("/dev/null")
+    storage.flash("/dev/null")
 
 
 def serial_test(serial):

--- a/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/driver.py
+++ b/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/driver.py
@@ -241,6 +241,12 @@ class StorageMuxInterface(metaclass=ABCMeta):
     async def read(self, dst: str): ...
 
 
+class StorageMuxFlasherInterface(StorageMuxInterface):
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_opendal.client.StorageMuxFlasherClient"
+
+
 @dataclass
 class MockStorageMux(StorageMuxInterface, Driver):
     file: _TemporaryFileWrapper = field(default_factory=NamedTemporaryFile)
@@ -270,3 +276,7 @@ class MockStorageMux(StorageMuxInterface, Driver):
             async with self.resource(dst) as res:
                 async for chunk in stream:
                     await res.send(chunk)
+
+@dataclass
+class MockStorageMuxFlasher(StorageMuxFlasherInterface, MockStorageMux):
+    pass

--- a/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver.py
+++ b/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver.py
@@ -8,13 +8,13 @@ import usb.core
 import usb.util
 from anyio import fail_after, sleep
 from anyio.streams.file import FileReadStream, FileWriteStream
-from jumpstarter_driver_opendal.driver import StorageMuxInterface
+from jumpstarter_driver_opendal.driver import StorageMuxFlasherInterface
 
 from jumpstarter.driver import Driver, export
 
 
 @dataclass(kw_only=True)
-class SDWire(StorageMuxInterface, Driver):
+class SDWire(StorageMuxFlasherInterface, Driver):
     serial: str | None = field(default=None)
     dev: usb.core.Device = field(init=False)
     itf: usb.core.Interface = field(init=False)


### PR DESCRIPTION
This enables simplified usage of mux storage, where the driver can be instantiated for use with a Flasher interface (which only provides flash and dump), or a more granular StorageMuxInterface with dut/host/write/read/off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced flash operations by unifying storage and flash functionalities.
  - Introduced a command-line interface for flashing and dumping device images with clear error feedback for unsupported options.
  - Added a new class for improved storage handling within the driver framework.
  - Expanded support for additional hardware drivers to streamline flash procedures.

- **Tests**
  - Added new tests to validate flash and dump operations, ensuring reliable behavior and accurate file handling.
  - Integrated tests for the new `MockStorageMuxFlasher` class to verify functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->