### PR TITLE
Add pre/post lease hooks

### DIFF
--- a/packages/jumpstarter/jumpstarter/config/exporter.py
+++ b/packages/jumpstarter/jumpstarter/config/exporter.py
@@ -18,6 +18,16 @@ from jumpstarter.common.importlib import import_class
 from jumpstarter.driver import Driver
 
 
+class HookConfigV1Alpha1(BaseModel):
+    """Configuration for lifecycle hooks."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pre_lease: str | None = Field(default=None, alias="preLease")
+    post_lease: str | None = Field(default=None, alias="postLease")
+    timeout: int = Field(default=300, description="Hook execution timeout in seconds")
+
+
 class ExporterConfigV1Alpha1DriverInstanceProxy(BaseModel):
     ref: str
 
@@ -85,6 +95,7 @@ class ExporterConfigV1Alpha1(BaseModel):
     grpcOptions: dict[str, str | int] | None = Field(default_factory=dict)
 
     export: dict[str, ExporterConfigV1Alpha1DriverInstance] = Field(default_factory=dict)
+    hooks: HookConfigV1Alpha1 = Field(default_factory=HookConfigV1Alpha1)
 
     path: Path | None = Field(default=None)
 
@@ -119,7 +130,7 @@ class ExporterConfigV1Alpha1(BaseModel):
 
     @classmethod
     def dump_yaml(self, config: Self) -> str:
-        return yaml.safe_dump(config.model_dump(mode="json", exclude={"alias", "path"}), sort_keys=False)
+        return yaml.safe_dump(config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), sort_keys=False)
 
     @classmethod
     def save(cls, config: Self, path: Optional[str] = None) -> Path:
@@ -130,7 +141,7 @@ class ExporterConfigV1Alpha1(BaseModel):
         else:
             config.path = Path(path)
         with config.path.open(mode="w") as f:
-            yaml.safe_dump(config.model_dump(mode="json", exclude={"alias", "path"}), f, sort_keys=False)
+            yaml.safe_dump(config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), f, sort_keys=False)
         return config.path
 
     @classmethod
@@ -173,6 +184,16 @@ class ExporterConfigV1Alpha1(BaseModel):
             )
             return aio_secure_channel(self.endpoint, credentials, self.grpcOptions)
 
+        # Create hook executor if hooks are configured
+        hook_executor = None
+        if self.hooks.pre_lease or self.hooks.post_lease:
+            from jumpstarter.exporter.hooks import HookExecutor
+
+            hook_executor = HookExecutor(
+                config=self.hooks,
+                device_factory=ExporterConfigV1Alpha1DriverInstance(children=self.export).instantiate,
+            )
+
         exporter = None
         entered = False
         try:
@@ -181,6 +202,7 @@ class ExporterConfigV1Alpha1(BaseModel):
                 device_factory=ExporterConfigV1Alpha1DriverInstance(children=self.export).instantiate,
                 tls=self.tls,
                 grpc_options=self.grpcOptions,
+                hook_executor=hook_executor,
             )
             # Initialize the exporter (registration, etc.)
             await exporter.__aenter__()

--- a/packages/jumpstarter/jumpstarter/config/exporter_test.py
+++ b/packages/jumpstarter/jumpstarter/config/exporter_test.py
@@ -101,3 +101,55 @@ export:
     ExporterConfigV1Alpha1.save(config)
 
     assert config == ExporterConfigV1Alpha1.load("test")
+
+
+def test_exporter_config_with_hooks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", tmp_path)
+
+    path = tmp_path / "test-hooks.yaml"
+
+    text = """apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: test-hooks
+endpoint: "jumpstarter.my-lab.com:1443"
+token: "test-token"
+hooks:
+  preLease: |
+    echo "Pre-lease hook for $LEASE_NAME"
+    j power on
+  postLease: |
+    echo "Post-lease hook for $LEASE_NAME"
+    j power off
+  timeout: 600
+export:
+  power:
+    type: "jumpstarter_driver_power.driver.PduPower"
+"""
+    path.write_text(
+        text,
+        encoding="utf-8",
+    )
+
+    config = ExporterConfigV1Alpha1.load("test-hooks")
+
+    assert config.hooks.pre_lease == 'echo "Pre-lease hook for $LEASE_NAME"\nj power on\n'
+    assert config.hooks.post_lease == 'echo "Post-lease hook for $LEASE_NAME"\nj power off\n'
+    assert config.hooks.timeout == 600
+
+    # Test that it round-trips correctly
+    path.unlink()
+    ExporterConfigV1Alpha1.save(config)
+    reloaded_config = ExporterConfigV1Alpha1.load("test-hooks")
+
+    assert reloaded_config.hooks.pre_lease == config.hooks.pre_lease
+    assert reloaded_config.hooks.post_lease == config.hooks.post_lease
+    assert reloaded_config.hooks.timeout == config.hooks.timeout
+
+    # Test that the YAML uses camelCase
+    yaml_output = ExporterConfigV1Alpha1.dump_yaml(config)
+    assert "preLease:" in yaml_output
+    assert "postLease:" in yaml_output
+    assert "pre_lease:" not in yaml_output
+    assert "post_lease:" not in yaml_output

--- a/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -8,6 +8,7 @@ import grpc
 from anyio import (
     AsyncContextManagerMixin,
     CancelScope,
+    Event,
     connect_unix,
     create_memory_object_stream,
     create_task_group,
@@ -25,6 +26,7 @@ from jumpstarter.common import Metadata
 from jumpstarter.common.streams import connect_router_stream
 from jumpstarter.config.tls import TLSConfigV1Alpha1
 from jumpstarter.driver import Driver
+from jumpstarter.exporter.hooks import HookContext, HookExecutor
 from jumpstarter.exporter.session import Session
 
 logger = logging.getLogger(__name__)
@@ -37,10 +39,13 @@ class Exporter(AsyncContextManagerMixin, Metadata):
     lease_name: str = field(init=False, default="")
     tls: TLSConfigV1Alpha1 = field(default_factory=TLSConfigV1Alpha1)
     grpc_options: dict[str, str] = field(default_factory=dict)
+    hook_executor: HookExecutor | None = field(default=None)
     registered: bool = field(init=False, default=False)
     _stop_requested: bool = field(init=False, default=False)
     _started: bool = field(init=False, default=False)
     _tg: TaskGroup | None = field(init=False, default=None)
+    _current_client_name: str = field(init=False, default="")
+    _pre_lease_ready: Event | None = field(init=False, default=None)
 
     def stop(self, wait_for_lease_exit=False):
         """Signal the exporter to stop.
@@ -49,9 +54,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             wait_for_lease_exit (bool): If True, wait for the current lease to exit before stopping.
         """
 
-        # Stop immediately if not started yet or if immediate stop is requested
         if (not self._started or not wait_for_lease_exit) and self._tg is not None:
-            logger.info("Stopping exporter immediately")
             self._tg.cancel_scope.cancel()
         elif not self._stop_requested:
             self._stop_requested = True
@@ -145,6 +148,12 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
         tg.start_soon(listen)
 
+        # Wait for pre-lease hook to complete before processing connections
+        if self._pre_lease_ready is not None:
+            logger.info("Waiting for pre-lease hook to complete before accepting connections")
+            await self._pre_lease_ready.wait()
+            logger.info("Pre-lease hook completed, now accepting connections")
+
         async with self.session() as path:
             async for request in listen_rx:
                 logger.info("Handling new connection request on lease %s", lease_name)
@@ -187,19 +196,83 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             tg.start_soon(status)
             async for status in status_rx:
                 if self.lease_name != "" and self.lease_name != status.lease_name:
+                    # Post-lease hook for the previous lease
+                    if self.hook_executor and self._current_client_name:
+                        hook_context = HookContext(
+                            lease_name=self.lease_name,
+                            client_name=self._current_client_name,
+                        )
+                        # Shield the post-lease hook from cancellation and await it
+                        with CancelScope(shield=True):
+                            await self.hook_executor.execute_post_lease_hook(hook_context)
+
                     self.lease_name = status.lease_name
                     logger.info("Lease status changed, killing existing connections")
+                    # Reset event for next lease
+                    self._pre_lease_ready = None
                     self.stop()
                     break
+
+                # Check for lease state transitions
+                previous_leased = hasattr(self, "_previous_leased") and self._previous_leased
+                current_leased = status.leased
+
                 self.lease_name = status.lease_name
                 if not self._started and self.lease_name != "":
                     self._started = True
+                    # Create event for pre-lease synchronization
+                    self._pre_lease_ready = Event()
                     tg.start_soon(self.handle, self.lease_name, tg)
-                if status.leased:
+
+                if current_leased:
                     logger.info("Currently leased by %s under %s", status.client_name, status.lease_name)
+                    self._current_client_name = status.client_name
+
+                    # Pre-lease hook when transitioning from unleased to leased
+                    if not previous_leased:
+                        if self.hook_executor:
+                            hook_context = HookContext(
+                                lease_name=status.lease_name,
+                                client_name=status.client_name,
+                            )
+
+                            # Start pre-lease hook asynchronously
+                            async def run_pre_lease_hook():
+                                try:
+                                    await self.hook_executor.execute_pre_lease_hook(hook_context)
+                                    logger.info("Pre-lease hook completed successfully")
+                                except Exception as e:
+                                    logger.error("Pre-lease hook failed: %s", e)
+                                finally:
+                                    # Always set the event to unblock connections
+                                    if self._pre_lease_ready:
+                                        self._pre_lease_ready.set()
+
+                            tg.start_soon(run_pre_lease_hook)
+                        else:
+                            # No hook configured, set event immediately
+                            if self._pre_lease_ready:
+                                self._pre_lease_ready.set()
                 else:
                     logger.info("Currently not leased")
+
+                    # Post-lease hook when transitioning from leased to unleased
+                    if previous_leased and self.hook_executor and self._current_client_name:
+                        hook_context = HookContext(
+                            lease_name=self.lease_name,
+                            client_name=self._current_client_name,
+                        )
+                        # Shield the post-lease hook from cancellation and await it
+                        with CancelScope(shield=True):
+                            await self.hook_executor.execute_post_lease_hook(hook_context)
+
+                    self._current_client_name = ""
+                    # Reset event for next lease
+                    self._pre_lease_ready = None
+
                     if self._stop_requested:
                         self.stop()
                         break
+
+                self._previous_leased = current_leased
         self._tg = None

--- a/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -1,0 +1,141 @@
+"""Lifecycle hooks for Jumpstarter exporters."""
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Callable
+
+from jumpstarter.config.env import JMP_DRIVERS_ALLOW, JUMPSTARTER_HOST
+from jumpstarter.config.exporter import HookConfigV1Alpha1
+from jumpstarter.driver import Driver
+from jumpstarter.exporter.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True)
+class HookContext:
+    """Context information passed to hooks."""
+
+    lease_name: str
+    client_name: str = ""
+    lease_duration: str = ""
+    exporter_name: str = ""
+    exporter_namespace: str = ""
+
+
+@dataclass(kw_only=True)
+class HookExecutor:
+    """Executes lifecycle hooks with access to the j CLI."""
+
+    config: HookConfigV1Alpha1
+    device_factory: Callable[[], Driver]
+    timeout: int = field(init=False)
+
+    def __post_init__(self):
+        self.timeout = self.config.timeout
+
+    @asynccontextmanager
+    async def _create_hook_environment(self, context: HookContext):
+        """Create a local session and Unix socket for j CLI access."""
+        with Session(
+            root_device=self.device_factory(),
+            # Use hook context for metadata
+            labels={
+                "jumpstarter.dev/hook-context": "true",
+                "jumpstarter.dev/lease": context.lease_name,
+            },
+        ) as session:
+            async with session.serve_unix_async() as unix_path:
+                # Create environment variables for the hook
+                hook_env = os.environ.copy()
+                hook_env.update(
+                    {
+                        JUMPSTARTER_HOST: str(unix_path),
+                        JMP_DRIVERS_ALLOW: "UNSAFE",  # Allow all drivers for local access
+                        "LEASE_NAME": context.lease_name,
+                        "CLIENT_NAME": context.client_name,
+                        "LEASE_DURATION": context.lease_duration,
+                        "EXPORTER_NAME": context.exporter_name,
+                        "EXPORTER_NAMESPACE": context.exporter_namespace,
+                    }
+                )
+
+                yield hook_env
+
+    async def _execute_hook(self, command: str, context: HookContext) -> bool:
+        """Execute a single hook command."""
+        if not command or not command.strip():
+            logger.debug("Hook command is empty, skipping")
+            return True
+
+        logger.info("Executing hook: %s", command.strip().split("\n")[0][:100])
+
+        async with self._create_hook_environment(context) as hook_env:
+            try:
+                # Execute the hook command using shell
+                process = await asyncio.create_subprocess_shell(
+                    command,
+                    env=hook_env,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+
+                try:
+                    # Stream output line-by-line for real-time logging
+                    output_lines = []
+
+                    async def read_output():
+                        while True:
+                            line = await process.stdout.readline()
+                            if not line:
+                                break
+                            line_decoded = line.decode().rstrip()
+                            output_lines.append(line_decoded)
+                            logger.info("[Hook Output] %s", line_decoded)
+
+                    # Run output reading and process waiting concurrently with timeout
+                    await asyncio.wait_for(asyncio.gather(read_output(), process.wait()), timeout=self.timeout)
+
+                    if process.returncode == 0:
+                        logger.info("Hook executed successfully")
+                        return True
+                    else:
+                        logger.error("Hook failed with return code %d", process.returncode)
+                        if output_lines:
+                            logger.error("Hook output: %s", "\n".join(output_lines))
+                        return False
+
+                except asyncio.TimeoutError:
+                    logger.error("Hook timed out after %d seconds", self.timeout)
+                    try:
+                        process.terminate()
+                        await asyncio.wait_for(process.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        process.kill()
+                        await process.wait()
+                    return False
+
+            except Exception as e:
+                logger.error("Error executing hook: %s", e, exc_info=True)
+                return False
+
+    async def execute_pre_lease_hook(self, context: HookContext) -> bool:
+        """Execute the pre-lease hook."""
+        if not self.config.pre_lease:
+            logger.debug("No pre-lease hook configured")
+            return True
+
+        logger.info("Executing pre-lease hook for lease %s", context.lease_name)
+        return await self._execute_hook(self.config.pre_lease, context)
+
+    async def execute_post_lease_hook(self, context: HookContext) -> bool:
+        """Execute the post-lease hook."""
+        if not self.config.post_lease:
+            logger.debug("No post-lease hook configured")
+            return True
+
+        logger.info("Executing post-lease hook for lease %s", context.lease_name)
+        return await self._execute_hook(self.config.post_lease, context)

--- a/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -1,0 +1,319 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, call, patch
+
+import pytest
+
+from jumpstarter.config.env import JMP_DRIVERS_ALLOW, JUMPSTARTER_HOST
+from jumpstarter.config.exporter import HookConfigV1Alpha1
+from jumpstarter.driver import Driver
+from jumpstarter.exporter.hooks import HookContext, HookExecutor
+
+pytestmark = pytest.mark.anyio
+
+
+class MockDriver(Driver):
+    @classmethod
+    def client(cls) -> str:
+        return "test.MockClient"
+
+    def close(self):
+        pass
+
+    def reset(self):
+        pass
+
+
+@pytest.fixture
+def mock_device_factory():
+    def factory():
+        return MockDriver()
+
+    return factory
+
+
+@pytest.fixture
+def hook_config():
+    return HookConfigV1Alpha1(
+        pre_lease="echo 'Pre-lease hook executed'",
+        post_lease="echo 'Post-lease hook executed'",
+        timeout=10,
+    )
+
+
+@pytest.fixture
+def hook_context():
+    return HookContext(
+        lease_name="test-lease-123",
+        client_name="test-client",
+        lease_duration="30m",
+        exporter_name="test-exporter",
+        exporter_namespace="default",
+    )
+
+
+class TestHookExecutor:
+    async def test_hook_executor_creation(self, hook_config, mock_device_factory):
+        executor = HookExecutor(
+            config=hook_config,
+            device_factory=mock_device_factory,
+        )
+
+        assert executor.config == hook_config
+        assert executor.device_factory == mock_device_factory
+        assert executor.timeout == 10
+
+    async def test_empty_hook_execution(self, mock_device_factory, hook_context):
+        empty_config = HookConfigV1Alpha1()
+        executor = HookExecutor(
+            config=empty_config,
+            device_factory=mock_device_factory,
+        )
+
+        # Both hooks should return True for empty/None commands
+        assert await executor.execute_pre_lease_hook(hook_context) is True
+        assert await executor.execute_post_lease_hook(hook_context) is True
+
+    async def test_successful_hook_execution(self, mock_device_factory, hook_context):
+        hook_config = HookConfigV1Alpha1(
+            pre_lease="echo 'Pre-lease hook executed'",
+            timeout=10,
+        )
+        # Mock the Session and serve_unix_async
+        with patch("jumpstarter.exporter.hooks.Session") as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.return_value.__enter__.return_value = mock_session
+
+            # Mock the async context manager for serve_unix_async
+            mock_session.serve_unix_async.return_value.__aenter__ = AsyncMock(return_value="/tmp/test_socket")
+            mock_session.serve_unix_async.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Mock asyncio.create_subprocess_shell to simulate successful execution
+            mock_process = AsyncMock()
+            mock_process.returncode = 0
+            # Mock stdout.readline to simulate line-by-line output
+            mock_process.stdout.readline.side_effect = [
+                b"Pre-lease hook executed\n",
+                b"",  # EOF
+            ]
+            mock_process.wait = AsyncMock(return_value=None)
+
+            with patch("asyncio.create_subprocess_shell", return_value=mock_process) as mock_subprocess:
+                executor = HookExecutor(
+                    config=hook_config,
+                    device_factory=mock_device_factory,
+                )
+
+                result = await executor.execute_pre_lease_hook(hook_context)
+
+                assert result is True
+
+                # Verify subprocess was called with correct environment
+                mock_subprocess.assert_called_once()
+                call_args = mock_subprocess.call_args
+                command = call_args[0][0]
+                env = call_args[1]["env"]
+
+                assert command == "echo 'Pre-lease hook executed'"
+                assert JUMPSTARTER_HOST in env
+                assert env[JUMPSTARTER_HOST] == "/tmp/test_socket"
+                assert env[JMP_DRIVERS_ALLOW] == "UNSAFE"
+                assert env["LEASE_NAME"] == "test-lease-123"
+                assert env["CLIENT_NAME"] == "test-client"
+
+    async def test_failed_hook_execution(self, mock_device_factory, hook_context):
+        failed_config = HookConfigV1Alpha1(
+            pre_lease="exit 1",  # Command that will fail
+            timeout=10,
+        )
+
+        with patch("jumpstarter.exporter.hooks.Session") as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.return_value.__enter__.return_value = mock_session
+
+            mock_session.serve_unix_async.return_value.__aenter__ = AsyncMock(return_value="/tmp/test_socket")
+            mock_session.serve_unix_async.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Mock failed process
+            mock_process = AsyncMock()
+            mock_process.returncode = 1
+            # Mock stdout.readline for failed process
+            mock_process.stdout.readline.side_effect = [
+                b"Command failed\n",
+                b"",  # EOF
+            ]
+            mock_process.wait = AsyncMock(return_value=None)
+
+            with patch("asyncio.create_subprocess_shell", return_value=mock_process):
+                executor = HookExecutor(
+                    config=failed_config,
+                    device_factory=mock_device_factory,
+                )
+
+                result = await executor.execute_pre_lease_hook(hook_context)
+
+                assert result is False
+
+    async def test_hook_timeout(self, mock_device_factory, hook_context):
+        timeout_config = HookConfigV1Alpha1(
+            pre_lease="sleep 60",  # Command that will timeout
+            timeout=1,  # 1 second timeout
+        )
+
+        with patch("jumpstarter.exporter.hooks.Session") as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.return_value.__enter__.return_value = mock_session
+
+            mock_session.serve_unix_async.return_value.__aenter__ = AsyncMock(return_value="/tmp/test_socket")
+            mock_session.serve_unix_async.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Mock process that times out
+            mock_process = AsyncMock()
+            mock_process.terminate.return_value = None
+            mock_process.wait.return_value = None
+
+            with (
+                patch("asyncio.create_subprocess_shell", return_value=mock_process),
+                patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()),
+            ):
+                executor = HookExecutor(
+                    config=timeout_config,
+                    device_factory=mock_device_factory,
+                )
+
+                result = await executor.execute_pre_lease_hook(hook_context)
+
+                assert result is False
+                mock_process.terminate.assert_called_once()
+
+    async def test_hook_environment_variables(self, mock_device_factory, hook_context):
+        hook_config = HookConfigV1Alpha1(
+            pre_lease="echo 'Pre-lease hook executed'",
+            timeout=10,
+        )
+        with patch("jumpstarter.exporter.hooks.Session") as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.return_value.__enter__.return_value = mock_session
+
+            mock_session.serve_unix_async.return_value.__aenter__ = AsyncMock(return_value="/tmp/test_socket")
+            mock_session.serve_unix_async.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            mock_process = AsyncMock()
+            mock_process.returncode = 0
+            # Mock stdout.readline for environment test
+            mock_process.stdout.readline.side_effect = [
+                b"",  # EOF (no output)
+            ]
+            mock_process.wait = AsyncMock(return_value=None)
+
+            with patch("asyncio.create_subprocess_shell", return_value=mock_process) as mock_subprocess:
+                executor = HookExecutor(
+                    config=hook_config,
+                    device_factory=mock_device_factory,
+                )
+
+                await executor.execute_pre_lease_hook(hook_context)
+
+                # Check that all expected environment variables are set
+                call_args = mock_subprocess.call_args
+                env = call_args[1]["env"]
+
+                assert env["LEASE_NAME"] == "test-lease-123"
+                assert env["CLIENT_NAME"] == "test-client"
+                assert env["LEASE_DURATION"] == "30m"
+                assert env["EXPORTER_NAME"] == "test-exporter"
+                assert env["EXPORTER_NAMESPACE"] == "default"
+                assert env[JUMPSTARTER_HOST] == "/tmp/test_socket"
+                assert env[JMP_DRIVERS_ALLOW] == "UNSAFE"
+
+    async def test_real_time_output_logging(self, mock_device_factory, hook_context):
+        """Test that hook output is logged in real-time at INFO level."""
+        hook_config = HookConfigV1Alpha1(
+            pre_lease="echo 'Line 1'; echo 'Line 2'; echo 'Line 3'",
+            timeout=10,
+        )
+
+        with patch("jumpstarter.exporter.hooks.Session") as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.return_value.__enter__.return_value = mock_session
+
+            mock_session.serve_unix_async.return_value.__aenter__ = AsyncMock(return_value="/tmp/test_socket")
+            mock_session.serve_unix_async.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            mock_process = AsyncMock()
+            mock_process.returncode = 0
+            # Mock multiple lines of output to verify streaming
+            mock_process.stdout.readline.side_effect = [
+                b"Line 1\n",
+                b"Line 2\n",
+                b"Line 3\n",
+                b"",  # EOF
+            ]
+            mock_process.wait = AsyncMock(return_value=None)
+
+            # Mock the logger to capture log calls
+            with (
+                patch("jumpstarter.exporter.hooks.logger") as mock_logger,
+                patch("asyncio.create_subprocess_shell", return_value=mock_process),
+            ):
+                executor = HookExecutor(
+                    config=hook_config,
+                    device_factory=mock_device_factory,
+                )
+
+                result = await executor.execute_pre_lease_hook(hook_context)
+
+                assert result is True
+
+                # Verify that output lines were logged in real-time at INFO level
+                expected_calls = [
+                    call.info("Executing hook: %s", "echo 'Line 1'; echo 'Line 2'; echo 'Line 3'"),
+                    call.info("[Hook Output] %s", "Line 1"),
+                    call.info("[Hook Output] %s", "Line 2"),
+                    call.info("[Hook Output] %s", "Line 3"),
+                    call.info("Hook executed successfully"),
+                ]
+                mock_logger.info.assert_has_calls(expected_calls, any_order=False)
+
+    async def test_post_lease_hook_execution_on_completion(self, mock_device_factory, hook_context):
+        """Test that post-lease hook executes when called directly."""
+        hook_config = HookConfigV1Alpha1(
+            post_lease="echo 'Post-lease cleanup completed'",
+            timeout=10,
+        )
+
+        with patch("jumpstarter.exporter.hooks.Session") as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.return_value.__enter__.return_value = mock_session
+
+            mock_session.serve_unix_async.return_value.__aenter__ = AsyncMock(return_value="/tmp/test_socket")
+            mock_session.serve_unix_async.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            mock_process = AsyncMock()
+            mock_process.returncode = 0
+            # Mock post-lease hook output
+            mock_process.stdout.readline.side_effect = [
+                b"Post-lease cleanup completed\n",
+                b"",  # EOF
+            ]
+            mock_process.wait = AsyncMock(return_value=None)
+
+            # Mock the logger to capture log calls
+            with patch("jumpstarter.exporter.hooks.logger") as mock_logger, \
+                 patch("asyncio.create_subprocess_shell", return_value=mock_process):
+                executor = HookExecutor(
+                    config=hook_config,
+                    device_factory=mock_device_factory,
+                )
+
+                result = await executor.execute_post_lease_hook(hook_context)
+
+                assert result is True
+
+                # Verify that post-lease hook output was logged
+                expected_calls = [
+                    call.info("Executing post-lease hook for lease %s", "test-lease-123"),
+                    call.info("Executing hook: %s", "echo 'Post-lease cleanup completed'"),
+                    call.info("[Hook Output] %s", "Post-lease cleanup completed"),
+                    call.info("Hook executed successfully"),
+                ]
+                mock_logger.info.assert_has_calls(expected_calls, any_order=False)


### PR DESCRIPTION
Implement new hook scripts that can be configured in the exporter config to run `j` commands within a temporary lease environment.

The following environment variables are exposed to hook scripts:
  - `JUMPSTARTER_HOST` - Path to the Unix socket for j CLI access
  - `JMP_DRIVERS_ALLOW=UNSAFE` - Allows all drivers for local access
  - `LEASE_NAME` - The name of the current lease
  - `CLIENT_NAME` - Name of the client that acquired the lease
  - `LEASE_DURATION` - Duration of the lease
  - `EXPORTER_NAME `- Name of the exporter
  - `EXPORTER_NAMESPACE` - Namespace of the exporter

Example YAML config:

```yaml
apiVersion: jumpstarter.dev/v1alpha1
kind: ExporterConfig
metadata:
  namespace: default
  name: test-exporter
endpoint: grpc.jumpstarter.100.123.60.47.nip.io:8082
hooks:
  preLease: |
    echo "Starting lease setup for ${CLIENT_NAME}"
    echo "Setting up power management..."
    j power on
    echo "Initializing device connections..."
    echo "Running pre-lease diagnostics..."
    sleep 5
    echo "Pre-lease setup completed successfully!"
  postLease: |
    echo "Starting lease cleanup for ${CLIENT_NAME}"
    echo "Shutting down power..."
    j power off
    echo "Cleaning up device connections..."
    echo "Running post-lease diagnostics..."
    sleep 5
    echo "Post-lease cleanup completed successfully!"
  timeout: 60
tls:
  ca: ''
  insecure: true
token: abc123
grpcOptions: {}
export:
  power:
    type: "jumpstarter_driver_power.driver.MockPower"
    config: {}
```