### PR TITLE
make pkg-test typo

### DIFF
--- a/.cursor/rules/creating-new-drivers.mdc
+++ b/.cursor/rules/creating-new-drivers.mdc
@@ -84,7 +84,7 @@ The script automatically creates:
 - Follow existing code style (validate with `make lint`, fix with `make lint-fix`)
 - Perform static type checking with `make ty-pkg-${package_name}`
 - Add comprehensive tests and update documentation
-- Verify all tests pass (`make test-pkg-${package_name}` or `make test`)
+- Verify all tests pass (`make pkg-test-${package_name}` or `make test`)
 
 ## Contributing Guidelines
 

--- a/.cursor/rules/project-structure.mdc
+++ b/.cursor/rules/project-structure.mdc
@@ -118,7 +118,7 @@ python/examples/
 
 ### Testing
 
-- **Package tests**: `make test-pkg-<package_name>`
+- **Package tests**: `make pkg-test-<package_name>`
 - **All tests**: `make test`
 - **Coverage**: Configured per package with HTML and XML reports
 

--- a/python/docs/source/contributing.md
+++ b/python/docs/source/contributing.md
@@ -29,7 +29,7 @@ If you have questions, reach out in our Matrix chat or open an issue on GitHub.
 - Follow code style (validate with `make lint`, fix with `make lint-fix`)
 - Perform static type checking with (`make ty-pkg-${package_name}`)
 - Add tests and update documentation. New drivers/features need tests and docs.
-- Verify all tests pass (`make test-pkg-${package_name}` or `make test`)
+- Verify all tests pass (`make pkg-test-${package_name}` or `make test`)
 
 ### Commit Messages
 

--- a/python/docs/source/contributing/development-environment.md
+++ b/python/docs/source/contributing/development-environment.md
@@ -47,7 +47,7 @@ $ make test
 You can also run specific tests with:
 
 ```console
-$ make test-pkg-${package_name}
+$ make pkg-test-${package_name}
 ```
 
 ## Go Environment


### PR DESCRIPTION
according to makefile, we're using `make pkg-test-` for testing a package, however few places mention `make test-pkg-` instead, which seems like a typo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guide documentation to reflect the correct test invocation command syntax: use `make pkg-test-${package_name}` instead of `make test-pkg-${package_name}` for running package-specific tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->