### PR TITLE
remove login method

### DIFF
--- a/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/corellium/api_test.py
+++ b/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/corellium/api_test.py
@@ -5,7 +5,7 @@ import pytest
 # import websockets
 from .api import ApiClient
 from .exceptions import CorelliumApiException
-from .types import Device, Instance, Project, Session
+from .types import Device, Instance, Project
 
 
 def fixture(path):
@@ -19,34 +19,6 @@ def fixture(path):
         return f.read()
 
 
-def test_login_ok(requests_mock):
-    requests_mock.post('https://api-host/api/v1/auth/login', text=fixture('http/login-200.json'))
-
-    api = ApiClient('api-host', 'api-token')
-    api.login()
-
-    assert 'session-token' == api.session.token
-    assert '2022-03-20T01:50:10.000Z' == api.session.expiration
-    assert {'Authorization': 'Bearer session-token'} == api.session.as_header()
-
-
-@pytest.mark.parametrize(
-    'status_code,data,msg',
-    [
-        (403, fixture('http/403.json'), 'Invalid or missing authorization token'),
-        (200, fixture('http/json-error.json'), 'Invalid control character at'),
-    ])
-def test_login_error(requests_mock, status_code, data, msg):
-    requests_mock.post('https://api-host/api/v1/auth/login', status_code=status_code, text=data)
-    api = ApiClient('api-host', 'api-token')
-
-    with pytest.raises(CorelliumApiException) as e:
-        api.login()
-
-    assert msg in str(e.value)
-    assert api.session is None
-
-
 @pytest.mark.parametrize('project_name,data,has_results', [
     ('OtherProject', fixture('http/get-projects-200.json'), True),
     (None, fixture('http/get-projects-200.json'), True),
@@ -55,7 +27,6 @@ def test_login_error(requests_mock, status_code, data, msg):
 def test_get_project_ok(requests_mock, project_name, data, has_results):
     requests_mock.get('https://api-host/api/v1/projects', status_code=200, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     args = []
     if project_name:
@@ -78,7 +49,6 @@ def test_get_project_ok(requests_mock, project_name, data, has_results):
 def test_get_project_error(requests_mock, status_code, data, msg):
     requests_mock.get('https://api-host/api/v1/projects', status_code=status_code, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     with pytest.raises(CorelliumApiException) as e:
         api.get_project()
@@ -93,7 +63,6 @@ def test_get_project_error(requests_mock, status_code, data, msg):
 def test_get_device_ok(requests_mock, model, data, has_results):
     requests_mock.get('https://api-host/api/v1/models', status_code=200, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     device = api.get_device(model)
 
@@ -112,7 +81,6 @@ def test_get_device_ok(requests_mock, model, data, has_results):
 def test_get_device_error(requests_mock, status_code, data, msg):
     requests_mock.get('https://api-host/api/v1/models', status_code=status_code, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     with pytest.raises(CorelliumApiException) as e:
         api.get_device('mymodel')
@@ -124,7 +92,6 @@ def test_create_instance_ok(requests_mock):
     data = fixture('http/create-instance-200.json')
     requests_mock.post('https://api-host/api/v1/instances', status_code=200, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     project = Project('d59db33d-27bd-4b22-878d-49e4758a648e', 'Default Project')
     device = Device(name='rd1ae', type='automotive', flavor='kronos',
@@ -144,7 +111,6 @@ def test_create_instance_ok(requests_mock):
 def test_create_instance_error(requests_mock, status_code, data, msg):
     requests_mock.post('https://api-host/api/v1/instances', status_code=status_code, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     with pytest.raises(CorelliumApiException) as e:
         project = Project('d59db33d-27bd-4b22-878d-49e4758a648e', 'Default Project')
@@ -160,7 +126,6 @@ def test_destroy_instance_state_ok(requests_mock):
 
     requests_mock.delete(f'https://api-host/api/v1/instances/{instance.id}', status_code=204, text='')
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
     api.destroy_instance(instance)
 
 
@@ -175,7 +140,6 @@ def test_destroy_instance_error(requests_mock, status_code, data, msg):
 
     requests_mock.delete(f'https://api-host/api/v1/instances/{instance.id}', status_code=status_code, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     with pytest.raises(CorelliumApiException) as e:
         api.destroy_instance(instance)
@@ -195,7 +159,6 @@ def test_get_instance_console_id_ok(requests_mock, console_name, console_id):
     instance = Instance(id='d59db33d-27bd-4b22-878d-49e4758a648e')
     requests_mock.get(f'https://api-host/api/v1/instances/{instance.id}', status_code=200, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     current = api.get_instance_console_id(instance, console_name)
 
@@ -213,7 +176,6 @@ def test_get_instance_console_id_error(requests_mock, status_code, data, msg):
     requests_mock.get(f'https://api-host/api/v1/instances/{instance.id}',
                       status_code=status_code, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     with pytest.raises(CorelliumApiException) as e:
         api.get_instance_console_id(instance, 'Console 1')
@@ -228,7 +190,6 @@ def test_get_instance_console_url_ok(requests_mock):
     requests_mock.get(f'https://api-host/api/v1/instances/{instance.id}/console?type=1-cons',
                       status_code=200, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     current = api.get_instance_console_url(instance, console_id)
     expected = 'wss://api-host/port-cons-1'
@@ -249,7 +210,6 @@ def test_get_instance_console_url_error(requests_mock, status_code, data, msg):
     requests_mock.get(f'https://api-host/api/v1/instances/{instance.id}/console?type=1-cons',
                       status_code=status_code, text=data)
     api = ApiClient('api-host', 'api-token')
-    api.session = Session('session-token', '2022-03-20T01:50:10.000Z')
 
     with pytest.raises(CorelliumApiException) as e:
         api.get_instance_console_url(instance, console_id)

--- a/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/corellium/types.py
+++ b/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/corellium/types.py
@@ -2,24 +2,7 @@
 Corellium API types.
 """
 from dataclasses import dataclass, field
-from typing import Dict, Optional
-
-
-@dataclass
-class Session:
-    """
-    Session data class to hold Corellium's API session data.
-    """
-    token: str
-    expiration: str
-
-    def as_header(self) -> Dict[str, str]:
-        """
-        Return a dict to be used as HTTP header for authenticated requests.
-        """
-        return {
-            'Authorization': f'Bearer {self.token}'
-        }
+from typing import Optional
 
 
 @dataclass

--- a/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/driver.py
+++ b/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/driver.py
@@ -5,7 +5,6 @@ import os
 import time
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from jumpstarter_driver_network.driver import WebsocketNetwork
@@ -81,26 +80,10 @@ class Corellium(Driver):
         return value
 
     @property
-    def api(self):
+    def api(self) -> ApiClient:
         """
-        Return the internal Corellium API client instance from `self._api`.
-
-        It will also be responsible for creating/refreshing the session token used
-        across different API methods that require authentication.
+        Return the Corellium API client object.
         """
-        # session does not exist, just login and return
-        if self._api.session is None:
-            self._api.login()
-
-            return self._api
-
-        # check if session is about to expire
-        # currently depends on the magic number of 60 seconds
-        now = datetime.utcnow()
-        diff = datetime.strptime(self._api.session.expiration, '%Y-%m-%dT%H:%M:%S.%fZ') - now
-        if diff > timedelta(seconds=1):
-            self._api.login()
-
         return self._api
 
 


### PR DESCRIPTION
## Changes

* refactor to remove Corellium's login/session creation and use its API token directly.

## Verification

It should work as before, just an internal API improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified authentication by using bearer token directly, removing explicit login and session management.
- **Tests**
  - Removed tests related to explicit session handling and login.
  - Updated tests to reflect changes in attribute access and authentication logic.
- **Chores**
  - Removed unused session-related code and data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->