### PR TITLE
Fix nodeport install in Kind

### DIFF
--- a/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/install.py
+++ b/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/install.py
@@ -55,8 +55,6 @@ async def install_helm_chart(
         args.append("--kube-context")
         args.append(context)
 
-    print("\n".join(args))
-
     # Attempt to install Jumpstarter using Helm
     process = await asyncio.create_subprocess_exec(*args)
     await process.wait()

--- a/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/install.py
+++ b/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/install.py
@@ -21,8 +21,6 @@ async def install_helm_chart(
     context: Optional[str],
     helm: Optional[str] = "helm",
 ):
-    grpc_port = grpc_endpoint.split(":")[1]
-    router_port = router_endpoint.split(":")[1]
     args = [
         helm,
         "upgrade",
@@ -43,10 +41,6 @@ async def install_helm_chart(
         "--set",
         f"jumpstarter-controller.grpc.nodeport.enabled={'true' if mode == 'nodeport' else 'false'}",
         "--set",
-        f"jumpstarter-controller.grpc.nodeport.port={grpc_port}",
-        "--set",
-        f"jumpstarter-controller.grpc.nodeport.routerPort={router_port}",
-        "--set",
         f"jumpstarter-controller.grpc.mode={mode}",
         "--version",
         version,
@@ -60,6 +54,8 @@ async def install_helm_chart(
     if context is not None:
         args.append("--kube-context")
         args.append(context)
+
+    print("\n".join(args))
 
     # Attempt to install Jumpstarter using Helm
     process = await asyncio.create_subprocess_exec(*args)


### PR DESCRIPTION
For some reason, specifying the `jumpstarter-controller.grpc.nodeport.port` and `jumpstarter-controller.grpc.nodeport.routerPort` parameters when installing the Helm chart (version `0.7.0-dev-22-g5cedce7`) breaks the install.

Removed both parameters when calling `jmp admin install`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The installer no longer sets explicit NodePort numbers for controller/router services. Ports now follow chart/cluster defaults, reducing manual configuration during setup.
  * Existing installation options (modes, endpoints, and other settings) remain unchanged.
  * Impact: If you previously depended on fixed NodePort values assigned by the installer, ensure your desired ports are managed via your Kubernetes/Helm configuration or cluster policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->