### PR TITLE
Implement forward-{tcp,port} command on network client

### DIFF
--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/portforward.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/adapters/portforward.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from functools import partial
+from os import PathLike
 
 from jumpstarter.client import DriverClient
 from jumpstarter.client.adapters import blocking
@@ -37,6 +38,7 @@ async def UnixPortforwardAdapter(
     *,
     client: DriverClient,
     method: str = "connect",
+    path: PathLike | None = None,
 ):
-    async with TemporaryUnixListener(partial(handler, client, method)) as addr:
+    async with TemporaryUnixListener(partial(handler, client, method), path=path) as addr:
         yield addr

--- a/packages/jumpstarter-driver-network/jumpstarter_driver_network/client.py
+++ b/packages/jumpstarter-driver-network/jumpstarter_driver_network/client.py
@@ -4,7 +4,7 @@ from threading import Event
 
 import asyncclick as click
 
-from .adapters import DbusAdapter, TcpPortforwardAdapter
+from .adapters import DbusAdapter, TcpPortforwardAdapter, UnixPortforwardAdapter
 from .driver import DbusNetwork
 from jumpstarter.client import DriverClient
 
@@ -20,7 +20,11 @@ class NetworkClient(DriverClient):
         @click.option("--address", default="localhost", show_default=True)
         @click.argument("port", type=int)
         def forward_tcp(address: str, port: int):
-            """Forward local TCP port to remote network connection"""
+            """
+            Forward local TCP port to remote network
+
+            PORT is the TCP port to listen on.
+            """
 
             with TcpPortforwardAdapter(
                 client=self,
@@ -34,6 +38,24 @@ class NetworkClient(DriverClient):
                         click.echo("[{}]:{}".format(host, port))
                     case _:
                         click.echo("{}:{}".format(host, port))
+
+                Event().wait()
+
+        @base.command()
+        @click.argument("path", type=click.Path(), required=False)
+        def forward_unix(path: str | None):
+            """
+            Forward local Unix domain socket to remote network
+
+            PATH is the path of the Unix domain socket to listen on,
+            defaults to a random path under $XDG_RUNTIME_DIR.
+            """
+
+            with UnixPortforwardAdapter(
+                client=self,
+                path=path,
+            ) as addr:
+                click.echo(addr)
 
                 Event().wait()
 

--- a/packages/jumpstarter-driver-network/pyproject.toml
+++ b/packages/jumpstarter-driver-network/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pexpect>=4.9.0",
   "fabric>=3.2.2",
   "wsproto>=1.2.0",
+  "asyncclick>=8.1.8",
 ]
 
 [project.entry-points."jumpstarter.drivers"]

--- a/uv.lock
+++ b/uv.lock
@@ -1359,6 +1359,7 @@ dev = [
 name = "jumpstarter-driver-network"
 source = { editable = "packages/jumpstarter-driver-network" }
 dependencies = [
+    { name = "asyncclick" },
     { name = "fabric" },
     { name = "jumpstarter" },
     { name = "pexpect" },
@@ -1376,6 +1377,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncclick", specifier = ">=8.1.8" },
     { name = "fabric", specifier = ">=3.2.2" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
     { name = "pexpect", specifier = ">=4.9.0" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line interface for network operations, enabling TCP and Unix domain socket forwarding commands.
	- Enhanced Unix socket forwarding with an option to specify a custom path.
- **Chores**
	- Added a new dependency to support asynchronous command-line operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->