### PR TITLE
Fix lease labels over-filtering

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/delete.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/delete.py
@@ -32,6 +32,8 @@ def delete_leases(config, name: str, selector: str | None, all: bool, output: Ou
         names.append(name)
     elif selector:
         leases = config.list_leases(filter=selector)
+        # Client-side filtering for matchExpressions (server only filters matchLabels)
+        leases = leases.filter_by_selector(selector)
         for lease in leases.leases:
             if lease.client == config.metadata.name:
                 names.append(lease.name)

--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -13,7 +13,7 @@ from grpc.aio import Channel
 from jumpstarter_protocol import client_pb2, client_pb2_grpc, jumpstarter_pb2_grpc, kubernetes_pb2, router_pb2_grpc
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
-from jumpstarter.client.selectors import selector_contains
+from jumpstarter.client.selectors import extract_match_labels_filter, selector_contains
 from jumpstarter.common.grpc import translate_grpc_exceptions
 
 
@@ -383,7 +383,7 @@ class ClientService:
                     parent="namespaces/{}".format(self.namespace),
                     page_size=page_size,
                     page_token=page_token,
-                    filter=filter,
+                    filter=extract_match_labels_filter(filter),
                     only_active=only_active,
                 )
             )

--- a/python/packages/jumpstarter/jumpstarter/client/selectors.py
+++ b/python/packages/jumpstarter/jumpstarter/client/selectors.py
@@ -51,6 +51,22 @@ def parse_label_selector(selector: str) -> tuple[dict[str, str], list[tuple[str,
     return match_labels, match_expressions
 
 
+def extract_match_labels_filter(selector: str | None) -> str | None:
+    """Extract only the matchLabels portion from a selector string.
+
+    This is used to send only the server-filterable portion to the server,
+    since matchExpressions can't be matched against metadata.labels.
+    """
+    if not selector:
+        return None
+    match_labels, _ = parse_label_selector(selector)
+    if not match_labels:
+        return None
+    # Format matchLabels dict back to a selector string.
+    # Example: {"board": "rpi", "env": "test"} -> "board=rpi,env=test"
+    return ",".join(f"{k}={v}" for k, v in match_labels.items())
+
+
 def selector_contains(selector: str, requirements: str) -> bool:
     """Check if selector contains all criteria from requirements.
 


### PR DESCRIPTION
A quick bug fix for server-side over-filtering where a complex selector was being sent to the server for pre-filtering as-is, instead of sending only its matchLabels subset and handling matchExpressions client-side.

also included some e2e tests to cover that.

this is a follow up PR to https://github.com/jumpstarter-dev/jumpstarter/pull/168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end regression tests covering complex lease selectors: combined label+expression selectors, partial matches, non-matches, and over-filtering scenarios.

* **Bug Fixes**
  * Listing and deletion of leases with complex selectors now combine server-side label filtering with client-side expression filtering to produce accurate results and avoid unintended over-filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->