### PR TITLE
ci: build expirable images for pull-requests

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -9,6 +9,7 @@ on:
       - main
       - 'release-*'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - 'release-*'
@@ -21,6 +22,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-pr-images')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -8,10 +8,14 @@ on:
     branches:
       - main
       - 'release-*'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
   merge_group:
 
 env:
-  PUSH: ${{ github.repository_owner == 'jumpstarter-dev' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/release-')) }}
+  PUSH: ${{ github.repository_owner == 'jumpstarter-dev' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/release-') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
   REGISTRY: quay.io
   QUAY_ORG: quay.io/jumpstarter-dev
 
@@ -119,6 +123,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image_name }}
+          tags: |
+            type=ref,event=pr,prefix=pr-
+          labels: |
+            quay.expires-after=${{ github.event_name == 'pull_request' && '7d' || '' }}
 
       - name: Build and push Docker image
         id: push
@@ -127,7 +135,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: ${{ env.PUSH }}
-          tags: ${{ steps.set-tags.outputs.tags }}
+          tags: ${{ github.event_name == 'pull_request' && steps.meta.outputs.tags || steps.set-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha


### PR DESCRIPTION
This PR enables the creation of a pr-<num> tagged set of images in quay for each PR, those expire after a week.

The images are only built if the "build-pr-images" is applied. This avoid unnecessary builds, CO2 and wasted storage space in quay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run image build/push for pull requests and main/release branches, increasing validation coverage.
  * PR builds gated by a label to control when preview images are produced.
  * Pull-request-aware image tagging and expiry metadata added so PR preview images are identifiable and short-lived.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->