### PR TITLE
Point pip calls to our release index

### DIFF
--- a/__templates__/create_driver.sh
+++ b/__templates__/create_driver.sh
@@ -42,7 +42,7 @@ cat > "${README_FILE}" << 'EOF'
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-${DRIVER_NAME}
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-${DRIVER_NAME}
 ```
 
 ## Configuration

--- a/docs/source/getting-started/installation/packages.md
+++ b/docs/source/getting-started/installation/packages.md
@@ -21,7 +21,7 @@ Install the Python package using `pip` or a similar tool. You need Python
 {{requires_python}}:
 
 ```shell
-$ pip3 install --extra-index-url https://pkg.jumpstarter.dev/ jumpstarter-all
+$ pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-all
 $ mkdir -p "${HOME}/.config/jumpstarter/"
 $ sudo mkdir /etc/jumpstarter
 ```
@@ -32,8 +32,16 @@ installing in a virtual environment instead:
 ```shell
 $ python3 -m venv ~/.venv/jumpstarter
 $ source ~/.venv/jumpstarter/bin/activate
-$ pip3 install --extra-index-url https://pkg.jumpstarter.dev/ jumpstarter-all
+$ pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-all
 ```
+
+Additional package indexes are available, this is a complete list of our indexes:
+
+| Index | Description |
+|-------|-------------|
+| [releases](https://pkg.jumpstarter.dev/) | Release, or release-candidate versions |
+| [main](https://pkg.jumpstarter.dev/main/) | Index tracking the main branch, equivalent to installing from sources |
+| [release-0.6](https://pkg.jumpstarter.dev/release-0.6) | Index tracking a stable branch |
 
 ### Installing from Source
 

--- a/packages/jumpstarter-driver-can/README.md
+++ b/packages/jumpstarter-driver-can/README.md
@@ -6,7 +6,7 @@ connections.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-can
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-can
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-composite/README.md
+++ b/packages/jumpstarter-driver-composite/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install jumpstarter-driver-composite
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-composite
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-corellium/README.md
+++ b/packages/jumpstarter-driver-corellium/README.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-corellium
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-corellium
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-dutlink/README.md
+++ b/packages/jumpstarter-driver-dutlink/README.md
@@ -6,7 +6,7 @@ Link devices.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-dutlink
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-dutlink
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-http/README.md
+++ b/packages/jumpstarter-driver-http/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-http
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-http
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-network/README.md
+++ b/packages/jumpstarter-driver-network/README.md
@@ -6,7 +6,7 @@ servers and connections.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-network
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-network
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-opendal/README.md
+++ b/packages/jumpstarter-driver-opendal/README.md
@@ -6,7 +6,7 @@ storages attached to the exporter.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-opendal
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-opendal
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-power/README.md
+++ b/packages/jumpstarter-driver-power/README.md
@@ -6,7 +6,7 @@ control devices.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-power
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-power
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-probe-rs/README.md
+++ b/packages/jumpstarter-driver-probe-rs/README.md
@@ -6,7 +6,7 @@ flashing of embedded devices using the [probe-rs](https://probe.rs) tools.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-probe-rs
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-probe-rs
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-pyserial/README.md
+++ b/packages/jumpstarter-driver-pyserial/README.md
@@ -6,7 +6,7 @@ communication.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-pyserial
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-pyserial
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-qemu/README.md
+++ b/packages/jumpstarter-driver-qemu/README.md
@@ -6,7 +6,7 @@ virtualization platform.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-qemu
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-qemu
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-raspberrypi/README.md
+++ b/packages/jumpstarter-driver-raspberrypi/README.md
@@ -6,7 +6,7 @@ Raspberry Pi devices.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-raspberrypi
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-raspberrypi
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-sdwire/README.md
+++ b/packages/jumpstarter-driver-sdwire/README.md
@@ -7,7 +7,7 @@ host.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-sdwire
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-sdwire
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-shell/README.md
+++ b/packages/jumpstarter-driver-shell/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-shell
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-snmp/README.md
+++ b/packages/jumpstarter-driver-snmp/README.md
@@ -6,7 +6,7 @@ SNMP-enabled PDUs (Power Distribution Units).
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-snmp
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-snmp
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-tftp/README.md
+++ b/packages/jumpstarter-driver-tftp/README.md
@@ -6,7 +6,7 @@ that can be used to serve files.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-tftp
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-tftp
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-uboot/README.md
+++ b/packages/jumpstarter-driver-uboot/README.md
@@ -7,7 +7,7 @@ it should be configured with backing power and serial drivers.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-uboot
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-uboot
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-ustreamer/README.md
+++ b/packages/jumpstarter-driver-ustreamer/README.md
@@ -7,7 +7,7 @@ video device and exposes both snapshot and streaming interfaces.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-ustreamer
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-ustreamer
 ```
 
 ## Configuration

--- a/packages/jumpstarter-driver-yepkit/README.md
+++ b/packages/jumpstarter-driver-yepkit/README.md
@@ -6,7 +6,7 @@ products.
 ## Installation
 
 ```shell
-pip install jumpstarter-driver-yepkit
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-yepkit
 ```
 
 ## Configuration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions across documentation and READMEs to use `pip3` instead of `pip`.
  - Added or updated the use of a custom package index URL (`https://pkg.jumpstarter.dev/simple/`) in installation commands.
  - Introduced a section listing multiple available package indexes with their URLs and descriptions in the installation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->