### PR TITLE
treewide: use fedora 43

### DIFF
--- a/.github/workflows/build-oci-bundle.yaml
+++ b/.github/workflows/build-oci-bundle.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-fits:
     runs-on: ubuntu-24.04-arm
-    container: fedora:42
+    container: fedora:43
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -70,14 +70,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: python/packages/jumpstarter-driver-qemu/images
-          key: fedora-cloud-41-1.4
+          key: fedora-cloud-43-1.6
 
       - name: Download Fedora Cloud images
         if: steps.cache-fedora-cloud-images.outputs.cache-hit != 'true'
         run: |
           for arch in aarch64 x86_64; do
-            curl -L --output "python/packages/jumpstarter-driver-qemu/images/Fedora-Cloud-Base-Generic-41-1.4.${arch}.qcow2" \
-              "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/${arch}/images/Fedora-Cloud-Base-Generic-41-1.4.${arch}.qcow2"
+            curl -L --fail --output "python/packages/jumpstarter-driver-qemu/images/Fedora-Cloud-Base-Generic-43-1.6.${arch}.qcow2" \
+              "https://iad.mirror.rackspace.com/fedora/releases/43/Cloud/${arch}/images/Fedora-Cloud-Base-Generic-43-1.6.${arch}.qcow2"
           done
 
       - name: Run pytest

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,12 +1,12 @@
 FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:latest AS uv
 
-FROM --platform=$BUILDPLATFORM fedora:42 AS builder
+FROM --platform=$BUILDPLATFORM fedora:43 AS builder
 RUN dnf install -y make git && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 COPY --from=uv /uv /uvx /bin/
 
-FROM fedora:42 AS product
+FROM fedora:43 AS product
 RUN dnf install -y python3 ustreamer libusb1 android-tools python3-libgpiod && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/python/Dockerfile.utils
+++ b/python/Dockerfile.utils
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM fedora:43
 RUN dnf install -y kubernetes-client easy-rsa trurl && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/python/docs/source/contributing/development-environment.md
+++ b/python/docs/source/contributing/development-environment.md
@@ -4,7 +4,7 @@ You can use
 [devspaces](https://github.com/jumpstarter-dev/jumpstarter/blob/main/.devfile.yaml),
 [devcontainers](https://github.com/jumpstarter-dev/jumpstarter/tree/main/.devcontainer),
 or your favorite OS/distro to develop Jumpstarter, however the following
-examples are for Fedora 42.
+examples are for Fedora 43.
 
 Jumpstarter is programmed in Python and Go, the Jumpstarter controller is
 written in Go, while the core and drivers are written in Python.

--- a/python/packages/jumpstarter-driver-flashers/oci_bundles/aarch64-itb/build_fits.sh
+++ b/python/packages/jumpstarter-driver-flashers/oci_bundles/aarch64-itb/build_fits.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 
 # run only in a container
 if [[ -z "$container" && ! -f /.dockerenv ]]; then
-    exec podman run --rm -it -v $(pwd):/host:Z -w /host fedora:42 "$0" "$@"
+    exec podman run --rm -it -v $(pwd):/host:Z -w /host fedora:43 "$0" "$@"
 else
 	set -euo pipefail
 	BUILDROOT_DIR="/var/tmp/buildroot"

--- a/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver_test.py
+++ b/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver_test.py
@@ -71,13 +71,13 @@ def test_driver_qemu(tmp_path, ovmf):
         username = qemu.username
         password = qemu.password
 
-        cached_image = Path(__file__).parent.parent / "images" / f"Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2"
+        cached_image = Path(__file__).parent.parent / "images" / f"Fedora-Cloud-Base-Generic-43-1.6.{arch}.qcow2"
 
         if cached_image.exists():
             qemu.flasher.flash(cached_image.resolve())
         else:
             qemu.flasher.flash(
-                f"pub/fedora/linux/releases/41/Cloud/{arch}/images/Fedora-Cloud-Base-Generic-41-1.4.{arch}.qcow2",
+                f"pub/fedora/linux/releases/43/Cloud/{arch}/images/Fedora-Cloud-Base-Generic-43-1.6.{arch}.qcow2",
                 operator=Operator("http", endpoint="https://download.fedoraproject.org"),
             )
 
@@ -97,7 +97,7 @@ def test_driver_qemu(tmp_path, ovmf):
             p.expect_exact(f"[{username}@{hostname} ~]$")
 
         with qemu.shell() as s:
-            assert s.run("uname -r").stdout.strip() == f"6.11.4-301.fc41.{arch}"
+            assert s.run("uname -r").stdout.strip() == f"6.17.1-300.fc43.{arch}"
 
         qemu.power.off()
 

--- a/python/packages/jumpstarter-driver-uboot/jumpstarter_driver_uboot/driver_test.py
+++ b/python/packages/jumpstarter-driver-uboot/jumpstarter_driver_uboot/driver_test.py
@@ -15,7 +15,7 @@ from jumpstarter.common.utils import serve
 def uboot_image(tmpdir_factory):
     tmp_path = tmpdir_factory.mktemp("uboot-images")
 
-    url = "https://kojipkgs.fedoraproject.org/packages/uboot-tools/2024.10/1.fc41/noarch/uboot-images-armv8-2024.10-1.fc41.noarch.rpm"
+    url = "https://kojipkgs.fedoraproject.org/packages/uboot-tools/2025.10/1.fc43/noarch/uboot-images-armv8-2025.10-1.fc43.noarch.rpm"
 
     with requests.get(url, stream=True) as r:
         r.raise_for_status()
@@ -33,7 +33,7 @@ def uboot_image(tmpdir_factory):
 
 @pytest.mark.xfail(
     platform.system() == "Darwin" and os.getenv("GITHUB_ACTIONS") == "true",
-    reason="QEMU-based U-Boot tests are flaky on macOS in GitHub CI"
+    reason="QEMU-based U-Boot tests are flaky on macOS in GitHub CI",
 )
 def test_driver_uboot_console(uboot_image):
     print(uboot_image)
@@ -56,8 +56,10 @@ def test_driver_uboot_console(uboot_image):
 
         with uboot.reboot_to_console(debug=True):
             assert uboot.run_command_checked("version") == [
-                "U-Boot 2024.10 (Oct 11 2024 - 00:00:00 +0000)",
+                "U-Boot 2025.10 (Oct 13 2025 - 00:00:00 +0000)",
                 "",
+                "gcc (GCC) 15.2.1 20250924 (Red Hat 15.2.1-2)",
+                "GNU ld version 2.45-1.fc43",
             ]
 
             print(uboot.setup_dhcp())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base images from Fedora 42 to Fedora 43 across build scripts and Dockerfiles.
  * Updated Fedora Cloud image versions to 43-1.6 in workflows and test fixtures.
  * Added error handling to container image download operations.

* **Documentation**
  * Updated development environment guide to reference Fedora 43.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->