### PR TITLE
ridesx: override extracted files

### DIFF
--- a/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
+++ b/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
@@ -66,10 +66,6 @@ class RideSXDriver(Driver):
 
         decompressed_file = compressed_file.parent / decompressed_name
 
-        if decompressed_file.exists():
-            self.logger.info(f"decompressed file already exists: {decompressed_name}")
-            return decompressed_file
-
         self.logger.info(f"decompressing {compressed_file.name} to {decompressed_name}")
 
         decompress_cmd = self._get_decompression_command(compressed_file.name)


### PR DESCRIPTION
it doesn't make sense to skip extraction...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decompression now runs even if a target file already exists, overwriting the output instead of skipping. This reduces instances of stale or corrupted files persisting between runs and improves overall reliability and consistency of extracted data.
  * No changes to configuration or user-facing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->