### PR TITLE
Change the default keepalive timeout

### DIFF
--- a/packages/jumpstarter/jumpstarter/common/grpc.py
+++ b/packages/jumpstarter/jumpstarter/common/grpc.py
@@ -58,7 +58,7 @@ def _override_default_grpc_options(grpc_options: dict[str, str | int] | None) ->
         ("grpc.lb_policy_name", "round_robin"),
         # we keep a low keepalive time to avoid idle timeouts on cloud load balancers
         ("grpc.keepalive_time_ms", 20000),
-        ("grpc.keepalive_timeout_ms", 5000),
+        ("grpc.keepalive_timeout_ms", 180000),
         ("grpc.http2.max_pings_without_data", 0),
         ("grpc.keepalive_permit_without_calls", 1),
     )


### PR DESCRIPTION
The default timeout of 5s is excessively low and causes issues under pressure.

See https://github.com/jumpstarter-dev/jumpstarter/issues/674 for more details.

Fixes-Issue: #674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated default connection keepalive timing to use a significantly longer timeout.
  - Users may notice fewer transient reconnects during idle periods and more stable long-running sessions.
  - This change also reduces background keepalive traffic, which can be beneficial on constrained networks.
  - No action is required; the improvement applies automatically after upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->