### PR TITLE
Stream exporter logs in jmp shell

### DIFF
--- a/packages/jumpstarter-cli/jumpstarter_cli/j.py
+++ b/packages/jumpstarter-cli/jumpstarter_cli/j.py
@@ -19,8 +19,7 @@ async def j_async():
         async with BlockingPortal() as portal:
             with ExitStack() as stack:
                 async with env_async(portal, stack) as client:
-                    async with client.log_stream_async():
-                        await to_thread.run_sync(lambda: client.cli()(standalone_mode=False))
+                    await to_thread.run_sync(lambda: client.cli()(standalone_mode=False))
 
     try:
         async with create_task_group() as tg:

--- a/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -20,9 +20,10 @@ from jumpstarter.config.exporter import ExporterConfigV1Alpha1
 @click.option("--lease", "lease_name")
 @opt_selector
 @opt_duration_partial(default=timedelta(minutes=30), show_default="00:30:00")
+@click.option("--exporter-logs", is_flag=True, help="Enable exporter log streaming")
 # end client specific
 @handle_exceptions_with_reauthentication(relogin_client)
-def shell(config, command: tuple[str, ...], lease_name, selector, duration):
+def shell(config, command: tuple[str, ...], lease_name, selector, duration, exporter_logs):
     """
     Spawns a shell (or custom command) connecting to a local or remote exporter
 
@@ -42,13 +43,24 @@ def shell(config, command: tuple[str, ...], lease_name, selector, duration):
             with config.lease(selector=selector, lease_name=lease_name, duration=duration) as lease:
                 with lease.serve_unix() as path:
                     with lease.monitor():
-                        exit_code = launch_shell(
-                            path,
-                            "remote",
-                            config.drivers.allow,
-                            config.drivers.unsafe,
-                            command=command,
-                        )
+                        if exporter_logs:
+                            with lease.connect() as client:
+                                with client.log_stream():
+                                    exit_code = launch_shell(
+                                        path,
+                                        "remote",
+                                        config.drivers.allow,
+                                        config.drivers.unsafe,
+                                        command=command,
+                                    )
+                        else:
+                            exit_code = launch_shell(
+                                path,
+                                "remote",
+                                config.drivers.allow,
+                                config.drivers.unsafe,
+                                command=command,
+                            )
 
             sys.exit(exit_code)
 


### PR DESCRIPTION
It's not enabled by default, now it requires the --exporter-logs flag, otherwise it becomes too annoying, for example when doing a serial console session or other activities.

Fixes-Issue: #554 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line option to stream exporter logs during shell sessions.

* **Bug Fixes**
  * Improved handling of log streaming to ensure compatibility with synchronous and asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->