### PR TITLE
Make sure that no bash scripts override PS1, i.e. devspaces

### DIFF
--- a/packages/jumpstarter/jumpstarter/common/utils.py
+++ b/packages/jumpstarter/jumpstarter/common/utils.py
@@ -89,8 +89,13 @@ def launch_shell(host: str, context: str, allow: list[str], unsafe: bool) -> int
         allow: List of allowed drivers
         unsafe: Whether to allow drivers outside of the allow list
     """
+    cmd = [os.environ.get("SHELL", "bash")]
+    if cmd[0].endswith("bash"):
+        cmd.append("--norc")
+        cmd.append("--noprofile")
+
     process = Popen(
-        [os.environ.get("SHELL", "bash")],
+        cmd,
         stdin=sys.stdin,
         stdout=sys.stdout,
         stderr=sys.stderr,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced shell launching behavior: Bash sessions now start without loading user configuration files, offering a cleaner and more consistent environment at launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->