### PR TITLE
Add insecure_tls_config flag

### DIFF
--- a/docs/source/getting-started/configuration/authentication.md
+++ b/docs/source/getting-started/configuration/authentication.md
@@ -46,13 +46,14 @@ Note, the HTTPS URL is mandatory, and you only need to include certificateAuthor
    prefix usernames with `keycloak:` as configured in the claim mappings:
 
 ```shell
-$ jmp admin create client test-client --oidc-username keycloak:developer-1
+$ jmp admin create client test-client --insecure-tls-config --oidc-username keycloak:developer-1
 ```
 
 4. Instruct users to log in with:
 
 ```shell
 $ jmp login --client <client alias> \
+    --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
     --namespace <namespace> --name <client name> \
     --issuer https://<keycloak domain>/realms/<realm name>
@@ -62,6 +63,7 @@ For non-interactive login, add username and password:
 
 ```shell
 $ jmp login --client <client alias> [other parameters] \
+    --insecure-tls-config \
     --username <username> \
     --password <password>
 ```
@@ -76,6 +78,7 @@ For exporters, use similar login command but with the `--exporter` flag:
 
 ```shell
 $ jmp login --exporter <exporter alias> \
+    --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
     --namespace <namespace> --name <exporter name> \
     --issuer https://<keycloak domain>/realms/<realm name>
@@ -188,6 +191,7 @@ jwt:
 
 ```shell
 $ jmp admin create exporter test-exporter \
+    --insecure-tls-config \
     --oidc-username dex:system:serviceaccount:default:test-service-account
 ```
 
@@ -197,6 +201,7 @@ For clients:
 
 ```shell
 $ jmp login --client <client alias> \
+    --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
     --namespace <namespace> --name <client name> \
     --issuer https://dex.dex.svc.cluster.local:5556 \
@@ -208,6 +213,7 @@ For exporters:
 
 ```shell
 $ jmp login --exporter <exporter alias> \
+    --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
     --namespace <namespace> --name <exporter name> \
     --issuer https://dex.dex.svc.cluster.local:5556 \

--- a/docs/source/getting-started/usage/setup-distributed-mode.md
+++ b/docs/source/getting-started/usage/setup-distributed-mode.md
@@ -3,6 +3,16 @@
 This guide walks you through the process of creating an exporter using the
 controller service, configuring drivers, and running the exporter.
 
+```{warning}
+The jumpstarter-controller endpoints are secured by TLS. However, in release 0.6.x,
+the certificates are self-signed and rotated on every restart. This means the client
+will not be able to verify the server certificate. To bypass this, you should use the
+`--insecure-tls-config` flag when creating clients and exporters. This issue will be
+resolved in the next release. See [issue #455](https://github.com/jumpstarter-dev/jumpstarter/issues/455)
+for more details.
+Alternatively, you can configure the ingress/route in reencrypt mode with your own key and certificate.
+```
+
 ## Prerequisites
 
 Install [the following packages](../installation/packages.md) in your Python
@@ -30,7 +40,7 @@ Run this command to create an exporter named `example-distributed` and save the
 configuration locally:
 
 ```shell
-$ jmp admin create exporter example-distributed --save
+$ jmp admin create exporter example-distributed --save --insecure-tls-config
 ```
 
 After creating the exporter, find the new configuration file at
@@ -78,7 +88,7 @@ development purposes, and saves the configuration locally in
 `${HOME}/.config/jumpstarter/clients/`:
 
 ```shell
-$ jmp admin create client hello --save --unsafe
+$ jmp admin create client hello --save --unsafe --insecure-tls-config
 ```
 
 ### Spawn an Exporter Shell

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create.py
@@ -6,7 +6,9 @@ from jumpstarter_cli_common.blocking import blocking
 from jumpstarter_cli_common.opt import (
     OutputMode,
     OutputType,
+    confirm_insecure_tls,
     opt_context,
+    opt_insecure_tls_config,
     opt_kubeconfig,
     opt_labels,
     opt_namespace,
@@ -69,6 +71,7 @@ def print_created_client(client: V1Alpha1Client, output: OutputType):
 @opt_labels
 @opt_kubeconfig
 @opt_context
+@opt_insecure_tls_config
 @opt_oidc_username
 @opt_nointeractive
 @opt_output_all
@@ -77,6 +80,7 @@ async def create_client(
     name: Optional[str],
     kubeconfig: Optional[str],
     context: Optional[str],
+    insecure_tls_config: bool,
     namespace: str,
     labels: list[(str, str)],
     save: bool,
@@ -89,6 +93,7 @@ async def create_client(
 ):
     """Create a client object in the Kubernetes cluster"""
     try:
+        confirm_insecure_tls(insecure_tls_config, nointeractive)
         async with ClientsV1Alpha1Api(namespace, kubeconfig, context) as api:
             if output is None:
                 # Only print status if  is not JSON/YAML
@@ -108,6 +113,7 @@ async def create_client(
                 allow_drivers = allow.split(",") if allow is not None and len(allow) > 0 else []
                 client_config.drivers.unsafe = unsafe
                 client_config.drivers.allow = allow_drivers
+                client_config.tls.insecure = insecure_tls_config
                 ClientConfigV1Alpha1.save(client_config, out)
                 # If this is the only client config, set it as default
                 if out is None and len(ClientConfigV1Alpha1.list()) == 1:
@@ -151,6 +157,7 @@ def print_created_exporter(exporter: V1Alpha1Exporter, output: OutputType):
 @opt_labels
 @opt_kubeconfig
 @opt_context
+@opt_insecure_tls_config
 @opt_oidc_username
 @opt_nointeractive
 @opt_output_all
@@ -159,6 +166,7 @@ async def create_exporter(
     name: Optional[str],
     kubeconfig: Optional[str],
     context: Optional[str],
+    insecure_tls_config: bool,
     namespace: str,
     labels: list[(str, str)],
     save: bool,
@@ -169,6 +177,7 @@ async def create_exporter(
 ):
     """Create an exporter object in the Kubernetes cluster"""
     try:
+        confirm_insecure_tls(insecure_tls_config, nointeractive)
         async with ExportersV1Alpha1Api(namespace, kubeconfig, context) as api:
             if output is None:
                 click.echo(f"Creating exporter '{name}' in namespace '{namespace}'")
@@ -178,6 +187,7 @@ async def create_exporter(
                 if output is None:
                     click.echo("Fetching exporter credentials from cluster")
                 exporter_config = await api.get_exporter_config(name)
+                exporter_config.tls.insecure = insecure_tls_config
                 ExporterConfigV1Alpha1.save(exporter_config, out)
                 if output is None:
                     click.echo(f"Exporter configuration successfully saved to {exporter_config.path}")

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create_test.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 from click.testing import CliRunner
@@ -115,7 +116,7 @@ def test_create_client(
     result = runner.invoke(create, ["client", CLIENT_NAME, "--unsafe", "--out", out], input="\n\n")
     assert result.exit_code == 0
     assert "Client configuration successfully saved" in result.output
-    mock_save_client.assert_called_once_with(UNSAFE_CLIENT_CONFIG, out)
+    mock_save_client.assert_called_once_with(UNSAFE_CLIENT_CONFIG, str(Path(out).resolve()))
     mock_save_client.reset_mock()
 
     # Regular client config is returned
@@ -257,7 +258,7 @@ def test_create_exporter(
     result = runner.invoke(create, ["exporter", EXPORTER_NAME, "--out", out])
     assert result.exit_code == 0
     assert "Exporter configuration successfully saved" in result.output
-    save_exporter_mock.assert_called_once_with(EXPORTER_CONFIG, out)
+    save_exporter_mock.assert_called_once_with(EXPORTER_CONFIG, str(Path(out).resolve()))
     save_exporter_mock.reset_mock()
 
     # Save with nointeractive

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create_test.py
@@ -17,6 +17,7 @@ from .create import create
 from jumpstarter.config.client import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers
 from jumpstarter.config.common import ObjectMeta
 from jumpstarter.config.exporter import ExporterConfigV1Alpha1
+from jumpstarter.config.tls import TLSConfigV1Alpha1
 
 # Generate a random client name
 CLIENT_NAME = uuid.uuid4().hex
@@ -82,6 +83,15 @@ CLIENT_CONFIG = ClientConfigV1Alpha1(
     drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=True),
 )
 
+INSECURE_TLS_CLIENT_CONFIG = ClientConfigV1Alpha1(
+    alias=CLIENT_NAME,
+    metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
+    endpoint=CLIENT_ENDPOINT,
+    token=CLIENT_TOKEN,
+    tls=TLSConfigV1Alpha1(insecure=True),
+    drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=True),
+)
+
 
 @patch.object(ClientConfigV1Alpha1, "save")
 @patch.object(ClientsV1Alpha1Api, "get_client_config")
@@ -100,6 +110,32 @@ def test_create_client(
     assert "Client configuration successfully saved" not in result.output
     mock_save_client.assert_not_called()
     mock_save_client.reset_mock()
+
+    # Insecure TLS config is returned
+    mock_get_client_config.return_value = INSECURE_TLS_CLIENT_CONFIG
+
+    # Save with prompts accept insecure = Y, save = Y, unsafe = Y
+    result = runner.invoke(create, ["client", "--insecure-tls-config", CLIENT_NAME], input="Y\nY\nY\n")
+    assert result.exit_code == 0
+    assert "Client configuration successfully saved" in result.output
+    mock_save_client.assert_called_once_with(INSECURE_TLS_CLIENT_CONFIG, None)
+    mock_save_client.reset_mock()
+
+    # Save no interactive and insecure tls
+    result = runner.invoke(create, ["client", "--insecure-tls-config", "--unsafe",
+                                    "--save", "--nointeractive", CLIENT_NAME])
+    assert result.exit_code == 0
+    assert "Client configuration successfully saved" in result.output
+    mock_save_client.assert_called_once_with(INSECURE_TLS_CLIENT_CONFIG, None)
+    mock_save_client.reset_mock()
+
+   # Insecure TLS config is returned
+    mock_get_client_config.return_value = INSECURE_TLS_CLIENT_CONFIG
+
+    # Save with prompts accept insecure = N
+    result = runner.invoke(create, ["client", "--insecure-tls-config", CLIENT_NAME], input="n\n")
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
 
     # Unsafe client config is returned
     mock_get_client_config.return_value = UNSAFE_CLIENT_CONFIG
@@ -220,6 +256,13 @@ EXPORTER_CONFIG = ExporterConfigV1Alpha1(
     token=EXPORTER_TOKEN,
 )
 
+INSECURE_TLS_EXPORTER_CONFIG = ExporterConfigV1Alpha1(
+    alias=EXPORTER_NAME,
+    metadata=ObjectMeta(namespace="default", name=EXPORTER_NAME),
+    endpoint=EXPORTER_ENDPOINT,
+    token=EXPORTER_TOKEN,
+    tls=TLSConfigV1Alpha1(insecure=True),
+)
 
 @patch.object(ExporterConfigV1Alpha1, "save")
 @patch.object(ExportersV1Alpha1Api, "_load_kube_config")
@@ -238,6 +281,31 @@ def test_create_exporter(
     assert "Exporter configuration successfully saved" not in result.output
     save_exporter_mock.assert_not_called()
     save_exporter_mock.reset_mock()
+
+    # Insecure TLS config is returned
+    _get_exporter_config_mock.return_value = INSECURE_TLS_EXPORTER_CONFIG
+    # Save with prompts accept insecure = Y, save = Y
+    result = runner.invoke(create, ["exporter", "--insecure-tls-config", EXPORTER_NAME], input="Y\nY\n")
+    assert result.exit_code == 0
+    assert "Exporter configuration successfully saved" in result.output
+    save_exporter_mock.assert_called_once_with(INSECURE_TLS_EXPORTER_CONFIG, None)
+    save_exporter_mock.reset_mock()
+
+    _get_exporter_config_mock.return_value = INSECURE_TLS_EXPORTER_CONFIG
+    # Save with prompts accept no interactive
+    result = runner.invoke(create, ["exporter", "--insecure-tls-config", "--nointeractive", "--save", EXPORTER_NAME])
+    assert result.exit_code == 0
+    assert "Exporter configuration successfully saved" in result.output
+    save_exporter_mock.assert_called_once_with(INSECURE_TLS_EXPORTER_CONFIG, None)
+    save_exporter_mock.reset_mock()
+
+    # Insecure TLS config is returned
+    _get_exporter_config_mock.return_value = INSECURE_TLS_EXPORTER_CONFIG
+    # Save with prompts accept insecure = N
+    result = runner.invoke(create, ["exporter", "--insecure-tls-config", EXPORTER_NAME], input="n\n")
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
+
 
     # Save with prompts
     result = runner.invoke(create, ["exporter", EXPORTER_NAME], input="Y\n")

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res.py
@@ -4,7 +4,9 @@ import click
 from jumpstarter_cli_common.blocking import blocking
 from jumpstarter_cli_common.opt import (
     PathOutputType,
+    confirm_insecure_tls,
     opt_context,
+    opt_insecure_tls_config,
     opt_kubeconfig,
     opt_namespace,
     opt_nointeractive,
@@ -46,6 +48,7 @@ def import_res():
 @opt_namespace
 @opt_kubeconfig
 @opt_context
+@opt_insecure_tls_config
 @opt_output_path_only
 @opt_nointeractive
 @blocking
@@ -54,6 +57,7 @@ async def import_client(
     namespace: str,
     kubeconfig: Optional[str],
     context: Optional[str],
+    insecure_tls_config: bool,
     allow: Optional[str],
     unsafe: bool,
     out: Optional[str],
@@ -65,6 +69,7 @@ async def import_client(
     if out is None and ClientConfigV1Alpha1.exists(name):
         raise click.ClickException(f"A client with the name '{name}' already exists")
     try:
+        confirm_insecure_tls(insecure_tls_config, nointeractive)
         async with ClientsV1Alpha1Api(namespace, kubeconfig, context) as api:
             if unsafe is False and allow is None and nointeractive is False:
                 unsafe = click.confirm("Allow unsafe driver client imports?")
@@ -76,6 +81,7 @@ async def import_client(
                 click.echo("Fetching client credentials from cluster")
             allow_drivers = allow.split(",") if allow is not None and len(allow) > 0 else []
             client_config = await api.get_client_config(name, allow=allow_drivers, unsafe=unsafe)
+            client_config.tls.insecure = insecure_tls_config
             config_path = ClientConfigV1Alpha1.save(client_config, out)
             # If this is the only client config, set it as default
             if out is None and len(ClientConfigV1Alpha1.list()) == 1:
@@ -102,6 +108,7 @@ async def import_client(
 @opt_namespace
 @opt_kubeconfig
 @opt_context
+@opt_insecure_tls_config
 @opt_output_path_only
 @opt_nointeractive
 @blocking
@@ -111,6 +118,7 @@ async def import_exporter(
     out: Optional[str],
     kubeconfig: Optional[str],
     context: Optional[str],
+    insecure_tls_config: bool,
     output: PathOutputType,
     nointeractive: bool,
 ):
@@ -122,10 +130,12 @@ async def import_exporter(
     else:
         raise click.ClickException(f'An exporter with the name "{name}" already exists')
     try:
+        confirm_insecure_tls(insecure_tls_config, nointeractive)
         async with ExportersV1Alpha1Api(namespace, kubeconfig, context) as api:
             if output is None:
                 click.echo("Fetching exporter credentials from cluster")
             exporter_config = await api.get_exporter_config(name)
+            exporter_config.tls.insecure = insecure_tls_config
             config_path = ExporterConfigV1Alpha1.save(exporter_config, out)
             if output is None:
                 click.echo(f"Exporter configuration successfully saved to {config_path}")

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res_test.py
@@ -12,6 +12,7 @@ from .import_res import import_res
 from jumpstarter.config.client import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers
 from jumpstarter.config.common import ObjectMeta
 from jumpstarter.config.exporter import ExporterConfigV1Alpha1
+from jumpstarter.config.tls import TLSConfigV1Alpha1
 
 # Generate a random client name
 CLIENT_NAME = uuid.uuid4().hex
@@ -32,6 +33,14 @@ CLIENT_CONFIG = ClientConfigV1Alpha1(
     endpoint=CLIENT_ENDPOINT,
     token=CLIENT_TOKEN,
     drivers=ClientConfigV1Alpha1Drivers(allow=[DRIVER_NAME], unsafe=False),
+)
+INSECURE_TLS_CLIENT_CONFIG = ClientConfigV1Alpha1(
+    alias=CLIENT_NAME,
+    metadata=ObjectMeta(namespace="default", name=CLIENT_NAME),
+    endpoint=CLIENT_ENDPOINT,
+    token=CLIENT_TOKEN,
+    tls=TLSConfigV1Alpha1(insecure=True),
+    drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=True),
 )
 
 
@@ -57,6 +66,34 @@ def test_import_client(_load_kube_config_mock, get_client_config_mock: AsyncMock
     assert "Client configuration successfully saved" in result.output
     save_client_config_mock.assert_called_once_with(UNSAFE_CLIENT_CONFIG, None)
     save_client_config_mock.reset_mock()
+
+    # Test insecure TLS config
+    get_client_config_mock.return_value = INSECURE_TLS_CLIENT_CONFIG
+
+    # Save with prompts accept insecure = Y
+    result = runner.invoke(import_res, ["client", CLIENT_NAME, "--insecure-tls-config"], input="Y\nY\n")
+    assert result.exit_code == 0
+    assert "Client configuration successfully saved" in result.output
+    save_client_config_mock.assert_called_once_with(INSECURE_TLS_CLIENT_CONFIG, None)
+    save_client_config_mock.reset_mock()
+
+   # Save with prompts no interactive prompts and insecure tls cert
+    result = runner.invoke(import_res, ["client", CLIENT_NAME, "--nointeractive", "--insecure-tls-config"])
+    assert result.exit_code == 0
+    assert "Client configuration successfully saved" in result.output
+    save_client_config_mock.assert_called_once_with(INSECURE_TLS_CLIENT_CONFIG, None)
+    save_client_config_mock.reset_mock()
+
+
+    # Save with prompts accept insecure = N
+    result = runner.invoke(import_res, ["client", CLIENT_NAME, "--insecure-tls-config"], input="n\n")
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
+    save_client_config_mock.assert_not_called()
+    save_client_config_mock.reset_mock()
+
+    # Reset mock for subsequent tests
+    get_client_config_mock.return_value = UNSAFE_CLIENT_CONFIG
 
     # Save with custom out file
     out = f"/tmp/{CLIENT_NAME}.yaml"
@@ -106,6 +143,13 @@ EXPORTER_CONFIG = ExporterConfigV1Alpha1(
     endpoint=EXPORTER_ENDPOINT,
     token=EXPORTER_TOKEN,
 )
+INSECURE_TLS_EXPORTER_CONFIG = ExporterConfigV1Alpha1(
+    alias=EXPORTER_NAME,
+    metadata=ObjectMeta(namespace="default", name=EXPORTER_NAME),
+    endpoint=EXPORTER_ENDPOINT,
+    token=EXPORTER_TOKEN,
+    tls=TLSConfigV1Alpha1(insecure=True),
+)
 
 
 @patch.object(ExporterConfigV1Alpha1, "save")
@@ -120,6 +164,26 @@ def test_import_exporter(_load_kube_config_mock, _get_exporter_config_mock, save
     assert "Exporter configuration successfully saved" in result.output
     save_exporter_config_mock.assert_called_with(EXPORTER_CONFIG, None)
     save_exporter_config_mock.reset_mock()
+
+    # Test insecure TLS config
+    _get_exporter_config_mock.return_value = INSECURE_TLS_EXPORTER_CONFIG
+
+    # Save with prompts accept insecure = Y
+    result = runner.invoke(import_res, ["exporter", EXPORTER_NAME, "--insecure-tls-config"], input="Y\n")
+    assert result.exit_code == 0
+    assert "Exporter configuration successfully saved" in result.output
+    save_exporter_config_mock.assert_called_once_with(INSECURE_TLS_EXPORTER_CONFIG, None)
+    save_exporter_config_mock.reset_mock()
+
+    # Save with prompts accept insecure = N
+    result = runner.invoke(import_res, ["exporter", EXPORTER_NAME, "--insecure-tls-config"], input="n\n")
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
+    save_exporter_config_mock.assert_not_called()
+    save_exporter_config_mock.reset_mock()
+
+    # Reset mock for subsequent tests
+    _get_exporter_config_mock.return_value = EXPORTER_CONFIG
 
     # Save with custom out file
     out = f"/tmp/{EXPORTER_NAME}.yaml"

--- a/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res_test.py
+++ b/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/import_res_test.py
@@ -63,7 +63,7 @@ def test_import_client(_load_kube_config_mock, get_client_config_mock: AsyncMock
     result = runner.invoke(import_res, ["client", CLIENT_NAME, "--unsafe", "--out", out])
     assert result.exit_code == 0
     assert "Client configuration successfully saved" in result.output
-    save_client_config_mock.assert_called_once_with(UNSAFE_CLIENT_CONFIG, out)
+    save_client_config_mock.assert_called_once_with(UNSAFE_CLIENT_CONFIG, str(Path(out).resolve()))
     save_client_config_mock.reset_mock()
 
     # Save with path output
@@ -74,7 +74,7 @@ def test_import_client(_load_kube_config_mock, get_client_config_mock: AsyncMock
     )
     assert result.exit_code == 0
     assert result.output == f"{out}\n"
-    save_client_config_mock.assert_called_once_with(UNSAFE_CLIENT_CONFIG, out)
+    save_client_config_mock.assert_called_once_with(UNSAFE_CLIENT_CONFIG, str(Path(out).resolve()))
     save_client_config_mock.reset_mock()
 
     # Create and save safe client config
@@ -126,7 +126,7 @@ def test_import_exporter(_load_kube_config_mock, _get_exporter_config_mock, save
     result = runner.invoke(import_res, ["exporter", EXPORTER_NAME, "--out", out])
     assert result.exit_code == 0
     assert "Exporter configuration successfully saved" in result.output
-    save_exporter_config_mock.assert_called_with(EXPORTER_CONFIG, out)
+    save_exporter_config_mock.assert_called_with(EXPORTER_CONFIG, str(Path(out).resolve()))
 
     # Save with path output
     out = f"/tmp/{EXPORTER_NAME}.yaml"
@@ -134,4 +134,4 @@ def test_import_exporter(_load_kube_config_mock, _get_exporter_config_mock, save
     result = runner.invoke(import_res, ["exporter", EXPORTER_NAME, "--out", out, "--output", "path"])
     assert result.exit_code == 0
     assert result.output == f"{out}\n"
-    save_exporter_config_mock.assert_called_with(EXPORTER_CONFIG, out)
+    save_exporter_config_mock.assert_called_with(EXPORTER_CONFIG, str(Path(out).resolve()))

--- a/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -37,6 +37,23 @@ opt_namespace = click.option("-n", "--namespace", type=str, help="Kubernetes nam
 
 opt_labels = click.option("-l", "--label", "labels", type=(str, str), multiple=True, help="Labels")
 
+opt_insecure_tls_config = click.option("--insecure-tls-config", "insecure_tls_config", is_flag=True, default=False,
+            help="Disable endpoint TLS verification. This is insecure and should only be used for testing purposes")
+
+def confirm_insecure_tls(insecure_tls_config:bool, nointeractive: bool):
+    """Confirm if insecure TLS config is enabled and user wants to continue.
+
+    Args:
+        insecure_tls_config (bool): Insecure TLS config flag requested by the user.
+        nointeractive (bool): This flag is set to True if the command is run in non-interactive mode.
+
+    Raises:
+        click.Abort: Abort the command if user does not want to continue.
+    """
+    if nointeractive is False and insecure_tls_config:
+        if not click.confirm("Insecure TLS config is enabled. Are you sure you want to continue?"):
+            click.echo("Aborting.")
+            raise click.Abort()
 
 class OutputMode(str):
     JSON = "json"

--- a/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -2,6 +2,7 @@ import click
 from jumpstarter_cli_common.blocking import blocking
 from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.oidc import Config, decode_jwt_issuer, opt_oidc
+from jumpstarter_cli_common.opt import confirm_insecure_tls, opt_insecure_tls_config, opt_nointeractive
 
 from jumpstarter.config.client import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers
 from jumpstarter.config.common import ObjectMeta
@@ -25,6 +26,8 @@ from jumpstarter.config.exporter import ExporterConfigV1Alpha1
     "--unsafe", is_flag=True, help="Should all driver client packages be allowed to load (UNSAFE!).", default=None
 )
 # end client specific
+@opt_insecure_tls_config
+@opt_nointeractive
 @opt_config(allow_missing=True)
 @blocking
 async def login(  # noqa: C901
@@ -39,9 +42,13 @@ async def login(  # noqa: C901
     client_id: str,
     connector_id: str,
     unsafe,
+    insecure_tls_config: bool,
+    nointeractive: bool,
     allow,
 ):
     """Login into a jumpstarter instance"""
+
+    confirm_insecure_tls(insecure_tls_config, nointeractive)
 
     match config:
         case ClientConfigV1Alpha1():
@@ -50,16 +57,24 @@ async def login(  # noqa: C901
             issuer = decode_jwt_issuer(config.token)
         case (kind, value):
             if namespace is None:
+                if nointeractive:
+                    raise click.UsageError("Namespace is required in non-interactive mode.")
                 namespace = click.prompt("Enter the Jumpstarter exporter namespace")
             if name is None:
+                if nointeractive:
+                    raise click.UsageError("Name is required in non-interactive mode.")
                 name = click.prompt("Enter the Jumpstarter exporter name")
             if endpoint is None:
+                if nointeractive:
+                    raise click.UsageError("Endpoint is required in non-interactive mode.")
                 endpoint = click.prompt("Enter the Jumpstarter service endpoint")
 
             if kind.startswith("client"):
                 if unsafe is None:
                     unsafe = click.confirm("Allow unsafe driver client imports?")
                     if unsafe is False and allow == "":
+                        if nointeractive:
+                            raise click.UsageError("Allowed driver packages are required in non-interactive mode.")
                         allow = click.prompt(
                             "Enter a comma-separated list of allowed driver packages (optional)", default="", type=str
                         )
@@ -82,6 +97,8 @@ async def login(  # noqa: C901
                 )
 
     if issuer is None:
+        if nointeractive:
+            raise click.UsageError("Issuer is required in non-interactive mode.")
         issuer = click.prompt("Enter the OIDC issuer")
 
     oidc = Config(issuer=issuer, client_id=client_id)
@@ -95,6 +112,7 @@ async def login(  # noqa: C901
         tokens = await oidc.authorization_code_grant()
 
     config.token = tokens["access_token"]
+    config.tls.insecure = insecure_tls_config
 
     match kind:
         case "client":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to enable insecure TLS configuration for creating, importing, and login commands.
  - Users are prompted to confirm when enabling insecure TLS in interactive mode; operations abort if declined.
  - The insecure TLS setting is saved in client and exporter configuration files.
  - Login command now supports non-interactive mode with strict input validation and insecure TLS handling.
- **Documentation**
  - Updated CLI command examples to include the insecure TLS option.
  - Added a warning about self-signed TLS certificates in distributed mode and recommended use of the insecure TLS flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->