### PR TITLE
Inject truststore earlier

### DIFF
--- a/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
+++ b/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
@@ -1,25 +1,16 @@
 import json
-import os
 from dataclasses import dataclass
 from functools import wraps
 from typing import ClassVar
 
 import aiohttp
 import click
-import truststore
 from aiohttp import web
 from anyio import create_memory_object_stream
 from anyio.to_thread import run_sync
 from authlib.integrations.requests_client import OAuth2Session
 from joserfc.jws import extract_compact
 from yarl import URL
-
-# if we are running in MacOS avoid injecting system certificates to avoid
-# https://github.com/jumpstarter-dev/jumpstarter/issues/362
-# also allow to force the system certificates injection with
-# JUMPSTARTER_FORCE_SYSTEM_CERTS=1
-if os.uname().sysname != "Darwin" or os.environ.get("JUMPSTARTER_FORCE_SYSTEM_CERTS") == "1":
-    truststore.inject_into_ssl()
 
 
 def opt_oidc(f):

--- a/packages/jumpstarter-cli/jumpstarter_cli/__init__.py
+++ b/packages/jumpstarter-cli/jumpstarter_cli/__init__.py
@@ -1,0 +1,10 @@
+import os
+
+import truststore
+
+# if we are running in MacOS avoid injecting system certificates to avoid
+# https://github.com/jumpstarter-dev/jumpstarter/issues/362
+# also allow to force the system certificates injection with
+# JUMPSTARTER_FORCE_SYSTEM_CERTS=1
+if os.uname().sysname != "Darwin" or os.environ.get("JUMPSTARTER_FORCE_SYSTEM_CERTS") == "1":
+    truststore.inject_into_ssl()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SSL certificates to avoid issues on macOS by skipping system certificate injection by default, with an option to override this behavior using an environment variable.

- **Chores**
  - Updated internal logic to manage SSL certificate injection at a different stage, ensuring more reliable platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->