### PR TITLE
pyserial: add "cps" option for slow-typing simulation

### DIFF
--- a/packages/jumpstarter-driver-pyserial/README.md
+++ b/packages/jumpstarter-driver-pyserial/README.md
@@ -21,15 +21,17 @@ export:
     config:
       url: "/dev/ttyUSB0"
       baudrate: 115200
+      cps: 10  # Optional: throttle to 10 characters per second
 ```
 
 ### Config parameters
 
-| Parameter      | Description                                                                                                                                          | Type | Required | Default |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | -------- | ------- |
-| url            | The serial port to connect to, in [pyserial format](https://pyserial.readthedocs.io/en/latest/url_handlers.html)                                     | str  | yes      |         |
-| baudrate       | The baudrate to use for the serial connection                                                                                                        | int  | no       | 115200  |
-| check_existing | Check if the serial port exists during exporter initialization, disable if you are connecting to a dynamically created port (i.e. USB from your DUT) | bool | no       | True    |
+| Parameter      | Description                                                                                                                                          | Type  | Required | Default |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | -------- | ------- |
+| url            | The serial port to connect to, in [pyserial format](https://pyserial.readthedocs.io/en/latest/url_handlers.html)                                     | str   | yes      |         |
+| baudrate       | The baudrate to use for the serial connection                                                                                                        | int   | no       | 115200  |
+| check_present | Check if the serial port exists during exporter initialization, disable if you are connecting to a dynamically created port (i.e. USB from your DUT) | bool  | no       | True    |
+| cps            | Characters per second throttling limit. When set, data transmission will be throttled to simulate slow typing. Useful for devices that can't handle fast input | float | no       | None    |
 
 ## API Reference
 

--- a/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver.py
+++ b/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver.py
@@ -1,11 +1,13 @@
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from typing import Optional, Union
 
 from anyio import (
     create_memory_object_stream,
+    sleep,
 )
 from anyio._backends._asyncio import StreamReaderWrapper, StreamWriterWrapper
-from anyio.abc import ObjectStream
+from anyio.abc import ObjectSendStream, ObjectStream
 from anyio.streams.stapled import StapledObjectStream
 from serial import serial_for_url
 from serial_asyncio import open_serial_connection
@@ -16,22 +18,72 @@ LOOP = "loop://"
 
 
 @dataclass(kw_only=True)
+class ThrottledStream(ObjectStream):
+    """Wrapper stream that adds CPS throttling to any ObjectStream."""
+    stream: Union[ObjectSendStream[bytes], ObjectStream[bytes]]
+    cps: Optional[float] = None
+
+    async def send(self, item: bytes):
+        if self.cps is not None and self.cps > 0:
+            await self._send_throttled(item)
+        else:
+            await self.stream.send(item)
+
+    async def _send_throttled(self, item: bytes):
+        """Send data with throttling based on characters per second."""
+        if not item:
+            return
+
+        delay_per_char = 1.0 / self.cps
+
+        # Send data character by character with delay
+        for i in range(len(item)):
+            char = item[i:i+1]
+            await self.stream.send(char)
+
+            # Add delay between characters (except for the last one)
+            if i < len(item) - 1:
+                await sleep(delay_per_char)
+
+    async def receive(self):
+        if hasattr(self.stream, "receive"):
+            return await self.stream.receive()  # type: ignore[no-any-return]
+        raise RuntimeError("receive() called on send-only ThrottledStream")
+
+    async def send_eof(self):
+        if hasattr(self.stream, "send_eof"):
+            await self.stream.send_eof()
+
+    async def aclose(self):
+        await self.stream.aclose()
+
+
+@dataclass(kw_only=True)
 class AsyncSerial(ObjectStream):
     reader: StreamReaderWrapper
-    writer: StreamWriterWrapper
+    writer: Union[StreamWriterWrapper, ThrottledStream]
+    cps: Optional[float] = None  # characters per second throttling
 
-    async def send(self, item):
+    def __post_init__(self):
+        # Replace writer with throttled version if chars-per-second throttling is set
+        if self.cps is not None and self.cps > 0:
+            self.writer = ThrottledStream(stream=self.writer, cps=self.cps)
+
+    async def send(self, item: bytes):
         await self.writer.send(item)
 
     async def receive(self):
         return await self.reader.receive()
 
     async def send_eof(self):
-        pass
+        if hasattr(self.writer, "send_eof"):
+            await self.writer.send_eof()
 
     async def aclose(self):
-        await self.writer.aclose()
-        await self.reader.aclose()
+        try:
+            await self.writer.aclose()
+        finally:
+            await self.reader.aclose()
 
 
 @dataclass(kw_only=True)
@@ -39,6 +91,7 @@ class PySerial(Driver):
     url: str
     baudrate: int = field(default=115200)
     check_present: bool = field(default=True)
+    cps: Optional[float] = field(default=None)  # characters per second throttling
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -53,17 +106,20 @@ class PySerial(Driver):
     @exportstream
     @asynccontextmanager
     async def connect(self):
-        self.logger.info("Connecting to %s, baudrate: %d", self.url, self.baudrate)
+        cps_info = f", cps: {self.cps}" if self.cps is not None else ""
+        self.logger.info("Connecting to %s, baudrate: %d%s", self.url, self.baudrate, cps_info)
         if self.url != LOOP:
             reader, writer = await open_serial_connection(url=self.url, baudrate=self.baudrate, limit=1)
             writer.transport.set_write_buffer_limits(high=4096, low=0)
             async with AsyncSerial(
                 reader=StreamReaderWrapper(reader),
                 writer=StreamWriterWrapper(writer),
+                cps=self.cps,
             ) as stream:
                 yield stream
             self.logger.info("Disconnected from %s", self.url)
         else:
-            tx, rx = create_memory_object_stream[bytes](32) # ty: ignore[call-non-callable]
-            async with StapledObjectStream(tx, rx) as stream:
+            tx, rx = create_memory_object_stream[bytes](32)  # type: ignore[call-overload]
+            stapled_stream = StapledObjectStream(tx, rx)
+            async with ThrottledStream(stream=stapled_stream, cps=self.cps) as stream:
                 yield stream

--- a/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
+++ b/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
@@ -1,7 +1,11 @@
+import time
 from typing import cast
 
+from anyio import create_memory_object_stream
+from anyio.streams.stapled import StapledObjectStream
+
 from .client import PySerialClient
-from .driver import PySerial
+from .driver import PySerial, ThrottledStream
 from jumpstarter.common.utils import serve
 
 
@@ -50,3 +54,104 @@ def test_can_open_not_present():
     with serve(PySerial(url="/dev/doesNotExist", check_present=False)):
         # we only verify that the context manager does not raise an exception
         pass
+
+
+def test_cps_throttling():
+    """Test that CPS throttling is configured correctly."""
+    cps = 5  # 5 characters per second
+    test_data = b"hello"  # 5 characters
+
+    with serve(PySerial(url="loop://", cps=cps)) as client:
+        with client.stream() as stream:
+            # Just verify that the throttling doesn't break functionality
+            # The actual timing test is done at the async level
+            stream.send(test_data)
+
+            # Verify data was sent correctly (receive character by character)
+            received_data = b""
+            for _ in range(len(test_data)):
+                received_data += stream.receive()
+            assert test_data == received_data
+
+
+def test_no_cps_throttling():
+    """Test that without CPS throttling, transmission is fast."""
+    test_data = b"hello"
+
+    with serve(PySerial(url="loop://")) as client:  # No CPS specified
+        with client.stream() as stream:
+            start_time = time.perf_counter()
+            stream.send(test_data)
+            end_time = time.perf_counter()
+
+            elapsed_time = end_time - start_time
+            # Without throttling, should be fast; allow headroom for CI noise
+            assert elapsed_time < 0.5, f"Expected fast transmission, got {elapsed_time}s"
+
+            received = stream.receive()
+            assert test_data.decode("utf-8").startswith(received.decode("utf-8"))
+
+
+def test_cps_zero_disables_throttling():
+    """Test that CPS=0 disables throttling."""
+    test_data = b"hello"
+
+    with serve(PySerial(url="loop://", cps=0)) as client:
+        with client.stream() as stream:
+            start_time = time.perf_counter()
+            stream.send(test_data)
+            end_time = time.perf_counter()
+
+            elapsed_time = end_time - start_time
+            # With CPS=0, should be fast (no throttling) – allow headroom
+            assert elapsed_time < 0.5, f"Expected fast transmission with cps=0, got {elapsed_time}s"
+
+            received = stream.receive()
+            assert test_data.decode("utf-8").startswith(received.decode("utf-8"))
+
+
+def test_throttled_stream_async():
+    """Test that ThrottledStream works correctly at the async level."""
+    import anyio
+
+    async def _test():
+        cps = 5  # 5 characters per second
+        test_data = b"hello world!"  # 12 characters
+        expected_min_time = (len(test_data) - 1) / cps  # Should take at least 11/5 = 2.2 seconds
+
+        # Create a memory stream for testing
+        tx, rx = create_memory_object_stream[bytes](32)
+        stapled_stream = StapledObjectStream(tx, rx)
+        # Wrap it with throttling and ensure proper closure
+        async with ThrottledStream(stream=stapled_stream, cps=cps) as throttled_stream:
+            start_time = time.perf_counter()
+            await throttled_stream.send(test_data)
+            end_time = time.perf_counter()
+
+            elapsed_time = end_time - start_time
+            # Allow some overhead for CI environments but not excessive delay
+            expected_max_time = expected_min_time * 1.5  # 50% overhead for CI slowness
+            assert expected_min_time <= elapsed_time <= expected_max_time, (
+                f"Expected {expected_min_time}s-{expected_max_time}s, got {elapsed_time}s"
+            )
+
+            # Verify data was sent correctly (character by character)
+            received_data = b""
+            for _ in range(len(test_data)):
+                received_data += await throttled_stream.receive()
+            assert test_data == received_data
+
+    anyio.run(_test)
+
+
+def test_cps_with_pexpect():
+    """Test that CPS throttling works with pexpect interface."""
+    cps = 10  # 10 characters per second
+
+    with serve(PySerial(url="loop://", cps=cps)) as client:
+        client = cast(PySerialClient, client)
+        with client.pexpect() as pexpect:
+            # Just verify that pexpect works with throttling enabled
+            pexpect.sendline("test")
+            assert pexpect.expect("test") == 0
+            # We don't test timing here since pexpect has complex buffering


### PR DESCRIPTION
Some devices may have troubles with bulk of data being sent. Add "cps" parameter (characters per second) to simulate someone typing slowly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional characters-per-second (cps) throttling for outbound serial data; per-connection configurable; set to 0/None to disable. Loop/memory streams are now throttled when cps is set.

- Documentation
  - README updated with cps config (default None) and example (e.g., cps: 10); renamed config field check_existing → check_present and adjusted table/description formatting.

- Tests
  - Added tests for throttled vs unthrottled behavior, zero-disable, timing expectations, and compatibility across stream types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->