### PR TITLE
Add smart copy-paste button to snippets/code

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "sphinx_click",
     "sphinx_substitution_extensions",
     "sphinx_multiversion",
+    "sphinx_copybutton"
 ]
 
 templates_path = ["_templates"]
@@ -135,3 +136,9 @@ html_context = {
     "display_lower": True,  # Display lower versions at the bottom of the menu
     "deploy_url": os.getenv("DEPLOY_URL", "https://docs.jumpstarter.dev"),  # Get Netlify URL from environment variable
 }
+
+# sphinx-copybutton config
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_only_copy_prompt_lines = True
+copybutton_line_continuation_character = "\\"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ docs = [
     "requests>=2.32.3",
     "sphinxcontrib-programoutput>=0.18",
     "sphinx-multiversion>=0.2.4",
+    "sphinx-copybutton>=0.5.2",
 ]
 dev = [
     "ruff==0.9.2",

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,7 @@ docs = [
     { name = "sphinx", specifier = "<8.1.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.4.16" },
     { name = "sphinx-click", specifier = ">=6.0.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-multiversion", specifier = ">=0.2.4" },
     { name = "sphinx-substitution-extensions", specifier = ">=2024.10.17" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
@@ -3564,6 +3565,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/0a/5b1e8d0579dbb4ca8114e456ca4a68020bfe8e15c7001f3856be4929ab83/sphinx_click-6.0.0.tar.gz", hash = "sha256:f5d664321dc0c6622ff019f1e1c84e58ce0cecfddeb510e004cf60c2a3ab465b", size = 29574, upload-time = "2024-05-15T14:49:17.044Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/d7/8621c4726ad3f788a1db4c0c409044b16edc563f5c9542807b3724037555/sphinx_click-6.0.0-py3-none-any.whl", hash = "sha256:1e0a3c83bcb7c55497751b19d07ebe56b5d7b85eb76dd399cf9061b497adc317", size = 9922, upload-time = "2024-05-15T14:49:15.768Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The sphinx_copybutton plugin removes prompts (python/shell/etc...) and handles multi-line snippets.

This removes the annoyance of removing shell prompts when copying, or copying line by line...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a copy button to code blocks in the documentation, allowing users to easily copy code examples.
- **Chores**
  - Updated documentation dependencies to include the sphinx-copybutton extension.
  - Configured the copy button to recognize and exclude common prompt characters for cleaner copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->