### PR TITLE
Make endpoint and token optional in exporter/client config

### DIFF
--- a/docs/source/getting-started/usage/setup-local-mode.md
+++ b/docs/source/getting-started/usage/setup-local-mode.md
@@ -21,7 +21,7 @@ connection between an exporter and client without physical hardware.
 
 Create an exporter configuration named `example-local` to define the
 capabilities of your local test exporter. This configuration mirrors a regular
-exporter config but leaves the `endpoint` and `token` fields empty since you
+exporter config but without the `endpoint` and `token` fields since you
 don't need to connect to the controller service.
 
 Create `example-local.yaml` in `/etc/jumpstarter/exporters` with this content:
@@ -32,8 +32,6 @@ kind: ExporterConfig
 metadata:
   namespace: default
   name: example-local
-endpoint: ""
-token: ""
 export:
   storage:
     type: jumpstarter_driver_opendal.driver.MockStorageMux

--- a/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -75,7 +75,7 @@ def test_client_config_from_env_allow_unsafe(monkeypatch: pytest.MonkeyPatch):
     assert config.drivers.unsafe is True
 
 
-@pytest.mark.parametrize("missing_field", [JMP_TOKEN, JMP_ENDPOINT])
+@pytest.mark.parametrize("missing_field", [JMP_NAMESPACE, JMP_NAME])
 def test_client_config_from_env_missing_field_raises(monkeypatch: pytest.MonkeyPatch, missing_field):
     monkeypatch.setenv(JMP_NAMESPACE, "default")
     monkeypatch.setenv(JMP_NAME, "testclient")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for configuring local exporter mode, specifying that certain fields should be omitted rather than left empty in example configurations.

- **Bug Fixes**
  - Improved validation for configuration fields, ensuring errors are raised if required fields are missing or unset.

- **Refactor**
  - Updated configuration options to allow certain fields to be optional, enhancing flexibility in setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->