### PR TITLE
Workaround the MacOS system certificate store issue with some SSL certs

### DIFF
--- a/docs/source/config/cli.md
+++ b/docs/source/config/cli.md
@@ -134,7 +134,8 @@ be useful in CI or when writing a script that uses Jumpstarter.
 (overrides the config value).
 - `JMP_DRIVERS_ALLOW` - A comma-separated list of allowed driver namespaces
 to automatically load. Can be set to `UNSAFE` to allow unsafe loading of drivers.
-
+- `JUMPSTARTER_FORCE_SYSTEM_CERTS` - Set to `1` to force the system CA certificates,
+  which is the behavior by default for all systems but MacOS (see [bug](https://github.com/jumpstarter-dev/jumpstarter/issues/362))
 ## System Configuration
 
 Jumpstarter stores system configs in the `/etc/jumpstarter` directory.

--- a/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
+++ b/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
@@ -1,4 +1,5 @@
 import json
+import os
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -12,7 +13,13 @@ from authlib.integrations.requests_client import OAuth2Session
 from joserfc.jws import extract_compact
 from yarl import URL
 
-truststore.inject_into_ssl()
+# if we are running in MacOS avoid injecting system certificates to avoid
+# https://github.com/jumpstarter-dev/jumpstarter/issues/362
+# also allow to force the system certificates injection with
+# JUMPSTARTER_FORCE_SYSTEM_CERTS=1
+if os.uname().sysname != "Darwin" or os.environ.get("JUMPSTARTER_FORCE_SYSTEM_CERTS") == "1":
+    truststore.inject_into_ssl()
+
 
 opt_client_id = click.option("--client-id", "client_id", type=str, default="jumpstarter-cli", help="OIDC client id")
 opt_connector_id = click.option(


### PR DESCRIPTION
Adds the JUMPSTARTER_FORCE_SYSTEM_CERTS env variable to still allow importing the
system certificate store in MacOS

Fixes-Issue: #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment variable, `JUMPSTARTER_FORCE_SYSTEM_CERTS`, that allows users to enforce the use of system CA certificates even on systems (like macOS) where this is not the default behavior.
- **Documentation**
  - Updated configuration instructions to include details about the new environment variable, providing users clearer guidance on managing SSL certificate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->