### PR TITLE
Don't stop grpc keepalives after 5 pings

### DIFF
--- a/packages/jumpstarter/jumpstarter/common/grpc.py
+++ b/packages/jumpstarter/jumpstarter/common/grpc.py
@@ -49,7 +49,7 @@ def _override_default_grpc_options(grpc_options: dict[str, str | int] | None) ->
         # we keep a low keepalive time to avoid idle timeouts on cloud load balancers
         ("grpc.keepalive_time_ms", 20000),
         ("grpc.keepalive_timeout_ms", 5000),
-        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.http2.max_pings_without_data", 0),
         ("grpc.keepalive_permit_without_calls", 1),
     )
     options = dict(defaults)


### PR DESCRIPTION
Otherwise the keepalive stops being effective and cloud
load balancers will close the connection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the gRPC connection settings by removing the limit on idle pings, which helps improve connection reliability and overall network communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->