### PR TITLE
[python/qemu-driver]  _vsock_available function changes 

### DIFF
--- a/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver.py
+++ b/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/driver.py
@@ -29,8 +29,14 @@ from jumpstarter.driver import Driver, export
 from jumpstarter.streams.encoding import AutoDecompressIterator
 
 
-def _vsock_available():
-    return platform.system() == "Linux"
+def _vsock_available(socket_path: str = "/dev/vhost-vsock") -> bool:
+    if platform.system() != "Linux":
+        return False
+
+    if not os.path.exists(socket_path):
+        return False
+
+    return os.access(socket_path, os.R_OK | os.W_OK)
 
 
 class QmpLogFilter(logging.Filter):


### PR DESCRIPTION
##  Motvation

The driver fails to create a VM if vsock cannot be used.

## Changes

* Changes how `_vsock_available` identifies if vsock is available by checking `/dev/vhost-vsock` path and perms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced socket availability detection with improved validation checks. Now accurately determines vsock availability by verifying path existence and access permissions, with proper handling for non-Linux systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->