### PR TITLE
use lgpio directly for GPIO

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -45,6 +45,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-arm qemu-system-x86
 
+      - name: Install libgpiod-dev (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgpiod-dev liblgpio-dev
+
       - name: Install Qemu (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/packages/jumpstarter-driver-raspberrypi/jumpstarter_driver_raspberrypi/conftest.py
+++ b/packages/jumpstarter-driver-raspberrypi/jumpstarter_driver_raspberrypi/conftest.py
@@ -1,0 +1,39 @@
+import sys
+from unittest.mock import MagicMock
+
+
+def pytest_configure(config):
+    mock_lgpio = MagicMock()
+    mock_lgpio.SET_OPEN_DRAIN = 4
+    mock_lgpio._pin_state = {}
+
+    def mock_gpiochip_open(chip_num):
+        return 0
+
+    def mock_gpiochip_close(handle):
+        pass
+
+    def mock_gpio_claim_output(handle, pin, initial_value, flags=0):
+        pass
+
+    def mock_gpio_claim_input(handle, pin):
+        pass
+
+    def mock_gpio_free(handle, pin):
+        if (handle, pin) in mock_lgpio._pin_state:
+            del mock_lgpio._pin_state[(handle, pin)]
+
+    def mock_gpio_read(handle, pin):
+        return mock_lgpio._pin_state.get((handle, pin), 0)
+
+    def mock_gpio_write(handle, pin, value):
+        mock_lgpio._pin_state[(handle, pin)] = value
+
+    mock_lgpio.gpiochip_open = mock_gpiochip_open
+    mock_lgpio.gpiochip_close = mock_gpiochip_close
+    mock_lgpio.gpio_claim_output = mock_gpio_claim_output
+    mock_lgpio.gpio_claim_input = mock_gpio_claim_input
+    mock_lgpio.gpio_free = mock_gpio_free
+    mock_lgpio.gpio_read = mock_gpio_read
+    mock_lgpio.gpio_write = mock_gpio_write
+    sys.modules["lgpio"] = mock_lgpio

--- a/packages/jumpstarter-driver-raspberrypi/jumpstarter_driver_raspberrypi/driver.py
+++ b/packages/jumpstarter-driver-raspberrypi/jumpstarter_driver_raspberrypi/driver.py
@@ -1,63 +1,134 @@
+from __future__ import annotations
+
+import time
 from dataclasses import dataclass, field
 
-from gpiozero import DigitalInputDevice, DigitalOutputDevice, InputDevice
+try:
+    import lgpio  # type: ignore[import-not-found]
+except ImportError as err:
+    raise ImportError("lgpio is not installed, lgpio might not be supported on your platform") from err
+
+from jumpstarter_driver_power.driver import PowerInterface
 
 from jumpstarter.driver import Driver, export
 
 
 @dataclass(kw_only=True)
-class DigitalOutput(Driver):
+class _GPIOBase(Driver):
+    """Base GPIO"""
+
+    pin: int
+    _h: int = field(init=False, repr=False)
+
+    _CHIP_NUM: int = 0
+
+    def __post_init__(self):
+        self.pin = int(str(self.pin).lstrip("GPIO"))
+        self._h = lgpio.gpiochip_open(self._CHIP_NUM)
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+
+    def close(self):
+        try:
+            lgpio.gpio_free(self._h, self.pin)
+            lgpio.gpiochip_close(self._h)
+        except Exception:
+            pass
+        super().close()
+
+    @export
+    def read_pin(self) -> int:
+        """Read current pin state"""
+        return lgpio.gpio_read(self._h, self.pin)
+
+
+@dataclass(kw_only=True)
+class DigitalOutput(_GPIOBase):
+    """Single GPIO output"""
+
     pin: int | str
-    device: InputDevice = field(init=False)  # Start as input
+    open_drain: bool = True
 
     @classmethod
     def client(cls) -> str:
         return "jumpstarter_driver_raspberrypi.client.DigitalOutputClient"
 
     def __post_init__(self):
-        if hasattr(super(), "__post_init__"):
-            super().__post_init__()
-        # Initialize as InputDevice first
-        self.device = InputDevice(pin=self.pin)
+        super().__post_init__()
 
-    def close(self):
-        if hasattr(self, "device"):
-            self.device.close()
-        super().close()
+        if self.open_drain:
+            lgpio.gpio_claim_output(self._h, self.pin, 1, lgpio.SET_OPEN_DRAIN)
+        else:
+            lgpio.gpio_claim_output(self._h, self.pin, 0)
 
     @export
     def off(self) -> None:
-        if not isinstance(self.device, DigitalOutputDevice):
-            self.device.close()
-            self.device = DigitalOutputDevice(pin=self.pin, initial_value=None)
-        self.device.off()
+        """Drive the pin low"""
+        lgpio.gpio_write(self._h, self.pin, 0)
+        self.logger.info(f"GPIO{self.pin} off() -> pin reads: {self.read_pin()}")
 
     @export
     def on(self) -> None:
-        if not isinstance(self.device, DigitalOutputDevice):
-            self.device.close()
-            self.device = DigitalOutputDevice(pin=self.pin, initial_value=None)
-        self.device.on()
+        """Release (open-drain) or drive high"""
+        lgpio.gpio_write(self._h, self.pin, 1)
+        self.logger.info(f"GPIO{self.pin} on() -> pin reads: {self.read_pin()}")
 
 
 @dataclass(kw_only=True)
-class DigitalInput(Driver):
+class DigitalInput(_GPIOBase):
+    """Simple GPIO input"""
+
     pin: int | str
-    device: DigitalInputDevice = field(init=False)
 
     @classmethod
     def client(cls) -> str:
         return "jumpstarter_driver_raspberrypi.client.DigitalInputClient"
 
     def __post_init__(self):
-        if hasattr(super(), "__post_init__"):
-            super().__post_init__()
-        self.device = DigitalInputDevice(pin=self.pin)
+        super().__post_init__()
+        lgpio.gpio_claim_input(self._h, self.pin)
 
     @export
     def wait_for_active(self, timeout: float | None = None):
-        self.device.wait_for_active(timeout)
+        """Block until the line reads high"""
+
+        self._wait_for(level=1, timeout=timeout)
 
     @export
     def wait_for_inactive(self, timeout: float | None = None):
-        self.device.wait_for_inactive(timeout)
+        """Block until the line reads low"""
+
+        self._wait_for(level=0, timeout=timeout)
+
+    def _wait_for(self, *, level: int, timeout: float | None):
+        deadline: float | None = None if timeout is None else time.time() + timeout
+
+        while True:
+            if lgpio.gpio_read(self._h, self.pin) == level:
+                return
+
+            if deadline is not None and time.time() >= deadline:
+                raise TimeoutError(f"Timed out waiting for GPIO{self.pin} to reach level {level}")
+
+            time.sleep(0.001)
+
+
+@dataclass(kw_only=True)
+class PowerSwitch(PowerInterface, DigitalOutput):
+    open_drain: bool = False
+
+    @export
+    def on(self) -> None:
+        """Switch on the power"""
+
+        DigitalOutput.on(self)
+
+    @export
+    def off(self) -> None:
+        """Switch off the power"""
+
+        DigitalOutput.off(self)
+
+    @export
+    def read(self):
+        return self.read_pin()

--- a/packages/jumpstarter-driver-raspberrypi/jumpstarter_driver_raspberrypi/driver_test.py
+++ b/packages/jumpstarter-driver-raspberrypi/jumpstarter_driver_raspberrypi/driver_test.py
@@ -1,46 +1,66 @@
 from concurrent.futures import ThreadPoolExecutor
 
-from gpiozero import Device
-from gpiozero.pins.mock import MockFactory
-
-from jumpstarter_driver_raspberrypi.driver import DigitalInput, DigitalOutput
+from jumpstarter_driver_raspberrypi.driver import DigitalInput, DigitalOutput, PowerSwitch, lgpio
 
 from jumpstarter.common.utils import serve
 
-Device.pin_factory = MockFactory()
+
+def _pin_state(handle: int, pin: int) -> int:
+    """Helper to fetch a pin's logic level from the lgpio"""
+
+    return lgpio._pin_state.get((handle, pin), 0)  # type: ignore[attr-defined]
 
 
 def test_drivers_gpio_digital_output():
-    pin_factory = MockFactory()
-    Device.pin_factory = pin_factory
     pin_number = 1
-    mock_pin = pin_factory.pin(pin_number)
-
     instance = DigitalOutput(pin=pin_number)
 
-    assert not mock_pin.state
+    assert _pin_state(0, pin_number) == 0
 
     with serve(instance) as client:
-        client.off()
-        assert not mock_pin.state
+        client.off()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 0
 
-        client.on()
-        assert mock_pin.state
+        client.on()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 1
 
-        client.off()
-        assert not mock_pin.state
-
-    mock_pin.assert_states([False, True, False])
+        client.off()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 0
 
 
 def test_drivers_gpio_digital_input():
-    instance = DigitalInput(pin=4)
+    pin_number = 4
+    instance = DigitalInput(pin=pin_number)
+
+    lgpio._pin_state[(0, pin_number)] = 0  # type: ignore[attr-defined]
 
     with serve(instance) as client:
         with ThreadPoolExecutor() as pool:
-            pool.submit(client.wait_for_active)
-            instance.device.pin.drive_high()
+            fut = pool.submit(client.wait_for_active, timeout=1.0)  # type: ignore[attr-defined]
+            lgpio._pin_state[(0, pin_number)] = 1  # type: ignore[attr-defined]
+            fut.result(timeout=1.5)
 
         with ThreadPoolExecutor() as pool:
-            pool.submit(client.wait_for_inactive)
-            instance.device.pin.drive_low()
+            fut = pool.submit(client.wait_for_inactive, timeout=1.0)  # type: ignore[attr-defined]
+            lgpio._pin_state[(0, pin_number)] = 0  # type: ignore[attr-defined]
+            fut.result(timeout=1.5)
+
+
+def test_drivers_gpio_power_switch_open_drain():
+    pin_number = 2
+    instance = PowerSwitch(pin=pin_number, open_drain=True)
+
+    assert _pin_state(0, pin_number) == 0
+
+    with serve(instance) as client:
+        client.off()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 0
+
+        client.on()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 1
+
+        client.off()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 0
+
+        client.cycle()  # type: ignore[attr-defined]
+        assert _pin_state(0, pin_number) == 1

--- a/packages/jumpstarter-driver-raspberrypi/pyproject.toml
+++ b/packages/jumpstarter-driver-raspberrypi/pyproject.toml
@@ -10,11 +10,12 @@ authors = [
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["jumpstarter", "jumpstarter-driver-power", "gpiozero>=2.0.1", "click>=8.1.7.2"]
+dependencies = ["jumpstarter", "jumpstarter-driver-power", "click>=8.1.7.2", "lgpio; platform_system == 'Linux'"]
 
 [project.entry-points."jumpstarter.drivers"]
 DigitalInput = "jumpstarter_driver_raspberrypi.driver:DigitalInput"
 DigitalOutput = "jumpstarter_driver_raspberrypi.driver:DigitalOutput"
+PowerSwitch = "jumpstarter_driver_raspberrypi.driver:PowerSwitch"
 
 [dependency-groups]
 dev = ["pytest>=8.3.2", "pytest-cov>=5.0.0"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new PowerSwitch driver for Raspberry Pi GPIO control, supporting open-drain mode and direct pin state reading.

* **Bug Fixes**
  * Improved GPIO input handling with more reliable state polling and timeouts.

* **Chores**
  * Updated dependencies to use lgpio instead of gpiozero for GPIO operations.
  * Enhanced test suite to better simulate GPIO hardware and cover new driver features.
  * Updated workflow to install required development libraries for GPIO support on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->