### PR TITLE
Init hatch-pin-jumpstarter hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docs-linkcheck:
 	uv run --isolated --all-packages --group docs $(MAKE) -C docs linkcheck
 
 pkg-test-%: packages/%
-	uv run --isolated --directory $< pytest
+	uv run --isolated --directory $< pytest || [ $$? -eq 5 ]
 
 pkg-mypy-%: packages/%
 	uv run --isolated --directory $< mypy .

--- a/__templates__/driver/pyproject.toml.tmpl
+++ b/__templates__/driver/pyproject.toml.tmpl
@@ -29,8 +29,11 @@ testpaths = ["jumpstarter_driver_${DRIVER_NAME}"]
 asyncio_mode = "auto"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
 
 [dependency-groups]
 dev = [

--- a/packages/hatch-pin-jumpstarter/pyproject.toml
+++ b/packages/hatch-pin-jumpstarter/pyproject.toml
@@ -18,5 +18,11 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+    "pytest-cov>=6.1.1",
+]
+
 [project.entry-points.hatch]
 pin_jumpstarter = "hatch_pin_jumpstarter"

--- a/packages/hatch-pin-jumpstarter/pyproject.toml
+++ b/packages/hatch-pin-jumpstarter/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "hatch-pin-jumpstarter"
+version = "0.1.0"
+description = "Hatch plugin that pins jumpstarter packages in the monorepo"
+readme = "README.md"
+authors = [
+    { name = "Nick Cao", email = "nickcao@nichi.co" }
+]
+requires-python = ">=3.12"
+dependencies = [
+    "hatchling>=1.27.0",
+    "packaging>=24.2",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project.entry-points.hatch]
+pin_jumpstarter = "hatch_pin_jumpstarter"

--- a/packages/hatch-pin-jumpstarter/pyproject.toml
+++ b/packages/hatch-pin-jumpstarter/pyproject.toml
@@ -10,6 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "hatchling>=1.27.0",
     "packaging>=24.2",
+    "tomli>=2.2.1",
+    "tomli-w>=1.2.0",
 ]
 
 [build-system]

--- a/packages/hatch-pin-jumpstarter/pyproject.toml
+++ b/packages/hatch-pin-jumpstarter/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Nick Cao", email = "nickcao@nichi.co" }
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "hatchling>=1.27.0",
     "packaging>=24.2",

--- a/packages/hatch-pin-jumpstarter/src/hatch_pin_jumpstarter/__init__.py
+++ b/packages/hatch-pin-jumpstarter/src/hatch_pin_jumpstarter/__init__.py
@@ -1,23 +1,49 @@
-from hatchling.metadata.plugin.interface import MetadataHookInterface
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import tomli
+import tomli_w
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from hatchling.plugin import hookimpl
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 
 
-class PinJumpstarter(MetadataHookInterface):
+class PinJumpstarter(BuildHookInterface):
     PLUGIN_NAME = "pin_jumpstarter"
 
-    def update(self, metadata):
-        version = metadata["version"]
-        dependencies = []
-        for dep in metadata["dependencies"]:
-            req = Requirement(dep)
-            if req.name.startswith("jumpstarter"):
-                req.specifier &= SpecifierSet(f"=={version}")
-            dependencies.append(str(req))
-        metadata["dependencies"] = dependencies
+    def initialize(self, version, build_data):
+        if self.target_name != "sdist":
+            return
+
+        pyproject = Path(self.root) / "pyproject.toml"
+
+        with pyproject.open("rb") as f:
+            metadata = tomli.load(f)
+
+        if "project" in metadata and "dependencies" in metadata["project"]:
+            for i, dep in enumerate(metadata["project"]["dependencies"]):
+                req = Requirement(dep)
+                if req.name.startswith("jumpstarter"):
+                    req.specifier &= SpecifierSet(f"=={self.metadata.version}")
+                    metadata["project"]["dependencies"][i] = str(req)
+
+        f = NamedTemporaryFile(delete=False)
+        tomli_w.dump(metadata, f)
+        f.close()
+
+        build_data["__hatch_pin_jumpstarter_tempfile"] = f
+        build_data["force_include"][f.name] = "pyproject.toml"
+
+    def finalize(self, version, build_data, artifact_path):
+        if self.target_name != "sdist":
+            return
+
+        f = build_data["__hatch_pin_jumpstarter_tempfile"]
+        os.unlink(f.name)
 
 
 @hookimpl
-def hatch_register_metadata_hook():
+def hatch_register_build_hook():
     return PinJumpstarter

--- a/packages/hatch-pin-jumpstarter/src/hatch_pin_jumpstarter/__init__.py
+++ b/packages/hatch-pin-jumpstarter/src/hatch_pin_jumpstarter/__init__.py
@@ -1,0 +1,23 @@
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+from hatchling.plugin import hookimpl
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+
+
+class PinJumpstarter(MetadataHookInterface):
+    PLUGIN_NAME = "pin_jumpstarter"
+
+    def update(self, metadata):
+        version = metadata["version"]
+        dependencies = []
+        for dep in metadata["dependencies"]:
+            req = Requirement(dep)
+            if req.name.startswith("jumpstarter"):
+                req.specifier &= SpecifierSet(f"=={version}")
+            dependencies.append(str(req))
+        metadata["dependencies"] = dependencies
+
+
+@hookimpl
+def hatch_register_metadata_hook():
+    return PinJumpstarter

--- a/packages/jumpstarter-all/pyproject.toml
+++ b/packages/jumpstarter-all/pyproject.toml
@@ -50,5 +50,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-all/pyproject.toml
+++ b/packages/jumpstarter-all/pyproject.toml
@@ -53,5 +53,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli-admin/pyproject.toml
+++ b/packages/jumpstarter-cli-admin/pyproject.toml
@@ -31,5 +31,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli-admin/pyproject.toml
+++ b/packages/jumpstarter-cli-admin/pyproject.toml
@@ -34,5 +34,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli-common/pyproject.toml
+++ b/packages/jumpstarter-cli-common/pyproject.toml
@@ -36,5 +36,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli-common/pyproject.toml
+++ b/packages/jumpstarter-cli-common/pyproject.toml
@@ -39,5 +39,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli-driver/pyproject.toml
+++ b/packages/jumpstarter-cli-driver/pyproject.toml
@@ -35,5 +35,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli-driver/pyproject.toml
+++ b/packages/jumpstarter-cli-driver/pyproject.toml
@@ -38,5 +38,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli/pyproject.toml
+++ b/packages/jumpstarter-cli/pyproject.toml
@@ -40,5 +40,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-cli/pyproject.toml
+++ b/packages/jumpstarter-cli/pyproject.toml
@@ -43,5 +43,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-can/pyproject.toml
+++ b/packages/jumpstarter-driver-can/pyproject.toml
@@ -29,5 +29,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-can/pyproject.toml
+++ b/packages/jumpstarter-driver-can/pyproject.toml
@@ -32,5 +32,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-composite/pyproject.toml
+++ b/packages/jumpstarter-driver-composite/pyproject.toml
@@ -27,5 +27,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-composite/pyproject.toml
+++ b/packages/jumpstarter-driver-composite/pyproject.toml
@@ -30,5 +30,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-corellium/pyproject.toml
+++ b/packages/jumpstarter-driver-corellium/pyproject.toml
@@ -30,5 +30,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-corellium/pyproject.toml
+++ b/packages/jumpstarter-driver-corellium/pyproject.toml
@@ -33,5 +33,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-dutlink/pyproject.toml
+++ b/packages/jumpstarter-driver-dutlink/pyproject.toml
@@ -40,5 +40,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-dutlink/pyproject.toml
+++ b/packages/jumpstarter-driver-dutlink/pyproject.toml
@@ -43,5 +43,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-flashers/pyproject.toml
+++ b/packages/jumpstarter-driver-flashers/pyproject.toml
@@ -46,5 +46,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = ["pytest-cov>=6.0.0", "pytest>=8.3.3"]
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-flashers/pyproject.toml
+++ b/packages/jumpstarter-driver-flashers/pyproject.toml
@@ -40,8 +40,11 @@ jumpstarter-driver-uboot = { workspace = true }
 #asyncio_mode = "auto"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = ["pytest-cov>=6.0.0", "pytest>=8.3.3"]
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-http/pyproject.toml
+++ b/packages/jumpstarter-driver-http/pyproject.toml
@@ -39,5 +39,5 @@ dev = [
     "pytest-asyncio>=0.24.0",
 ]
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-http/pyproject.toml
+++ b/packages/jumpstarter-driver-http/pyproject.toml
@@ -28,7 +28,7 @@ asyncio_default_fixture_loop_scope = "function"
 testpaths = ["src"]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
@@ -38,3 +38,6 @@ dev = [
     "pytest-asyncio>=0.0.0",
     "pytest-asyncio>=0.24.0",
 ]
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-network/pyproject.toml
+++ b/packages/jumpstarter-driver-network/pyproject.toml
@@ -52,5 +52,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-network/pyproject.toml
+++ b/packages/jumpstarter-driver-network/pyproject.toml
@@ -49,5 +49,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-opendal/pyproject.toml
+++ b/packages/jumpstarter-driver-opendal/pyproject.toml
@@ -26,5 +26,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-opendal/pyproject.toml
+++ b/packages/jumpstarter-driver-opendal/pyproject.toml
@@ -29,5 +29,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-power/pyproject.toml
+++ b/packages/jumpstarter-driver-power/pyproject.toml
@@ -26,5 +26,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-power/pyproject.toml
+++ b/packages/jumpstarter-driver-power/pyproject.toml
@@ -29,5 +29,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-probe-rs/pyproject.toml
+++ b/packages/jumpstarter-driver-probe-rs/pyproject.toml
@@ -28,8 +28,11 @@ log_cli_level = "INFO"
 testpaths = ["jumpstarter_driver_probe_rs"]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = ["pytest-cov>=6.0.0", "pytest>=8.3.3"]
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-probe-rs/pyproject.toml
+++ b/packages/jumpstarter-driver-probe-rs/pyproject.toml
@@ -34,5 +34,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = ["pytest-cov>=6.0.0", "pytest>=8.3.3"]
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-pyserial/pyproject.toml
+++ b/packages/jumpstarter-driver-pyserial/pyproject.toml
@@ -34,5 +34,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-pyserial/pyproject.toml
+++ b/packages/jumpstarter-driver-pyserial/pyproject.toml
@@ -37,5 +37,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-qemu/pyproject.toml
+++ b/packages/jumpstarter-driver-qemu/pyproject.toml
@@ -40,5 +40,8 @@ jumpstarter-driver-pyserial = { workspace = true }
 jumpstarter-driver-power = { workspace = true }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-qemu/pyproject.toml
+++ b/packages/jumpstarter-driver-qemu/pyproject.toml
@@ -43,5 +43,5 @@ jumpstarter-driver-power = { workspace = true }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-raspberrypi/pyproject.toml
+++ b/packages/jumpstarter-driver-raspberrypi/pyproject.toml
@@ -31,5 +31,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-raspberrypi/pyproject.toml
+++ b/packages/jumpstarter-driver-raspberrypi/pyproject.toml
@@ -28,5 +28,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-sdwire/pyproject.toml
+++ b/packages/jumpstarter-driver-sdwire/pyproject.toml
@@ -31,5 +31,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-sdwire/pyproject.toml
+++ b/packages/jumpstarter-driver-sdwire/pyproject.toml
@@ -28,5 +28,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-shell/pyproject.toml
+++ b/packages/jumpstarter-driver-shell/pyproject.toml
@@ -30,5 +30,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-shell/pyproject.toml
+++ b/packages/jumpstarter-driver-shell/pyproject.toml
@@ -33,5 +33,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-snmp/pyproject.toml
+++ b/packages/jumpstarter-driver-snmp/pyproject.toml
@@ -35,5 +35,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-snmp/pyproject.toml
+++ b/packages/jumpstarter-driver-snmp/pyproject.toml
@@ -38,5 +38,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-tftp/pyproject.toml
+++ b/packages/jumpstarter-driver-tftp/pyproject.toml
@@ -41,5 +41,5 @@ asyncio_mode = "auto"
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-tftp/pyproject.toml
+++ b/packages/jumpstarter-driver-tftp/pyproject.toml
@@ -38,5 +38,8 @@ testpaths = ["jumpstarter_driver_tftp"]
 asyncio_mode = "auto"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-uboot/pyproject.toml
+++ b/packages/jumpstarter-driver-uboot/pyproject.toml
@@ -35,5 +35,8 @@ jumpstarter-driver-composite = { workspace = true }
 jumpstarter-driver-qemu = { workspace = true }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-uboot/pyproject.toml
+++ b/packages/jumpstarter-driver-uboot/pyproject.toml
@@ -38,5 +38,5 @@ jumpstarter-driver-qemu = { workspace = true }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-ustreamer/pyproject.toml
+++ b/packages/jumpstarter-driver-ustreamer/pyproject.toml
@@ -24,5 +24,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-ustreamer/pyproject.toml
+++ b/packages/jumpstarter-driver-ustreamer/pyproject.toml
@@ -27,5 +27,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-yepkit/pyproject.toml
+++ b/packages/jumpstarter-driver-yepkit/pyproject.toml
@@ -39,5 +39,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = ["pytest-cov>=6.0.0", "pytest>=8.3.3"]
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-driver-yepkit/pyproject.toml
+++ b/packages/jumpstarter-driver-yepkit/pyproject.toml
@@ -33,8 +33,11 @@ testpaths = ["jumpstarter_driver_yepkit"]
 asyncio_mode = "auto"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = ["pytest-cov>=6.0.0", "pytest>=8.3.3"]
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-imagehash/pyproject.toml
+++ b/packages/jumpstarter-imagehash/pyproject.toml
@@ -24,5 +24,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-imagehash/pyproject.toml
+++ b/packages/jumpstarter-imagehash/pyproject.toml
@@ -27,5 +27,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-kubernetes/pyproject.toml
+++ b/packages/jumpstarter-kubernetes/pyproject.toml
@@ -30,5 +30,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-kubernetes/pyproject.toml
+++ b/packages/jumpstarter-kubernetes/pyproject.toml
@@ -33,5 +33,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-protocol/pyproject.toml
+++ b/packages/jumpstarter-protocol/pyproject.toml
@@ -32,5 +32,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-protocol/pyproject.toml
+++ b/packages/jumpstarter-protocol/pyproject.toml
@@ -35,5 +35,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter-testing/pyproject.toml
+++ b/packages/jumpstarter-testing/pyproject.toml
@@ -26,5 +26,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter-testing/pyproject.toml
+++ b/packages/jumpstarter-testing/pyproject.toml
@@ -29,5 +29,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/packages/jumpstarter/pyproject.toml
+++ b/packages/jumpstarter/pyproject.toml
@@ -44,5 +44,8 @@ source = "vcs"
 raw-options = { 'root' = '../../' }
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/packages/jumpstarter/pyproject.toml
+++ b/packages/jumpstarter/pyproject.toml
@@ -47,5 +47,5 @@ raw-options = { 'root' = '../../' }
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata.hooks.pin_jumpstarter]
+[tool.hatch.build.hooks.pin_jumpstarter]
 name = "pin_jumpstarter"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ jumpstarter-kubernetes = { workspace = true }
 jumpstarter-protocol = { workspace = true }
 jumpstarter-testing = { workspace = true }
 sphinx-click = { git = "https://github.com/NickCao/sphinx-click" }
+hatch-pin-jumpstarter = { workspace = true }
 
 [dependency-groups]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -815,12 +815,28 @@ source = { editable = "packages/hatch-pin-jumpstarter" }
 dependencies = [
     { name = "hatchling" },
     { name = "packaging" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "hatchling", specifier = ">=1.27.0" },
     { name = "packaging", specifier = ">=24.2" },
+    { name = "tomli", specifier = ">=2.2.1" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
 ]
 
 [[package]]
@@ -3537,6 +3553,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.11"
 
 [manifest]
 members = [
+    "hatch-pin-jumpstarter",
     "jumpstarter",
     "jumpstarter-all",
     "jumpstarter-cli",
@@ -805,6 +806,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+]
+
+[[package]]
+name = "hatch-pin-jumpstarter"
+version = "0.1.0"
+source = { editable = "packages/hatch-pin-jumpstarter" }
+dependencies = [
+    { name = "hatchling" },
+    { name = "packaging" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "packaging", specifier = ">=24.2" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794 },
 ]
 
 [[package]]
@@ -2414,6 +2445,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3526,6 +3566,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/47/f62e62a1a6f37909aed0bf8f5d5411e06fa03846cfcb64540cd1180ccc9f/trio-0.29.0.tar.gz", hash = "sha256:ea0d3967159fc130acb6939a0be0e558e364fee26b5deeecc893a6b08c361bdf", size = 588952 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/55/c4d9bea8b3d7937901958f65124123512419ab0eb73695e5f382521abbfb/trio-0.29.0-py3-none-any.whl", hash = "sha256:d8c463f1a9cc776ff63e331aba44c125f423a5a13c684307e828d930e625ba66", size = 492920 },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2025.4.28.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/f3/4d82f6d81391237842c4250766ae02c7a178a3a236e0fbd749ec154da17c/trove_classifiers-2025.4.28.22.tar.gz", hash = "sha256:42bef4957a74fe7724b8310dafd4b23e0a71406a4812cf4dfd65e2ee34f1943d", size = 16883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/d6/647f7aca9314bcc83d5608166f89121f55ccc05402b0cd1a1e72cffa3e62/trove_classifiers-2025.4.28.22-py3-none-any.whl", hash = "sha256:fdb453fefa3a0da9c18b8d390846e6df7e961e8924703559ea9be07ec99c0925", size = 14056 },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new build plugin that automatically pins certain dependencies' versions during the build process.
- **Chores**
  - Added a new package for the build plugin and integrated it into the build configuration across all relevant packages.
  - Updated workspace configuration to include the new build plugin package.
  - Modified test commands to handle specific exit codes gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->