### PR TITLE
add offline access to allow refresh tokens

### DIFF
--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -69,18 +69,18 @@ wait_for_exporter() {
 }
 
 @test "can create clients with admin cli" {
-  jmp admin create client -n "${JS_NAMESPACE}" test-client-oidc     --unsafe --out /dev/null \
+  jmp admin create client -n "${JS_NAMESPACE}" test-client-oidc     --unsafe --nointeractive \
     --oidc-username dex:test-client-oidc
-  jmp admin create client -n "${JS_NAMESPACE}" test-client-sa       --unsafe --out /dev/null \
+  jmp admin create client -n "${JS_NAMESPACE}" test-client-sa       --unsafe --nointeractive \
     --oidc-username dex:system:serviceaccount:"${JS_NAMESPACE}":test-client-sa
   jmp admin create client -n "${JS_NAMESPACE}" test-client-legacy   --unsafe --save
 }
 
 @test "can create exporters with admin cli" {
-  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-oidc   --out /dev/null \
+  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-oidc   --nointeractive \
     --oidc-username dex:test-exporter-oidc \
     --label example.com/board=oidc
-  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-sa     --out /dev/null \
+  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-sa     --nointeractive \
     --oidc-username dex:system:serviceaccount:"${JS_NAMESPACE}":test-exporter-sa \
     --label example.com/board=sa
   jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-legacy --save \

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/auth.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/auth.py
@@ -1,13 +1,18 @@
 from datetime import datetime, timezone
 
 import click
+from jumpstarter_cli_common.blocking import blocking
 from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.oidc import (
     TOKEN_EXPIRY_WARNING_SECONDS,
+    Config,
     decode_jwt,
+    decode_jwt_issuer,
     format_duration,
     get_token_remaining_seconds,
 )
+
+from jumpstarter.config.client import ClientConfigV1Alpha1
 
 
 @click.group()
@@ -19,21 +24,52 @@ def _print_token_status(remaining: float) -> None:
     """Print token status message based on remaining time."""
     duration = format_duration(remaining)
 
+    hint = "Run 'jmp login' to refresh your credentials."
+
     if remaining < 0:
         click.echo(click.style(f"Status: EXPIRED ({duration} ago)", fg="red", bold=True))
-        click.echo(click.style("Run 'jmp login --force' to refresh your credentials.", fg="yellow"))
+        click.echo(click.style(hint, fg="yellow"))
     elif remaining < TOKEN_EXPIRY_WARNING_SECONDS:
         click.echo(click.style(f"Status: EXPIRING SOON ({duration} remaining)", fg="red", bold=True))
-        click.echo(click.style("Run 'jmp login --force' to refresh your credentials.", fg="yellow"))
+        click.echo(click.style(hint, fg="yellow"))
     elif remaining < 3600:
         click.echo(click.style(f"Status: Valid ({duration} remaining)", fg="yellow"))
     else:
         click.echo(click.style(f"Status: Valid ({duration} remaining)", fg="green"))
 
 
+def _print_subject_issuer(payload: dict) -> None:
+    sub = payload.get("sub")
+    iss = payload.get("iss")
+    if sub:
+        click.echo(f"Subject: {sub}")
+    if iss:
+        click.echo(f"Issuer: {iss}")
+
+
+def _print_timestamp(label: str, value: int | None) -> None:
+    if value is None:
+        return
+    dt = datetime.fromtimestamp(value, tz=timezone.utc)
+    click.echo(f"{label}: {dt.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+
+
+def _print_verbose_details(payload: dict, config) -> None:
+    iat = payload.get("iat")
+    auth_time = payload.get("auth_time")
+    if isinstance(iat, int):
+        _print_timestamp("Issued at", iat)
+    if isinstance(auth_time, int):
+        _print_timestamp("Auth time", auth_time)
+
+    refresh_token = getattr(config, "refresh_token", None)
+    click.echo(f"Refresh token stored: {'yes' if refresh_token else 'no'}")
+
+
 @auth.command(name="status")
+@click.option("--verbose", is_flag=True, help="Show additional token details")
 @opt_config(exporter=False)
-def token_status(config):
+def token_status(config, verbose: bool):
     """Display token status and expiry information."""
     token_str = getattr(config, "token", None)
 
@@ -58,10 +94,38 @@ def token_status(config):
 
     _print_token_status(remaining)
 
-    # Show additional token info
-    sub = payload.get("sub")
-    iss = payload.get("iss")
-    if sub:
-        click.echo(f"Subject: {sub}")
-    if iss:
-        click.echo(f"Issuer: {iss}")
+    _print_subject_issuer(payload)
+
+    if verbose:
+        _print_verbose_details(payload, config)
+
+
+@auth.command(name="refresh")
+@opt_config(exporter=False)
+@blocking
+async def refresh_token(config):
+    """Refresh the access token using a stored refresh token."""
+    refresh_token = getattr(config, "refresh_token", None)
+    if not refresh_token:
+        raise click.ClickException("No refresh token found. Run 'jmp login --offline-access'.")
+
+    access_token = getattr(config, "token", None)
+    if not access_token:
+        raise click.ClickException("No access token found. Run 'jmp login --offline-access'.")
+
+    try:
+        issuer = decode_jwt_issuer(access_token)
+    except Exception as e:
+        raise click.ClickException(f"Failed to decode JWT issuer: {e}") from e
+
+    if issuer is None:
+        raise click.ClickException("Failed to determine issuer from access token.")
+
+    oidc = Config(issuer=issuer, client_id="jumpstarter-cli")
+    tokens = await oidc.refresh_token_grant(refresh_token)
+    config.token = tokens["access_token"]
+    new_refresh_token = tokens.get("refresh_token")
+    if new_refresh_token is not None:
+        config.refresh_token = new_refresh_token
+    ClientConfigV1Alpha1.save(config)  # ty: ignore[invalid-argument-type]
+    click.echo("Access token refreshed.")

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -140,7 +140,7 @@ async def login(  # noqa: C901
             tokens = await oidc.refresh_token_grant(stored_refresh_token)
             config.token = tokens["access_token"]
             refresh_token = tokens.get("refresh_token")
-            if refresh_token is not None:
+            if refresh_token is not None and isinstance(config, ClientConfigV1Alpha1):
                 config.refresh_token = refresh_token
             save_config()
             click.echo("Refreshed access token using stored refresh token.")
@@ -160,7 +160,9 @@ async def login(  # noqa: C901
 
     config.token = tokens["access_token"]
     refresh_token = tokens.get("refresh_token")
-    if refresh_token is not None:
+
+    # only client configs support refresh_token
+    if refresh_token is not None and isinstance(config, ClientConfigV1Alpha1):
         config.refresh_token = refresh_token
 
     save_config()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -145,7 +145,9 @@ async def login(  # noqa: C901
             save_config()
             click.echo("Refreshed access token using stored refresh token.")
             return
-        except Exception:
+        except Exception as e:
+            if nointeractive:
+                raise click.ClickException(f"Failed to refresh access token: {e}") from e
             pass
 
     if token is not None:

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -112,6 +112,7 @@ class ClientConfigV1Alpha1(BaseSettings):
     endpoint: str | None = Field(default=None)
     tls: TLSConfigV1Alpha1 = Field(default_factory=TLSConfigV1Alpha1)
     token: str | None = Field(default=None)
+    refresh_token: str | None = Field(default=None)
     grpcOptions: dict[str, str | int] | None = Field(default_factory=dict)
 
     drivers: ClientConfigV1Alpha1Drivers = Field(default_factory=ClientConfigV1Alpha1Drivers)
@@ -345,12 +346,19 @@ class ClientConfigV1Alpha1(BaseSettings):
         else:
             config.path = Path(path)
         with config.path.open(mode="w") as f:
-            yaml.safe_dump(config.model_dump(mode="json", exclude={"path", "alias"}), f, sort_keys=False)
+            yaml.safe_dump(
+                config.model_dump(mode="json", exclude={"path", "alias"}, exclude_none=True),
+                f,
+                sort_keys=False,
+            )
         return config.path
 
     @classmethod
     def dump_yaml(cls, config: Self) -> str:
-        return yaml.safe_dump(config.model_dump(mode="json", exclude={"path", "alias"}), sort_keys=False)
+        return yaml.safe_dump(
+            config.model_dump(mode="json", exclude={"path", "alias"}, exclude_none=True),
+            sort_keys=False,
+        )
 
     @classmethod
     def exists(cls, alias: str) -> bool:


### PR DESCRIPTION
```shell

$ jmp auth status
Token expiry: 2026-01-28 07:09:11 UTC
Status: Valid (20h 37m remaining)
Subject: ...
Issuer: ..

$ jmp login
Refreshed access token using stored refresh token.

$ jmp auth status
Token expiry: 2026-01-28 10:31:26 UTC
Status: Valid (23h 59m remaining)
Subject: ...
Issuer: ...

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --offline-access flag to enable storing and using refresh tokens.
  * Added a refresh command to renew access tokens from stored refresh tokens.
  * token_status gains a --verbose mode showing extra token details.

* **Improvements**
  * Login auto-refreshes and persists stored credentials when available; refresh tokens are saved.
  * Client config saves are now atomic with stricter file permissions; exports omit refresh tokens.

* **Tests**
  * CLI e2e tests run non-interactively to avoid prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->