### PR TITLE
Add drivers for EnerGenie Power Management System (PMS) products

### DIFF
--- a/docs/source/reference/package-apis/drivers/energenie.md
+++ b/docs/source/reference/package-apis/drivers/energenie.md
@@ -1,0 +1,1 @@
+../../../../../packages/jumpstarter-driver-energenie/README.md

--- a/docs/source/reference/package-apis/drivers/index.md
+++ b/docs/source/reference/package-apis/drivers/index.md
@@ -21,6 +21,7 @@ Drivers that control the power state and basic operation of devices:
   control
 * **[DUT Link](dutlink.md)** (`jumpstarter-driver-dutlink`) - [DUT Link
   Board](https://github.com/jumpstarter-dev/dutlink-board) hardware control
+* **[Energenie PDU](energenie.md)** (`jumpstarter-driver-energenie`) - Energenie PDUs
 
 ### Communication Drivers
 
@@ -79,6 +80,7 @@ General-purpose utility drivers:
 can.md
 corellium.md
 dutlink.md
+energenie.md
 flashers.md
 http.md
 network.md

--- a/packages/jumpstarter-driver-energenie/.gitignore
+++ b/packages/jumpstarter-driver-energenie/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/packages/jumpstarter-driver-energenie/README.md
+++ b/packages/jumpstarter-driver-energenie/README.md
@@ -1,0 +1,78 @@
+# EnerGenie
+
+Drivers for EnerGenie products.
+
+## EnerGenie driver
+
+This driver provides a client for the [EnerGenie Programmable power switch](https://energenie.com/products.aspx?sg=239). The driver was tested on EG-PMS2-LAN device only but should be easy to support other devices.
+
+**driver**: `jumpstarter_driver_energenie.driver.EnerGenie`
+
+## Installation
+
+```shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-energenie
+```
+
+### Configuration
+
+```yaml
+export:
+  power:
+    type: jumpstarter_driver_energenie.driver.EnerGenie
+    config:
+      host: "192.168.0.1"
+      password: "password"
+      slot: "1"
+```
+
+### Config parameters
+
+| Parameter | Description | Type | Required | Default |
+|-----------|-------------|------|----------|---------|
+| host | The ip address of the EnerGenie system | string | yes | None |
+| password | The password of the EnerGenie system | string | no | None |
+| slot | The slot number to be managed, 1, 2, 3, 4 | int | yes | 1 |
+
+### PowerClient API
+
+The EnerGenie driver provides a `PowerClient` with the following API:
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_power.client.PowerClient()
+    :no-index:
+    :members: on, off
+```
+
+### Examples
+
+Powering on and off a device
+
+```{testcode}
+:skipif: True
+client.power.on()
+time.sleep(1)
+client.power.off()
+```
+
+### CLI
+
+```bash
+$ sudo uv run jmp exporter shell -c ./packages/jumpstarter-driver-energenie/examples/exporter.yaml
+
+$$ j
+Usage: j [OPTIONS] COMMAND [ARGS]...
+
+  Generic composite device
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  power   Generic power
+
+$$ j power on
+
+
+$$ exit
+```

--- a/packages/jumpstarter-driver-energenie/examples/exporter.yaml
+++ b/packages/jumpstarter-driver-energenie/examples/exporter.yaml
@@ -1,0 +1,14 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
+endpoint: grpc.jumpstarter.192.168.0.203.nip.io:8082
+token: "<token>"
+export:
+  power:
+    type: jumpstarter_driver_energenie.driver.EnerGenie
+    config:
+      host: "192.168.1.51"
+      password: "1"
+      slot: 1

--- a/packages/jumpstarter-driver-energenie/jumpstarter_driver_energenie/driver.py
+++ b/packages/jumpstarter-driver-energenie/jumpstarter_driver_energenie/driver.py
@@ -1,0 +1,92 @@
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+
+import requests
+from jumpstarter_driver_power.driver import PowerInterface, PowerReading
+
+from jumpstarter.driver import Driver, export
+
+
+@dataclass(kw_only=True)
+class EnerGenie(PowerInterface, Driver):
+    """
+    driver for the EnerGenie Programmable surge protector with LAN interface.
+
+    This driver was tested on EG-PMS2-LAN device only but should be easy to support other devices.
+    """
+
+    host: str | None = field(default=None)
+    password: str | None = field(default="1")
+    slot: int = 1
+
+    def login(self):
+        """
+        Log in to the programmable power switch.
+
+        :return: True if login is successful, False otherwise.
+        """
+        login_url = f"{self.base_url}/login.html"
+        try:
+            response = requests.post(login_url, data={"pw": self.password}, timeout=10)
+            return response.status_code == 200
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout,
+                requests.exceptions.RequestException) as e:
+            self.logger.error(f"Login failed: {str(e)}")
+            return False
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+        # Programmable power switch initialitzation. The EG-PMS2-LAN device has up to 4 slots.
+        if self.slot < 1 or self.slot > 4:
+            raise ValueError("Slot must be between 1 and 4")
+        if self.host is None:
+            raise ValueError("Host must be specified")
+        self.logger.debug(f"Using Host: {self.host}, Slot: {self.slot}")
+        self.base_url = f"http://{self.host}"
+
+
+    def set_switch(self, switch_number, state):
+        """
+        Set the state of a specific switch.
+
+        :param switch_number: The switch number (1, 2, etc.).
+        :param state: The state to set (1 for ON, 0 for OFF).
+        :return: True if the operation is successful, False otherwise.
+        """
+        if state not in [0, 1]:
+            self.logger.error(f"Invalid state: {state}")
+            return False
+
+        if self.login():
+            self.logger.debug("Login successful!")
+        else:
+            self.logger.debug("Login failed!")
+            return False
+        data = {f"cte{switch_number}": state}
+        try:
+            response = requests.post(self.base_url, data=data, timeout=10)
+            if response.status_code != 200:
+                self.logger.error(f"Set switch {switch_number} to {state} state failed!")
+                return False
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout,
+                requests.exceptions.RequestException) as e:
+            self.logger.error(f"Set switch failed: {str(e)}")
+            return False
+
+        self.logger.debug(f"Set switch {switch_number} to {state} state")
+
+        return True
+
+    @export
+    def on(self) -> None:
+        self.set_switch(self.slot, 1)
+
+    @export
+    def off(self) -> None:
+        self.set_switch(self.slot, 0)
+
+    @export
+    def read(self) -> AsyncGenerator[PowerReading, None]:
+        raise NotImplementedError

--- a/packages/jumpstarter-driver-energenie/jumpstarter_driver_energenie/driver_test.py
+++ b/packages/jumpstarter-driver-energenie/jumpstarter_driver_energenie/driver_test.py
@@ -1,0 +1,46 @@
+from pytest_httpserver import HTTPServer
+
+from .driver import EnerGenie
+from jumpstarter.common.utils import serve
+
+
+def test_drivers_energenie(httpserver: HTTPServer):
+    # Configure mock responses
+    # 1. Login response - Match raw data string
+    httpserver.expect_request(
+        "/login.html",
+        method="POST",
+        data="pw=1"
+    ).respond_with_data("Login successful") # Defaults to status 200
+
+    # 2. Response for turning ON switch 1 - Match raw data string
+    httpserver.expect_request(
+        "/",
+        method="POST",
+        data="cte1=1"
+    ).respond_with_data("Switch turned ON") # Defaults to status 200
+
+    # 3. Response for turning OFF switch 1 - Match raw data string
+    httpserver.expect_request(
+        "/",
+        method="POST",
+        data="cte1=0"
+    ).respond_with_data("Switch turned OFF") # Defaults to status 200
+
+    # Get the mock server's host and port
+    host = f"{httpserver.host}:{httpserver.port}"
+
+    # Create EnerGenie instance with the mock server's URL
+    instance = EnerGenie(host=host)
+
+    with serve(instance) as client:
+        client.on()
+        client.off()
+
+    # check_assertions will verify that all expected requests were received
+    # in the correct order and that no unexpected requests arrived.
+    try:
+        httpserver.check_assertions()
+    except AssertionError as e:
+        print(f"httpserver assertions FAILED: {e}")
+        raise # Re-raise the assertion error to fail the test

--- a/packages/jumpstarter-driver-energenie/pyproject.toml
+++ b/packages/jumpstarter-driver-energenie/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "jumpstarter-driver-energenie"
+dynamic = ["version", "urls"]
+description = "Energenie is an advanced surge protector with power management features"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Enric Balletbo i Serra", email = "eballetbo@redhat.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "anyio>=4.6.2.post1",
+    "jumpstarter",
+    "jumpstarter-driver-power"
+]
+
+[project.entry-points."jumpstarter.drivers"]
+EnerGenie = "jumpstarter_driver_energenie.driver:EnerGenie"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+    "pytest-httpserver>=1.0.0",
+]
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../'}
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ jumpstarter-driver-can = { workspace = true }
 jumpstarter-driver-composite = { workspace = true }
 jumpstarter-driver-corellium = { workspace = true }
 jumpstarter-driver-dutlink = { workspace = true }
+jumpstarter-driver-energenie = { workspace = true }
 jumpstarter-driver-flashers = { workspace = true }
 jumpstarter-driver-http = { workspace = true }
 jumpstarter-driver-raspberrypi = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "jumpstarter-driver-composite",
     "jumpstarter-driver-corellium",
     "jumpstarter-driver-dutlink",
+    "jumpstarter-driver-energenie",
     "jumpstarter-driver-flashers",
     "jumpstarter-driver-http",
     "jumpstarter-driver-network",
@@ -1347,6 +1348,36 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-energenie"
+source = { editable = "packages/jumpstarter-driver-energenie" }
+dependencies = [
+    { name = "anyio" },
+    { name = "jumpstarter" },
+    { name = "jumpstarter-driver-power" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-httpserver" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.6.2.post1" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-httpserver", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -2918,6 +2949,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000 },
+]
+
+[[package]]
 name = "python-can"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3813,6 +3856,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
 ]
 
 [[package]]


### PR DESCRIPTION
The driver was tested on EG-PMS2-LAN device only but should be easy to support other devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for EnerGenie power management devices, allowing users to control power switches via the new driver.
- **Documentation**
  - Added comprehensive documentation and usage instructions for the EnerGenie driver, including installation, configuration, and example usage.
  - Updated system control driver documentation to include the EnerGenie driver.
- **Tests**
  - Added automated tests to verify EnerGenie driver functionality.
- **Chores**
  - Added configuration and metadata files for project setup and version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->