### PR TITLE
preserve history from parent shell in zsh

### DIFF
--- a/packages/jumpstarter/jumpstarter/common/utils.py
+++ b/packages/jumpstarter/jumpstarter/common/utils.py
@@ -83,7 +83,7 @@ def launch_shell(
 
         cmd = [shell]
         if not use_profiles:
-            cmd.extend(['--norc','--noprofile'])
+            cmd.extend(["--norc", "--noprofile"])
         process = Popen(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, env=env)
         return process.wait()
 
@@ -109,7 +109,16 @@ def launch_shell(
         env = common_env | {
             "PS1": f"%F{{8}}%1~ %F{{yellow}}⚡%F{{white}}{context} %F{{yellow}}➤%f ",
         }
-        cmd = [shell, "--no-rcs"]
+
+        if "HISTFILE" not in env:
+            env["HISTFILE"] = os.path.join(os.path.expanduser("~"), ".zsh_history")
+
+        cmd = [shell]
+        if not use_profiles:
+            cmd.append("--no-rcs")
+
+        cmd.extend(["-o", "inc_append_history", "-o", "share_history"])
+
         process = Popen(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, env=env)
         return process.wait()
 


### PR DESCRIPTION
fixes #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved zsh shell initialization by enabling incremental and shared history options.
  * Automatically sets the default history file for zsh if not already defined.

* **Style**
  * Updated option formatting for bash shell arguments (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->