### PR TITLE
import_pr fix "Script failed" after successful apply

### DIFF
--- a/import_pr.sh
+++ b/import_pr.sh
@@ -337,10 +337,10 @@ apply_patches() {
             patch_name=$(basename "$patch")
             if git am --directory="${subdir}" "$patch" 2>/dev/null; then
                 log_info "Applied: ${patch_name}"
-                ((applied++))
+                ((applied++)) || true
             else
                 log_error "Failed to apply: ${patch_name}"
-                ((failed++))
+                ((failed++)) || true
                 # Abort the am session
                 git am --abort 2>/dev/null || true
                 break


### PR DESCRIPTION
just a quick fix to an issue observed in my system

```
Applying: gracefully handle missing drivers with stub client
[INFO] Applied: 0001-gracefully-handle-missing-drivers-with-stub-client.patch

[WARN] Script failed. Temporary directory preserved for debugging:
```

the script fails after successfully applying the first patch, with no error other than the final verdict. 
This is likely due to set -e combined with ((applied++)) - when applied is 0, ((applied++)) returns exit code 1 (because 0 is falsy in bash arithmetic), which causes the script to exit.

by adding the or true condition I was able to run it in my system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of the patch application process to prevent potential script failures during patch import operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->