### PR TITLE
Cache fedora cloud images in actions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -46,6 +46,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-arm qemu-system-x86
 
+      - name: Cache Fedora Cloud images
+        id: cache-fedora-cloud-images
+        uses: actions/cache@v4
+        with:
+          path: packages/jumpstarter-driver-qemu/images
+          key: fedora-cloud-41-1.4
+
+      - name: Download Fedora Cloud images
+        if: steps.cache-fedora-cloud-images.outputs.cache-hit != 'true'
+        run: |
+          for arch in aarch64 x86_64; do
+            curl -L --output "packages/jumpstarter-driver-qemu/images/Fedora-Cloud-Base-Generic-41-1.4.${arch}.qcow2" \
+              "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/${arch}/images/Fedora-Cloud-Base-Generic-41-1.4.${arch}.qcow2"
+          done
+
       - name: Run pytest
         run: make test
 

--- a/packages/jumpstarter-driver-qemu/images/.gitignore
+++ b/packages/jumpstarter-driver-qemu/images/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver_test.py
+++ b/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver_test.py
@@ -1,5 +1,6 @@
 import sys
 import tarfile
+from pathlib import Path
 
 import pytest
 import requests
@@ -35,10 +36,15 @@ def test_driver_qemu(tmp_path, ovmf, arch, ovmf_arch):
         username = qemu.username
         password = qemu.password
 
-        qemu.flasher.flash(
-            f"pub/fedora/linux/releases/41/Cloud/{arch}/images/Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2",
-            operator=Operator("http", endpoint="https://download.fedoraproject.org"),
-        )
+        cached_image = Path(f"images/Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2")
+
+        if cached_image.exists():
+            qemu.flasher.flash(cached_image.resolve())
+        else:
+            qemu.flasher.flash(
+                f"pub/fedora/linux/releases/41/Cloud/{arch}/images/Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2",
+                operator=Operator("http", endpoint="https://download.fedoraproject.org"),
+            )
 
         qemu.flasher.flash(
             ovmf / ovmf_arch / "code.fd",

--- a/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver_test.py
+++ b/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver_test.py
@@ -36,7 +36,7 @@ def test_driver_qemu(tmp_path, ovmf, arch, ovmf_arch):
         username = qemu.username
         password = qemu.password
 
-        cached_image = Path(f"images/Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2")
+        cached_image = Path(__file__).parent.parent / "images" / f"Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2"
 
         if cached_image.exists():
             qemu.flasher.flash(cached_image.resolve())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved image handling with a caching mechanism for Fedora Cloud images to streamline operations.
  - Enhanced efficiency by using locally available images when possible, reducing unnecessary downloads.
- **Chores**
  - Added a `.gitignore` file to exclude unnecessary files from version control in the images directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->