### PR TITLE
ci: run PR workflows on top of any branch

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -10,9 +10,6 @@ on:
       - 'release-*'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-    branches:
-      - main
-      - 'release-*'
   merge_group:
 
 env:

--- a/.github/workflows/controller-bundle.yaml
+++ b/.github/workflows/controller-bundle.yaml
@@ -2,9 +2,6 @@ name: Check Bundle
 
 on:
   pull_request:
-    branches:
-      - main
-      - 'release-*'
     paths:
       - 'controller/**'
 

--- a/.github/workflows/controller-kind.yaml
+++ b/.github/workflows/controller-kind.yaml
@@ -3,9 +3,6 @@ name: Kind based CI
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
-      - 'release-*'
     paths:
       - 'controller/**'
 

--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -3,9 +3,6 @@ name: Controller Unit/Functional tests
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
-      - 'release-*'
     paths:
       - 'controller/**'
       - 'protocol/**'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,9 +3,6 @@ name: End-to-end tests
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
-      - 'release-*'
   merge_group:
 
 permissions:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,9 +7,6 @@ on:
       - main
       - 'release-*'
   pull_request:
-    branches:
-      - main
-      - 'release-*'
   merge_group:
 
 permissions:


### PR DESCRIPTION
This makes sure that PRs depending on ohter PRs are still running all the CI jobs. Otherwise some of the workflows don't run on that type of PR which base is just another branch from another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded GitHub Actions workflow triggers to execute on pull requests across all branches instead of main and release-* only, improving test coverage and validation throughout the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->