### PR TITLE
Fix installations script on CI runners like gitlab

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 set -e
 
-# Colors for output
-RED="$(tput setaf 1)"
-GREEN="$(tput setaf 2)"
-YELLOW="$(tput setaf 3)"
-BLUE="$(tput setaf 4)"
-NC="$(tput sgr0)" # No Color
+# Define color outputs
+# Check if colors should be enabled based on:
+# 1. NO_COLOR environment variable (https://no-color.org/)
+# 2. Terminal capability (TERM set and tput works)
+# 3. Interactive terminal (isatty check [ -t 1 ])
+if [ -z "${NO_COLOR:-}" ] && [ -n "${TERM:-}" ] && command -v tput >/dev/null 2>&1 && tput setaf 1 >/dev/null 2>&1 && [ -t 1 ]; then
+    RED="$(tput setaf 1)"
+    GREEN="$(tput setaf 2)"
+    YELLOW="$(tput setaf 3)"
+    BLUE="$(tput setaf 4)"
+    NC="$(tput sgr0)" # No Color
+else
+    # Fallback for CI environments, non-interactive terminals, or when NO_COLOR is set
+    RED=""
+    GREEN=""
+    YELLOW=""
+    BLUE=""
+    NC=""
+fi
 
 # Default values
 INSTALL_DIR="${HOME}/.local/jumpstarter"


### PR DESCRIPTION

When defining the escape color codes tput could not determine the terminal in some environments, and fail. This adds a fallback where tput is not available or no TERM is defined.

Fixes-Issue: #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer terminal color handling: colors enabled only when environment supports them (TERM set, tput available, stdout is a TTY, and NO_COLOR not set).
  * Falls back to colorless output in unsupported environments (e.g., CI) to avoid stray escape sequences.
  * Preserves existing installation behavior and messages; only visual formatting adapts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->