### PR TITLE
Suppress OSError from sending EOF on UDS

### DIFF
--- a/packages/jumpstarter/jumpstarter/streams/common.py
+++ b/packages/jumpstarter/jumpstarter/streams/common.py
@@ -18,7 +18,13 @@ async def copy_stream(dst: AnyByteStream, src: AnyByteStream):
     with suppress(BrokenResourceError, ClosedResourceError, asyncio.exceptions.InvalidStateError):
         async for v in src:
             await dst.send(v)
-        with suppress(AttributeError):
+        with suppress(
+            AttributeError,
+            # https://github.com/jumpstarter-dev/jumpstarter/issues/444
+            # sending EOF to UDS on Darwin could result in
+            # OSError: [Errno 57] Socket is not connected
+            OSError,
+        ):
             await dst.send_eof()
 
 


### PR DESCRIPTION
Fixes https://github.com/jumpstarter-dev/jumpstarter/issues/444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when signaling end-of-file over Unix Domain Sockets on Darwin systems, preventing unexpected errors in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->