### PR TITLE
docs/treewide: replace shell/bash code blocks with console blocks

### DIFF
--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -50,7 +50,7 @@ We welcome bug fixes, features, and improvements to the core codebase.
 
 To create a new driver scaffold:
 
-```shell
+```console
 $ ./__templates__/create_driver.sh driver_package DriverClass "Your Name" "your.email@example.com"
 ```
 
@@ -62,7 +62,7 @@ Test your driver: `make pkg-test-${package_name}`
 
 Jumpstarter uses Sphinx with Markdown. Build and preview locally:
 
-```shell
+```console
 $ make docs-serve
 ```
 

--- a/docs/source/contributing/development-environment.md
+++ b/docs/source/contributing/development-environment.md
@@ -14,33 +14,33 @@ We use [uv](https://docs.astral.sh/uv/) as our python package and project manage
 and `make` as our build interface.
 
 To install the basic set of dependencies, run the following commands:
-```bash
-sudo dnf install -y python-devel g++ make git uv qemu qemu-user-static
+```console
+$ sudo dnf install -y python-devel g++ make git uv qemu qemu-user-static
 ```
 
 Then you can clone the project and build the virtual environment with:
-```bash
-git clone https://github.com/jumpstarter-dev/jumpstarter.git
-cd jumpstarter
-make sync
+```console
+$ git clone https://github.com/jumpstarter-dev/jumpstarter.git
+$ cd jumpstarter
+$ make sync
 ```
 
 At this point you can run any of the jumpstarter commands prefixing them with `uv run`:
 
 i.e.:
-```bash
-uv run jmp
+```console
+$ uv run jmp
 ```
 
 ### Running the tests
 To run the tests, you can use the `make` command:
-```bash
-make test
+```console
+$ make test
 ```
 
 You can also run specific tests with:
-```bash
-make test-pkg-${package_name}
+```console
+$ make test-pkg-${package_name}
 ```
 
 ## Go environment
@@ -50,29 +50,29 @@ The Jumpstarter controller lives in the
 repository.
 
 To install the basic set of dependencies, run the following commands:
-```bash
-sudo dnf install -y git make golang kubectl
+```console
+$ sudo dnf install -y git make golang kubectl
 ```
 
 Then you can clone the project and build the project with:
-```bash
-git clone https://github.com/jumpstarter-dev/jumpstarter-controller.git
-cd jumpstarter-controller
-make build
+```console
+$ git clone https://github.com/jumpstarter-dev/jumpstarter-controller.git
+$ cd jumpstarter-controller
+$ make build
 ```
 
 At this point you can deploy the controller in a kubernetes cluster in docker (`kind`) with:
-```bash
-CONTAINER_TOOL=podman make deploy
+```console
+$ CONTAINER_TOOL=podman make deploy
 ```
 
 And you can cleanup and stop the controller/cluster with:
-```bash
-CONTAINER_TOOL=podman make clean
+```console
+$ CONTAINER_TOOL=podman make clean
 ```
 
 ### Running the tests
 To run the tests, you can use the `make` command:
-```bash
-make test
+```console
+$ make test
 ```

--- a/docs/source/getting-started/configuration/authentication.md
+++ b/docs/source/getting-started/configuration/authentication.md
@@ -45,13 +45,13 @@ Note, the HTTPS URL is mandatory, and you only need to include certificateAuthor
 3. Create clients and exporters with the `jmp admin create` commands. Be sure to
    prefix usernames with `keycloak:` as configured in the claim mappings:
 
-```shell
+```console
 $ jmp admin create client test-client --insecure-tls-config --oidc-username keycloak:developer-1
 ```
 
 4. Instruct users to log in with:
 
-```shell
+```console
 $ jmp login --client <client alias> \
     --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
@@ -61,7 +61,7 @@ $ jmp login --client <client alias> \
 
 For non-interactive login, add username and password:
 
-```shell
+```console
 $ jmp login --client <client alias> [other parameters] \
     --insecure-tls-config \
     --username <username> \
@@ -70,13 +70,13 @@ $ jmp login --client <client alias> [other parameters] \
 
 For machine-to-machine authentication (useful in CI environments), use a token:
 
-```shell
+```console
 $ jmp login --client <client alias> [other parameters] --token <token>
 ```
 
 For exporters, use similar login command but with the `--exporter` flag:
 
-```shell
+```console
 $ jmp login --exporter <exporter alias> \
     --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
@@ -90,7 +90,7 @@ Follow these steps to set up Dex for service account authentication:
 
 1. Initialize a self-signed CA and sign certificate for Dex:
 
-```shell
+```console
 $ easyrsa init-pki
 $ easyrsa --no-pass build-ca
 $ easyrsa --no-pass build-server-full dex.dex.svc.cluster.local
@@ -98,7 +98,7 @@ $ easyrsa --no-pass build-server-full dex.dex.svc.cluster.local
 
 Then import the certificate into a Kubernetes secret:
 
-```shell
+```console
 $ kubectl create namespace dex
 $ kubectl -n dex create secret tls dex-tls \
     --cert=pki/issued/dex.dex.svc.cluster.local.crt \
@@ -153,7 +153,7 @@ service:
 
 Ensure OIDC discovery URLs do not require authentication:
 
-```shell
+```console
 $ kubectl create clusterrolebinding oidc-reviewer  \
     --clusterrole=system:service-account-issuer-discovery \
     --group=system:unauthenticated
@@ -161,7 +161,7 @@ $ kubectl create clusterrolebinding oidc-reviewer  \
 
 Then install Dex:
 
-```shell
+```console
 $ helm repo add dex https://charts.dexidp.io
 $ helm install --namespace dex --wait -f values.yaml dex dex/dex
 ```
@@ -189,7 +189,7 @@ jwt:
 4. Create clients and exporters with appropriate OIDC usernames. Prefix the full
    service account name with "dex:" as configured in the claim mappings.:
 
-```shell
+```console
 $ jmp admin create exporter test-exporter --label foo=bar \
     --insecure-tls-config \
     --oidc-username dex:system:serviceaccount:default:test-service-account
@@ -199,7 +199,7 @@ $ jmp admin create exporter test-exporter --label foo=bar \
 
 For clients:
 
-```shell
+```console
 $ jmp login --client <client alias> \
     --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \
@@ -211,7 +211,7 @@ $ jmp login --client <client alias> \
 
 For exporters:
 
-```shell
+```console
 $ jmp login --exporter <exporter alias> \
     --insecure-tls-config \
     --endpoint <jumpstarter controller endpoint> \

--- a/docs/source/getting-started/configuration/files.md
+++ b/docs/source/getting-started/configuration/files.md
@@ -59,11 +59,11 @@ drivers:
 - `JUMPSTARTER_FORCE_SYSTEM_CERTS` - Set to `1` to force system CA certificates
 
 **CLI Commands**:
-```shell
-jmp config client create <name>  # Create new client config
-jmp config client use <name>     # Switch to a different client
-jmp config client list           # List available clients
-jmp config client delete <name>  # Remove a client config
+```console
+$ jmp config client create <name>  # Create new client config
+$ jmp config client use <name>     # Switch to a different client
+$ jmp config client list           # List available clients
+$ jmp config client delete <name>  # Remove a client config
 ```
 
 ## Exporter Configuration
@@ -108,22 +108,22 @@ export:
 - `JMP_NAME` - Exporter name
 
 **CLI Commands**:
-```shell
-jmp config exporter create <name>   # Create new exporter config
-jmp config exporter list            # List available exporters
-jmp config exporter delete <name>   # Remove an exporter config
+```console
+$ jmp config exporter create <name>   # Create new exporter config
+$ jmp config exporter list            # List available exporters
+$ jmp config exporter delete <name>   # Remove an exporter config
 ```
 
 ## Running Exporters
 
 Exporters can be run manually or as system services:
 
-```shell
+```console
 # Run with specific exporter config
-jmp run --exporter my-exporter
+$ jmp run --exporter my-exporter
 
 # Or specify a config path directly
-jmp run --exporter-config /etc/jumpstarter/exporters/my-exporter.yaml
+$ jmp run --exporter-config /etc/jumpstarter/exporters/my-exporter.yaml
 ```
 
 For persistent operation, exporters can be installed as systemd services using
@@ -152,7 +152,7 @@ WantedBy=multi-user.target default.target
 
 Then enable and start the service:
 
-```shell
-sudo systemctl daemon-reload
-sudo systemctl enable --now my-exporter
+```console
+$ sudo systemctl daemon-reload
+$ sudo systemctl enable --now my-exporter
 ```

--- a/docs/source/getting-started/configuration/loading-order.md
+++ b/docs/source/getting-started/configuration/loading-order.md
@@ -48,13 +48,13 @@ Here's a practical example of how configuration overrides work:
 
 2. You set an environment variable in your terminal:
 
-   ```shell
+   ```console
    $ export JMP_ENDPOINT="jumpstarter2.my-lab.com:1443"
    ```
 
 3. You run a command with an explicit endpoint argument:
 
-   ```shell
+   ```console
    $ jmp --endpoint jumpstarter3.my-lab.com:1443 info
    ```
 

--- a/docs/source/getting-started/installation/packages.md
+++ b/docs/source/getting-started/installation/packages.md
@@ -20,7 +20,7 @@ tools you need to run an exporter or interact with your hardware as a client.
 Install the Python package using `pip` or a similar tool. You need Python
 {{requires_python}}:
 
-```{code-block} shell
+```{code-block} console
 :substitutions:
 $ pip3 install --extra-index-url {{index_url}} jumpstarter-all
 $ mkdir -p "${HOME}/.config/jumpstarter/"
@@ -30,7 +30,7 @@ $ sudo mkdir /etc/jumpstarter
 The command above installs packages globally. For library usage, we recommend
 installing in a virtual environment instead:
 
-```{code-block} shell
+```{code-block} console
 :substitutions:
 $ python3 -m venv ~/.venv/jumpstarter
 $ source ~/.venv/jumpstarter/bin/activate
@@ -51,7 +51,7 @@ Jumpstarter undergoes active development with frequent feature additions. We
 conduct thorough testing and recommend installing the latest version from the
 `main` branch.
 
-```shell
+```console
 $ sudo dnf install -y uv make git
 $ git clone https://github.com/jumpstarter-dev/jumpstarter.git
 $ cd jumpstarter
@@ -63,7 +63,7 @@ $ sudo mkdir /etc/jumpstarter
 
 Activate the virtual environment to use Jumpstarter CLI commands:
 
-```shell
+```console
 $ source .venv/bin/activate
 $ jmp version
 ```
@@ -75,7 +75,7 @@ instead. To interact with the service without local Python package installation,
 create an alias to run the `jmp` client in a container. We recommend adding this
 alias to your shell profile for persistent use:
 
-```{code-block} shell
+```{code-block} console
 :substitutions:
 $ alias jmp='podman run --rm -it -w /home \
     -v "$(pwd):/home":z \
@@ -88,7 +88,7 @@ When you need hardware access for running the `jmp` command or following the
 container with device access, host networking, and privileged mode. This
 typically requires `root` privileges:
 
-```{code-block} shell
+```{code-block} console
 :substitutions:
 $ mkdir -p "${HOME}/.config/jumpstarter/" /etc/jumpstarter
 $ alias jmp='podman run --rm -it \
@@ -100,6 +100,6 @@ $ alias jmp='podman run --rm -it \
 
 If you've configured a `jmp` alias you can undefine it with:
 
-```shell
+```console
 $ unalias jmp
 ```

--- a/docs/source/getting-started/installation/service.md
+++ b/docs/source/getting-started/installation/service.md
@@ -20,7 +20,7 @@ Jumpstarter environment. Before installing, ensure you have:
 
 Install Jumpstarter on a standard Kubernetes cluster using Helm:
 
-```{code-block} bash
+```{code-block} console
 :substitutions:
 $ helm upgrade jumpstarter --install oci://quay.io/jumpstarter-dev/helm/jumpstarter \
         --create-namespace --namespace jumpstarter-lab \
@@ -34,7 +34,7 @@ $ helm upgrade jumpstarter --install oci://quay.io/jumpstarter-dev/helm/jumpstar
 
 Install Jumpstarter on an OpenShift cluster using Helm:
 
-```{code-block} bash
+```{code-block} console
 :substitutions:
 $ helm upgrade jumpstarter --install oci://quay.io/jumpstarter-dev/helm/jumpstarter \
           --create-namespace --namespace jumpstarter-lab \
@@ -48,7 +48,7 @@ $ helm upgrade jumpstarter --install oci://quay.io/jumpstarter-dev/helm/jumpstar
 
 First, create and label a namespace for Jumpstarter:
 
-```shell
+```console
 $ kubectl create namespace jumpstarter-lab
 $ kubectl label namespace jumpstarter-lab argocd.argoproj.io/managed-by=openshift-gitops
 ```
@@ -140,7 +140,7 @@ website](https://minikube.sigs.k8s.io/docs/start/).
 
 Expand the default NodePort range to include the Jumpstarter ports:
 
-```shell
+```console
 $ minikube start --extra-config=apiserver.service-node-port-range=8000-9000
 ```
 
@@ -151,7 +151,7 @@ your Kubernetes cluster.
 
 Use the minikube IP address when installing with the CLI:
 
-```shell
+```console
 $ jmp admin install --ip $(minikube ip)
 ```
 
@@ -162,7 +162,7 @@ options, see the [MAN pages](../../reference/man-pages/jmp.md).
 
 For manual installation with Helm, use these commands:
 
-```{code-block} shell
+```{code-block} console
 :substitutions:
 $ export IP=$(minikube ip)
 $ export BASEDOMAIN="jumpstarter.${IP}.nip.io"
@@ -234,7 +234,7 @@ nodes:
 
 Next, create a kind cluster using the config you created:
 
-```shell
+```console
 $ kind create cluster --config kind_config.yaml
 ```
 
@@ -246,7 +246,7 @@ cluster.
 
 Install Jumpstarter with default options:
 
-```shell
+```console
 $ jmp admin install
 ```
 
@@ -257,7 +257,7 @@ options, see the [MAN pages](../../reference/man-pages/jmp.md).
 
 If you prefer manual installation with Helm, use the following commands:
 
-```{code-block} bash
+```{code-block} console
 :substitutions:
 $ export IP="X.X.X.X"
 $ export BASEDOMAIN="jumpstarter.${IP}.nip.io"

--- a/docs/source/getting-started/usage/examples.md
+++ b/docs/source/getting-started/usage/examples.md
@@ -6,17 +6,17 @@ distributed modes. Each example demonstrates how to accomplish common tasks.
 ## Starting and Exiting a Session
 
 Start a local exporter session:
-```shell
+```console
 $ jmp shell --exporter example-local
 ```
 
 Start a distributed exporter session:
-```shell
+```console
 $ jmp shell --client hello --selector example.com/board=foo
 ```
 
 When finished, simply exit the shell:
-```shell
+```console
 $ exit
 ```
 
@@ -25,7 +25,7 @@ $ exit
 The exporter shell provides access to driver CLI interfaces through the magic
 `j` command:
 
-```shell
+```console
 $ jmp shell # Use appropriate --exporter or --client parameters
 $ j
 Usage: j [OPTIONS] COMMAND [ARGS]...
@@ -77,7 +77,7 @@ with env() as client:
    client.power.off()
 ```
 
-```shell
+```console
 $ jmp shell # Use appropriate --exporter or --client parameters
 $ python ./example.py
 $ exit
@@ -121,7 +121,7 @@ class MyTest(JumpstarterTest):
       client.power.off()
 ```
 
-```shell
+```console
 $ jmp shell # Use appropriate --exporter or --client parameters
 $ pytest ./example_test.py
 $ exit

--- a/docs/source/getting-started/usage/setup-distributed-mode.md
+++ b/docs/source/getting-started/usage/setup-distributed-mode.md
@@ -39,7 +39,7 @@ provides commands to interact with the controller directly.
 Run this command to create an exporter named `example-distributed` and save the
 configuration locally:
 
-```shell
+```console
 $ jmp admin create exporter example-distributed --label foo=bar --save --insecure-tls-config
 ```
 
@@ -47,7 +47,7 @@ After creating the exporter, find the new configuration file at
 `/etc/jumpstarter/exporters/example-distributed.yaml`. Edit the configuration
 using your default text editor with:
 
-```shell
+```console
 $ jmp config exporter edit example-distributed
 ```
 
@@ -73,7 +73,7 @@ export:
 
 Start the exporter locally using the `jmp` CLI tool:
 
-```shell
+```console
 $ jmp run --exporter example-distributed
 ```
 
@@ -87,7 +87,7 @@ The following command creates a client named "hello", enables unsafe drivers for
 development purposes, and saves the configuration locally in
 `${HOME}/.config/jumpstarter/clients/`:
 
-```shell
+```console
 $ jmp admin create client hello --save --unsafe --insecure-tls-config
 ```
 
@@ -98,7 +98,7 @@ in the `jmp` CLI. When you spawn a shell, the client attempts to acquire a lease
 on an exporter. Once the lease is acquired, you can interact with the exporter
 through your shell session.
 
-```shell
+```console
 $ jmp shell --client hello --selector example.com/board=foo
 ```
 
@@ -106,7 +106,7 @@ $ jmp shell --client hello --selector example.com/board=foo
 
 To terminate the local exporter, simply exit the shell:
 
-```shell
+```console
 $ exit
 ```
 

--- a/docs/source/getting-started/usage/setup-local-mode.md
+++ b/docs/source/getting-started/usage/setup-local-mode.md
@@ -47,7 +47,7 @@ Interact with your local exporter using the "exporter shell" functionality in
 the `jmp` CLI. When you spawn a shell, Jumpstarter runs a local exporter
 instance in the background for the duration of your shell session.
 
-```shell
+```console
 $ jmp shell --exporter example-local
 ```
 
@@ -55,7 +55,7 @@ $ jmp shell --exporter example-local
 
 To terminate the local exporter, simply exit the shell:
 
-```shell
+```console
 $ exit
 ```
 

--- a/docs/source/introduction/exporters.md
+++ b/docs/source/introduction/exporters.md
@@ -68,7 +68,7 @@ current Python environment.
 
 You can run the exporter in your local terminal with:
 
-```shell
+```console
 $ jmp run --exporter myexporter
 ```
 

--- a/docs/source/introduction/index.md
+++ b/docs/source/introduction/index.md
@@ -89,7 +89,7 @@ or other infrastructure. Developers can work with devices on their desk, develop
 drivers, create automation scripts, and test with QEMU or other virtualization
 tools.
 
-```shell
+```console
 $ jmp shell --exporter my-exporter
 $ pytest test_device.py
 ```
@@ -176,7 +176,7 @@ credentials, ensuring proper resource isolation in shared testing environments.
 
 The following example shows how to run tests in distributed mode:
 
-```shell
+```console
 $ jmp config client use my-client
 $ jmp create lease --selector vendor=acme,model=widget-v2
 $ pytest test_device.py

--- a/docs/source/reference/man-pages/j.md
+++ b/docs/source/reference/man-pages/j.md
@@ -6,8 +6,8 @@ exporter.
 
 Usage:
 
-```shell
-j [OPTIONS] COMMAND [ARGS]...
+```console
+$ j [OPTIONS] COMMAND [ARGS]...
 ```
 
 The available commands depend on which drivers are loaded in your current


### PR DESCRIPTION
This improves the rendering of the shell prompt (`$`) and prevents it from being selected when copying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all shell command code blocks in the documentation to use the `console` language identifier for improved syntax highlighting.
  - Added a leading `$` prompt to shell command examples for clarity and consistency.
  - Minor formatting improvements, including adding missing newlines at the end of some files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->