### PR TITLE
Recommend installing using the developer method for python.

### DIFF
--- a/docs/source/installation/python-package.md
+++ b/docs/source/installation/python-package.md
@@ -1,6 +1,12 @@
 # Python Packages and CLI
 
 ## Release install
+
+```{warning}
+Until we release 0.6.0 please continue to use the [developer install method](#development-install). 0.5.0 is
+heavily outdated and not fully released to pip, it is not recommended now.
+```
+
 The [Jumpstarter Python packages](https://docs.jumpstarter.dev/packages/)
 contain all the necessary tools to run an exporter or interact with your
 hardware as a client.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a warning in the installation instructions advising users to continue using the developer install method until version 0.6.0, as the current version (0.5.0) is considered outdated and not fully available on pip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->