### PR TITLE
Enable tls.insecure true by default

### DIFF
--- a/docs/source/getting-started/configuration/files.md
+++ b/docs/source/getting-started/configuration/files.md
@@ -29,7 +29,17 @@ config:
 **File**: Various files with `.yaml` extension  
 **Location**: `~/.config/jumpstarter/clients/*.yaml`  
 **Description**: Stores client configurations including endpoints, access
-tokens, and driver settings.  
+tokens, and driver settings.
+
+```{warning}
+The jumpstarter-controller endpoints are secured by TLS, but in 0.6 the certificates
+are rotated every time the controller is restarted. This means that the certificates cannot
+be trusted by default. You should either use `tls.insecure: true` in your client
+configuration which is the default for this version, or set the `JUMPSTARTER_GRPC_INSECURE`
+environment variable to `1` to disable TLS verification. This will be fixed in 0.7 with proper
+certificate management, and cert-manager integration. See issue
+[#455](https://github.com/jumpstarter-dev/jumpstarter/issues/455)
+```
 
 **Format**:
 ```yaml
@@ -39,7 +49,7 @@ metadata:
   name: myclient
   namespace: jumpstarter-lab
 tls:
-  insecure: false
+  insecure: true
   ca: ""
 endpoint: "jumpstarter.my-lab.com:1443"
 token: "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"
@@ -81,7 +91,7 @@ metadata:
   name: myexporter
   namespace: jumpstarter-lab
 tls:
-  insecure: false
+  insecure: true
   ca: ""
 endpoint: "jumpstarter.my-lab.com:1443"
 token: "dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz"

--- a/docs/source/getting-started/installation/service.md
+++ b/docs/source/getting-started/installation/service.md
@@ -16,6 +16,16 @@ Jumpstarter environment. Before installing, ensure you have:
 - `router.jumpstarter.example.com` (for router endpoints)
 ```
 
+```{warning}
+The jumpstarter-controller endpoints are secured by TLS, but in 0.6 the certificates
+are rotated every time the controller is restarted. This means that the certificates cannot
+be trusted by default. You should either use `tls.insecure: true` in your client
+configuration which is the default for this version, or set the `JUMPSTARTER_GRPC_INSECURE`
+environment variable to `1` to disable TLS verification. This will be fixed in 0.7 with proper
+certificate management, and cert-manager integration. See issue
+[#455](https://github.com/jumpstarter-dev/jumpstarter/issues/455)
+```
+
 ## Kubernetes with Helm
 
 Install Jumpstarter on a standard Kubernetes cluster using Helm:

--- a/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -205,7 +205,7 @@ metadata:
 endpoint: jumpstarter.my-lab.com:1443
 tls:
   ca: ''
-  insecure: false
+  insecure: true
 token: dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz
 grpcOptions: {}
 drivers:
@@ -241,7 +241,7 @@ metadata:
 endpoint: jumpstarter.my-lab.com:1443
 tls:
   ca: ''
-  insecure: false
+  insecure: true
 token: dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz
 grpcOptions: {}
 drivers:
@@ -275,7 +275,7 @@ metadata:
 endpoint: jumpstarter.my-lab.com:1443
 tls:
   ca: ''
-  insecure: false
+  insecure: true
 token: dGhpc2lzYXRva2VuLTEyMzQxMjM0MTIzNEyMzQtc2Rxd3Jxd2VycXdlcnF3ZXJxd2VyLTEyMzQxMjM0MTIz
 grpcOptions: {}
 drivers:

--- a/packages/jumpstarter/jumpstarter/config/tls.py
+++ b/packages/jumpstarter/jumpstarter/config/tls.py
@@ -3,4 +3,6 @@ from pydantic import BaseModel, Field
 
 class TLSConfigV1Alpha1(BaseModel):
     ca: str = Field(default="")
-    insecure: bool = Field(default=False)
+    insecure: bool = Field(default=True)
+    # TODO(mangelajo): Move this back to false once we have a proper way to setup
+    # TLS certificates in the jumpstarter controller.


### PR DESCRIPTION
Our jumpstarter-controller currently re-creates the TLS certificates on every restart. This means that clients and exporters cannot trust the gRPC certificates by default.

This commit sets tls insecure by default to avoid user frustration, this should be fixed for 0.7 once the controller supports proper certificate handling.

Related-Issue: #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added warnings in configuration and installation guides about temporary TLS certificate rotation and trust issues in version 0.6.
  - Updated example configurations to set `tls.insecure: true` by default and included guidance on disabling TLS verification.
- **New Features**
  - Default client and exporter configurations now disable TLS verification to accommodate rotated, untrusted certificates in version 0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->