### PR TITLE
ci: fix python skips

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -7,9 +7,6 @@ on:
       - main
       - release-*
   pull_request:
-    branches:
-      - main
-      - 'release-*'
   merge_group:
 
 permissions:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -6,14 +6,10 @@ on:
     branches:
       - main
       - release-*
-    paths:
-      - 'python/**'
-      - 'protocol/**'
   pull_request:
-    # running for all, since github does not detect skipped on this when required for merging
-    #paths:
-    #  - 'python/**'
-    #  - 'protocol/**'
+    branches:
+      - main
+      - 'release-*'
   merge_group:
 
 permissions:
@@ -21,7 +17,27 @@ permissions:
   pull-requests: read
 
 jobs:
+  changes:
+    if: github.repository_owner == 'jumpstarter-dev'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
+          filters: |
+            python:
+              - 'python/**'
+              - '.github/workflows/python-tests.yaml'
+
   pytest-matrix:
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
@@ -89,13 +105,14 @@ jobs:
   # https://github.com/orgs/community/discussions/26822
   pytest:
     runs-on: ubuntu-latest
-    needs: [pytest-matrix]
+    needs: [changes, pytest-matrix]
     if: ${{ always() }}
     steps:
       - run: exit 1
+        # Fail on failures or cancellations, but allow skips when no relevant changes
         if: >-
           ${{
                contains(needs.*.result, 'failure')
             || contains(needs.*.result, 'cancelled')
-            || contains(needs.*.result, 'skipped')
+            || (contains(needs.*.result, 'skipped') && needs.changes.outputs.should_run == 'true')
           }}


### PR DESCRIPTION
General workflow level skips don't work for github if you make PRs depending on any jobs from the workflow, the PR just keeps waiting and the job never shows up, this is a know limitation of github today.

The alternative that seems to work is to make individual jobs skipped based on rules, like in this case the detection of files being modified or not, this will make the job show as "skipped" and then it's ok that you add a rule to require the job for merging, when the job shows at skipped that is good enough for you to be able to merge the PR.

The intent of this PR is to optimize the usage of CI resources and the noise/clutter of too many CI runs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI testing workflow: added a pre-check job that exposes a should_run output.
  * Test matrix now depends on that pre-check and runs only when should_run is true or on manual trigger.
  * Test job dependency chain adjusted to include the pre-check and matrix.
  * Push-trigger configuration no longer restricts runs by specific paths.
  * Final test-step treats skipped outcomes as failures unless should_run is true.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->