### PR TITLE
flashers: fallback to request for metadata request

### DIFF
--- a/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/bundle.py
+++ b/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/bundle.py
@@ -9,14 +9,17 @@ class FileAddress(BaseModel):
     file: str
     address: str
 
+
 class DtbVariant(BaseModel):
     bootcmd: None | str = None
     file: None | str = None
+
 
 class Dtb(BaseModel):
     default: str
     address: str
     variants: dict[str, DtbVariant]
+
 
 class FlasherLogin(BaseModel):
     login_prompt: str

--- a/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver.py
+++ b/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver.py
@@ -113,8 +113,7 @@ class BaseFlasher(Driver):
             if manifest.spec.dtb:
                 variant_list = list(manifest.spec.dtb.variants.keys())
             raise ValueError(
-                f"DTB variant {variant} not found in the flasher bundle, "
-                f"available variants are: {variant_list}."
+                f"DTB variant {variant} not found in the flasher bundle, available variants are: {variant_list}."
             )
         self.variant = variant
 
@@ -221,6 +220,7 @@ class BaseFlasher(Driver):
         """Return the bootcmd"""
         manifest = await self.get_flasher_manifest()
         return manifest.get_boot_cmd(self.variant)
+
 
 @dataclass(kw_only=True)
 class TIJ784S4Flasher(BaseFlasher):

--- a/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver_test.py
+++ b/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver_test.py
@@ -37,6 +37,7 @@ def complete_flasher(temp_dirs):
         },
     )
 
+
 def test_missing_serial(temp_dirs):
     cache, http, tftp = temp_dirs
     with pytest.raises(ConfigurationError):
@@ -140,4 +141,3 @@ def test_drivers_flashers_get_bootcmd_invalid_variant(complete_flasher):
         # Set an invalid variant
         with pytest.raises(DriverInvalidArgument):
             client.call("use_dtb_variant", "noexists")
-


### PR DESCRIPTION
There is currently an issue with custom certificates in opendal, which fails with open/send requests. This patch falls back to using requests to fetch the metadata instead.