### PR TITLE
unzboot with zstd landed in Fedora 42

### DIFF
--- a/packages/jumpstarter-driver-flashers/oci_bundles/aarch64-itb/build_fits.sh
+++ b/packages/jumpstarter-driver-flashers/oci_bundles/aarch64-itb/build_fits.sh
@@ -13,10 +13,6 @@ else
 		wget cpio rsync bc lzop zip patch perl tar qemu-system-aarch64 qemu-img unzboot \
 		uboot-tools kmod awk zstd lz4  kernel dtc rpm-build
 
-	# FIXME remove in Fedora 43
-	# until unzboot is updated, use the build directly
-	rpm -Uvh https://kojipkgs.fedoraproject.org//packages/unzboot/0.1~git.20250502.0c0c3ad/2.fc43/aarch64/unzboot-0.1~git.20250502.0c0c3ad-2.fc43.aarch64.rpm
-
 	git clone --depth 1 --branch 2025.08  https://github.com/buildroot/buildroot "${BUILDROOT_DIR}"
 
 	# build buildroot (initramfs)


### PR DESCRIPTION
dropping the workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated Fedora-specific dependency installation step, simplifying the setup and reducing special-casing.
  * Eliminated reliance on installing packages from external URLs, improving consistency and reliability across environments.
  * Build flow and outputs remain unchanged for end users; standard dependency installation and subsequent build steps continue as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->