### PR TITLE
Allow grpc option tweaking, i.e. keepalive settings

### DIFF
--- a/docs/source/cli/clients.md
+++ b/docs/source/cli/clients.md
@@ -32,6 +32,9 @@ metadata:
   name: john
 endpoint: grpc.jumpstarter.192.168.1.10.nip.io:8082
 token: <<token>>
+grpcConfig:
+  # please refer to the https://grpc.github.io/grpc/core/group__grpc__arg__keys.html documentation
+  grpc.keepalive_time_ms: 20000
 tls:
   ca: ''
   insecure: False

--- a/docs/source/introduction/exporters.md
+++ b/docs/source/introduction/exporters.md
@@ -30,6 +30,9 @@ metadata:
   name: demo
 endpoint: grpc.jumpstarter.example.com:443
 token: xxxxx
+grpcConfig:
+    # Please refer to the https://grpc.github.io/grpc/core/group__grpc__arg__keys.html documentation
+    grpc.keepalive_time_ms: 20000
 export:
   power:
     type: jumpstarter_driver_yepkit.driver.Ykush

--- a/packages/jumpstarter/jumpstarter/common/grpc.py
+++ b/packages/jumpstarter/jumpstarter/common/grpc.py
@@ -3,6 +3,7 @@ import os
 import socket
 import ssl
 from contextlib import contextmanager
+from typing import Any, Sequence, Tuple
 from urllib.parse import urlparse
 
 import grpc
@@ -34,18 +35,26 @@ def ssl_channel_credentials(target: str, tls_config):
         return grpc.ssl_channel_credentials()
 
 
-def aio_secure_channel(target: str, credentials: grpc.ChannelCredentials):
+def aio_secure_channel(target: str, credentials: grpc.ChannelCredentials, grpc_options: dict[str, Any] | None):
     return grpc.aio.secure_channel(
         target,
         credentials,
-        options=(
-            ("grpc.lb_policy_name", "round_robin"),
-            ("grpc.keepalive_time_ms", 350000),
-            ("grpc.keepalive_timeout_ms", 5000),
-            ("grpc.http2.max_pings_without_data", 5),
-            ("grpc.keepalive_permit_without_calls", 1),
-        ),
+        options=_override_default_grpc_options(grpc_options),
     )
+
+
+def _override_default_grpc_options(grpc_options: dict[str, str | int] | None) -> Sequence[Tuple[str, Any]]:
+    defaults = (
+        ("grpc.lb_policy_name", "round_robin"),
+        # we keep a low keepalive time to avoid idle timeouts on cloud load balancers
+        ("grpc.keepalive_time_ms", 20000),
+        ("grpc.keepalive_timeout_ms", 5000),
+        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.keepalive_permit_without_calls", 1),
+    )
+    options = dict(defaults)
+    options.update(grpc_options or {})
+    return tuple(options.items())
 
 
 def configure_grpc_env():

--- a/packages/jumpstarter/jumpstarter/common/streams.py
+++ b/packages/jumpstarter/jumpstarter/common/streams.py
@@ -32,13 +32,13 @@ class StreamRequestMetadata(BaseModel):
 
 
 @asynccontextmanager
-async def connect_router_stream(endpoint, token, stream, tls_config):
+async def connect_router_stream(endpoint, token, stream, tls_config, grpc_options):
     credentials = grpc.composite_channel_credentials(
         ssl_channel_credentials(endpoint, tls_config),
         grpc.access_token_call_credentials(token),
     )
 
-    async with aio_secure_channel(endpoint, credentials) as channel:
+    async with aio_secure_channel(endpoint, credentials, grpc_options) as channel:
         router = router_pb2_grpc.RouterServiceStub(channel)
         context = router.Stream(metadata=())
         async with RouterStream(context=context) as s:

--- a/packages/jumpstarter/jumpstarter/config/client.py
+++ b/packages/jumpstarter/jumpstarter/config/client.py
@@ -48,6 +48,7 @@ class ClientConfigV1Alpha1(BaseModel):
     endpoint: str
     tls: TLSConfigV1Alpha1 = Field(default_factory=TLSConfigV1Alpha1)
     token: str
+    grpcOptions: dict[str, str | int] | None = Field(default_factory=dict)
 
     drivers: ClientConfigV1Alpha1Drivers
 
@@ -57,7 +58,7 @@ class ClientConfigV1Alpha1(BaseModel):
             call_credentials("Client", self.metadata, self.token),
         )
 
-        return aio_secure_channel(self.endpoint, credentials)
+        return aio_secure_channel(self.endpoint, credentials, self.grpcOptions)
 
     @contextmanager
     def lease(self, metadata_filter: MetadataFilter, lease_name: str | None = None):
@@ -122,6 +123,7 @@ class ClientConfigV1Alpha1(BaseModel):
             allow=self.drivers.allow,
             unsafe=self.drivers.unsafe,
             tls_config=self.tls,
+            grpc_options=self.grpcOptions,
         )
         with translate_grpc_exceptions():
             return await lease.request_async()
@@ -161,6 +163,7 @@ class ClientConfigV1Alpha1(BaseModel):
             unsafe=self.drivers.unsafe,
             release=release_lease,
             tls_config=self.tls,
+            grpc_options=self.grpcOptions,
         ) as lease:
             yield lease
 

--- a/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -206,6 +206,7 @@ tls:
   ca: ''
   insecure: false
 token: dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz
+grpcOptions: {}
 drivers:
   allow:
   - jumpstarter.drivers.*
@@ -241,6 +242,7 @@ tls:
   ca: ''
   insecure: false
 token: dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz
+grpcOptions: {}
 drivers:
   allow:
   - jumpstarter.drivers.*
@@ -274,6 +276,7 @@ tls:
   ca: ''
   insecure: false
 token: dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz
+grpcOptions: {}
 drivers:
   allow: []
   unsafe: true

--- a/packages/jumpstarter/jumpstarter/config/exporter.py
+++ b/packages/jumpstarter/jumpstarter/config/exporter.py
@@ -81,6 +81,7 @@ class ExporterConfigV1Alpha1(BaseModel):
     endpoint: str
     tls: TLSConfigV1Alpha1 = Field(default_factory=TLSConfigV1Alpha1)
     token: str
+    grpcOptions: dict[str, str | int] | None = Field(default_factory=dict)
 
     export: dict[str, ExporterConfigV1Alpha1DriverInstance] = Field(default_factory=dict)
 
@@ -163,12 +164,13 @@ class ExporterConfigV1Alpha1(BaseModel):
                 ssl_channel_credentials(self.endpoint, self.tls),
                 call_credentials("Exporter", self.metadata, self.token),
             )
-            return aio_secure_channel(self.endpoint, credentials)
+            return aio_secure_channel(self.endpoint, credentials, self.grpcOptions)
 
         async with Exporter(
             channel_factory=channel_factory,
             device_factory=ExporterConfigV1Alpha1DriverInstance(children=self.export).instantiate,
             tls=self.tls,
+            grpc_options=self.grpcOptions,
         ) as exporter:
             await exporter.serve()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable options for gRPC connections, including optimized keepalive settings to enhance connection stability.
  - Introduced `grpcConfig` and `grpcOptions` parameters for both clients and exporters to expand configuration capabilities.
- **Documentation**
  - Updated configuration guides to include the new `grpcConfig` and `grpcOptions` parameters for both clients and exporters.
- **Tests**
  - Modified test setups to validate the enhanced gRPC configuration options, including the new `grpcOptions` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->