### PR TITLE
allow lease filtering by exporter labels

### DIFF
--- a/controller/api/v1alpha1/lease_helpers.go
+++ b/controller/api/v1alpha1/lease_helpers.go
@@ -199,6 +199,7 @@ func LeaseFromProtobuf(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: key.Namespace,
 			Name:      key.Name,
+			Labels:    selector.MatchLabels,
 		},
 		Spec: LeaseSpec{
 			ClientRef: clientRef,

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -175,6 +175,16 @@ EOF
   jmp create lease     --selector example.com/board=oidc --duration 1d
   jmp get    leases
   jmp get    exporters
+
+  # Verify label selector filtering works (regression test for issue #36)
+  run jmp get leases --selector example.com/board=oidc -o yaml
+  assert_success
+  assert_output --partial "example.com/board=oidc"
+
+  run jmp get leases --selector example.com/board=doesnotexist
+  assert_success
+  assert_output "No resources found."
+
   jmp delete leases    --all
 }
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get.py
@@ -54,6 +54,6 @@ def get_leases(config, selector: str | None, output: OutputType, show_all: bool)
     Display one or many leases
     """
 
-    leases = config.list_leases(filter=selector, only_active=not show_all)
+    leases = config.list_leases(filter=selector, only_active=not show_all).filter_by_selector(selector)
 
     model_print(leases, output)

--- a/python/packages/jumpstarter/jumpstarter/client/selectors.py
+++ b/python/packages/jumpstarter/jumpstarter/client/selectors.py
@@ -1,0 +1,81 @@
+"""Kubernetes label selector parsing and matching utilities."""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_label_selector(selector: str) -> tuple[dict[str, str], list[tuple[str, str, list[str]]]]:
+    """Parse a label selector string into matchLabels and matchExpressions.
+
+    Returns (matchLabels, matchExpressions) where matchExpressions is a list of
+    (key, operator, values) tuples. Operators: "=", "!=", "in", "notin", "exists", "!exists"
+    """
+    if not selector or not selector.strip():
+        return {}, []
+
+    match_labels: dict[str, str] = {}
+    match_expressions: list[tuple[str, str, list[str]]] = []
+
+    # Split by comma, but not inside parentheses
+    parts = re.split(r",(?![^()]*\))", selector)
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        # key in (v1, v2, ...)
+        if m := re.match(r"^([a-zA-Z0-9_./-]+)\s+in\s+\(([^)]*)\)$", part):
+            key, values = m.groups()
+            match_expressions.append((key, "in", [v.strip() for v in values.split(",")]))
+        # key notin (v1, v2, ...)
+        elif m := re.match(r"^([a-zA-Z0-9_./-]+)\s+notin\s+\(([^)]*)\)$", part):
+            key, values = m.groups()
+            match_expressions.append((key, "notin", [v.strip() for v in values.split(",")]))
+        # !key (DoesNotExist)
+        elif m := re.match(r"^!\s*([a-zA-Z0-9_./-]+)$", part):
+            match_expressions.append((m.group(1), "!exists", []))
+        # key!=value (whitespace-tolerant)
+        elif m := re.match(r"^([a-zA-Z0-9_./-]+)\s*!=\s*(.+)$", part):
+            key, value = m.groups()
+            match_expressions.append((key, "!=", [value.strip()]))
+        # key=value or key==value (whitespace-tolerant)
+        elif m := re.match(r"^([a-zA-Z0-9_./-]+)\s*==?\s*(.+)$", part):
+            key, value = m.groups()
+            match_labels[key] = value.strip()
+        # key (Exists) - bare key without operator
+        elif re.match(r"^[a-zA-Z0-9_./-]+$", part):
+            match_expressions.append((part, "exists", []))
+
+    return match_labels, match_expressions
+
+
+def selector_contains(selector: str, requirements: str) -> bool:
+    """Check if selector contains all criteria from requirements.
+
+    Returns True if all matchLabels and matchExpressions in `requirements`
+    are present in `selector`.
+    """
+    if not requirements or not requirements.strip():
+        return True
+
+    req_labels, req_exprs = parse_label_selector(requirements)
+    sel_labels, sel_exprs = parse_label_selector(selector)
+
+    # All required matchLabels must be in selector's matchLabels
+    for key, value in req_labels.items():
+        if sel_labels.get(key) != value:
+            return False
+
+    # All required matchExpressions must be in selector's matchExpressions
+    for r_key, r_op, r_vals in req_exprs:
+        found = False
+        for s_key, s_op, s_vals in sel_exprs:
+            if s_key == r_key and s_op == r_op and set(s_vals) == set(r_vals):
+                found = True
+                break
+        if not found:
+            return False
+
+    return True

--- a/python/packages/jumpstarter/jumpstarter/client/selectors_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/selectors_test.py
@@ -1,0 +1,42 @@
+"""Tests for label selector matching."""
+
+from jumpstarter.client.selectors import selector_contains
+
+
+class TestSelectorContains:
+    """Tests for checking if a lease's selector contains a filter's criteria."""
+
+    def test_exact_match_labels(self):
+        assert selector_contains("board=rpi", "board=rpi") is True
+
+    def test_subset_match_labels(self):
+        assert selector_contains("board=rpi,env=prod", "board=rpi") is True
+
+    def test_no_match_labels(self):
+        assert selector_contains("board=jetson", "board=rpi") is False
+
+    def test_exact_match_expressions(self):
+        assert selector_contains("firmware in (v2, v3)", "firmware in (v2, v3)") is True
+
+    def test_match_mixed(self):
+        lease = "board=rpi,firmware in (v2, v3)"
+        assert selector_contains(lease, "board=rpi") is True
+        assert selector_contains(lease, "firmware in (v2, v3)") is True
+        assert selector_contains(lease, "board=rpi,firmware in (v2, v3)") is True
+
+    def test_no_match_expression(self):
+        assert selector_contains("board=rpi", "firmware in (v2, v3)") is False
+
+    def test_filter_not_exists(self):
+        assert selector_contains("board=rpi,!experimental", "!experimental") is True
+        assert selector_contains("board=rpi", "!experimental") is False
+
+    def test_empty_filter_matches_all(self):
+        assert selector_contains("board=rpi,firmware in (v2, v3)", "") is True
+
+    def test_whitespace_tolerance(self):
+        """Whitespace around operators should be tolerated (matching Go behavior)."""
+        assert selector_contains("board=rpi", "board = rpi") is True
+        assert selector_contains("board=rpi", "board =rpi") is True
+        assert selector_contains("board=rpi", "board= rpi") is True
+        assert selector_contains("firmware!=v3", "firmware != v3") is True


### PR DESCRIPTION
Mirrors the labels from `spec.selector.matchLabels` to `metadata.labels` 
during lease creation. This allows the controller to filter leases 
server-side when using label selectors (e.g., `jmp get leases -l key=val`).

Fixes: https://github.com/jumpstarter-dev/jumpstarter/issues/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lease objects now inherit labels from selector matchLabels.
  * Client tooling adds label-selector parsing and optional client-side selector filtering.

* **Bug Fixes**
  * Lease listing applies an active-only filter by default when unspecified.

* **Tests**
  * New unit and end-to-end tests covering label propagation, selector parsing, matchExpressions-only, negation, and selector-filtering behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->