### PR TITLE
shell: keep shell usable after token refreshes

### DIFF
--- a/python/packages/jumpstarter-cli/conftest.py
+++ b/python/packages/jumpstarter-cli/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from datetime import timedelta
 
@@ -8,6 +9,8 @@ from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.exceptions import handle_exceptions_with_reauthentication
 from jumpstarter_cli_common.oidc import (
     TOKEN_EXPIRY_WARNING_SECONDS,
+    Config,
+    decode_jwt_issuer,
     format_duration,
     get_token_remaining_seconds,
 )
@@ -19,6 +22,11 @@ from jumpstarter.common.utils import launch_shell
 from jumpstarter.config.client import ClientConfigV1Alpha1
 from jumpstarter.config.exporter import ExporterConfigV1Alpha1
 
+logger = logging.getLogger(__name__)
+
+# Refresh token when less than this many seconds remain
+_TOKEN_REFRESH_THRESHOLD_SECONDS = 120
+
 
 def _warn_about_expired_token(lease_name: str, selector: str) -> None:
     """Warn user that lease won't be cleaned up due to expired token."""
@@ -27,36 +35,184 @@ def _warn_about_expired_token(lease_name: str, selector: str) -> None:
     click.echo(click.style(f"To reconnect: JMP_LEASE={lease_name} jmp shell", fg="cyan"))
 
 
-async def _monitor_token_expiry(config, cancel_scope) -> None:
-    """Monitor token expiry and warn user."""
+async def _update_lease_channel(config, lease) -> None:
+    """Update the lease's gRPC channel with the current config credentials."""
+    if lease is not None:
+        new_channel = await config.channel()
+        lease.refresh_channel(new_channel)
+
+
+async def _try_refresh_token(config, lease) -> bool:
+    """Attempt to refresh the token and update the lease channel.
+
+    Returns True if refresh succeeded, False otherwise.
+    """
+    refresh_token = getattr(config, "refresh_token", None)
+    if not refresh_token:
+        return False
+
+    old_token = config.token
+    old_refresh_token = config.refresh_token
+    try:
+        issuer = decode_jwt_issuer(config.token)
+        oidc = Config(
+            issuer=issuer,
+            client_id="jumpstarter-cli",
+            offline_access=True,
+        )
+
+        tokens = await oidc.refresh_token_grant(refresh_token)
+        config.token = tokens["access_token"]
+        new_refresh_token = tokens.get("refresh_token")
+        if new_refresh_token is not None:
+            config.refresh_token = new_refresh_token
+
+        # Update the lease channel first (critical for the running session)
+        await _update_lease_channel(config, lease)
+
+        # Persist to disk (best-effort, uses original config path)
+        try:
+            ClientConfigV1Alpha1.save(config, path=config.path)
+        except Exception as e:
+            logger.warning("Failed to save refreshed token to disk: %s", e)
+
+        return True
+    except Exception as e:
+        # Restore old token so the monitor doesn't think we succeeded
+        config.token = old_token
+        config.refresh_token = old_refresh_token
+        logger.debug("Token refresh failed: %s", e)
+        return False
+
+
+async def _try_reload_token_from_disk(config, lease) -> bool:
+    """Check if the config on disk has a newer/valid token (e.g. from 'jmp login').
+
+    If a valid token is found on disk, updates the in-memory config and lease channel.
+    Returns True if a valid token was loaded, False otherwise.
+    """
+    config_path = getattr(config, "path", None)
+    if not config_path:
+        return False
+
+    old_token = config.token
+    old_refresh_token = config.refresh_token
+    try:
+        disk_config = ClientConfigV1Alpha1.from_file(config_path)
+        disk_token = getattr(disk_config, "token", None)
+        if not disk_token or disk_token == config.token:
+            return False
+
+        # Check if the token on disk is actually valid
+        disk_remaining = get_token_remaining_seconds(disk_token)
+        if disk_remaining is None or disk_remaining <= 0:
+            return False
+
+        # Token on disk is valid and different - use it
+        config.token = disk_token
+        disk_refresh = getattr(disk_config, "refresh_token", None)
+        if disk_refresh is not None:
+            config.refresh_token = disk_refresh
+
+        # Update the lease channel (critical for the running session)
+        await _update_lease_channel(config, lease)
+
+        return True
+    except Exception as e:
+        config.token = old_token
+        config.refresh_token = old_refresh_token
+        logger.debug("Failed to reload token from disk: %s", e)
+        return False
+
+
+async def _attempt_token_recovery(config, lease, remaining) -> str | None:
+    """Try all available methods to recover a valid token.
+
+    Attempts OIDC refresh first, then falls back to reloading from disk
+    (e.g. if user ran 'jmp login' from the shell).
+
+    Returns a message describing the recovery method, or None if all failed.
+    """
+    if await _try_refresh_token(config, lease):
+        return "Token refreshed automatically."
+    if await _try_reload_token_from_disk(config, lease):
+        return "Token reloaded from login."
+    return None
+
+
+def _warn_refresh_failed(remaining: float) -> None:
+    """Warn the user that token refresh failed."""
+    if remaining > 0:
+        duration = format_duration(remaining)
+        click.echo(
+            click.style(
+                f"\nToken expires in {duration} and auto-refresh failed. "
+                "Run 'jmp login' from this shell to refresh manually.",
+                fg="yellow",
+                bold=True,
+            )
+        )
+    else:
+        click.echo(
+            click.style(
+                "\nToken expired and auto-refresh failed. "
+                "New commands will fail until you run 'jmp login' from this shell.",
+                fg="red",
+                bold=True,
+            )
+        )
+
+
+async def _monitor_token_expiry(config, lease, cancel_scope) -> None:
+    """Monitor token expiry, auto-refresh when possible, warn user otherwise.
+
+    this monitor:
+    1. Proactively refreshes the token before it expires using the refresh token
+    2. Updates the lease's gRPC channel with new credentials
+    3. If refresh fails, periodically checks the config on disk for a token
+       refreshed externally (e.g. via 'jmp login' from within the shell)
+    4. Never cancels the scope - the shell stays alive regardless
+    """
     token = getattr(config, "token", None)
     if not token:
         return
 
-    warned = False
+    warned_expiry = False
+    warned_refresh_failed = False
     while not cancel_scope.cancel_called:
         try:
-            remaining = get_token_remaining_seconds(token)
+            # Re-read config.token each iteration since it may have been refreshed
+            remaining = get_token_remaining_seconds(config.token)
             if remaining is None:
                 return
 
-            if remaining <= 0:
-                click.echo(click.style("\nToken expired! Exiting shell.", fg="red", bold=True))
-                cancel_scope.cancel()
-                return
+            # Try to refresh proactively before the token expires
+            if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
+                recovery_msg = await _attempt_token_recovery(config, lease, remaining)
+                if recovery_msg:
+                    click.echo(click.style(f"\n{recovery_msg}", fg="green"))
+                    warned_expiry = False
+                    warned_refresh_failed = False
+                elif not warned_refresh_failed:
+                    _warn_refresh_failed(remaining)
+                    warned_refresh_failed = True
 
-            if remaining <= TOKEN_EXPIRY_WARNING_SECONDS and not warned:
+            elif remaining <= TOKEN_EXPIRY_WARNING_SECONDS and not warned_expiry:
                 duration = format_duration(remaining)
                 click.echo(
                     click.style(
-                        f"\nToken expires in {duration}. Session will continue but cleanup may fail on exit.",
+                        f"\nToken expires in {duration}. Will attempt auto-refresh.",
                         fg="yellow",
                         bold=True,
                     )
                 )
-                warned = True
+                warned_expiry = True
 
-            await anyio.sleep(30)
+            # Check more frequently as we approach expiry
+            if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
+                await anyio.sleep(5)
+            else:
+                await anyio.sleep(30)
         except Exception:
             return
 
@@ -111,7 +267,7 @@ async def _shell_with_signal_handling(
                         lease_used = lease
 
                         # Start token monitoring only once we're in the shell
-                        tg.start_soon(_monitor_token_expiry, config, tg.cancel_scope)
+                        tg.start_soon(_monitor_token_expiry, config, lease, tg.cancel_scope)
 
                         exit_code = await anyio.to_thread.run_sync(
                             _run_shell_with_lease, lease, exporter_logs, config, command

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -1,0 +1,377 @@
+import logging
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from jumpstarter_cli.shell import (
+    _attempt_token_recovery,
+    _monitor_token_expiry,
+    _try_refresh_token,
+    _try_reload_token_from_disk,
+    _update_lease_channel,
+    _warn_refresh_failed,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _make_config(token="tok", refresh_token="rt", path="/tmp/config.yaml"):
+    """Create a mock config with sensible defaults."""
+    config = Mock()
+    config.token = token
+    config.refresh_token = refresh_token
+    config.path = path
+    config.channel = AsyncMock(return_value=Mock(name="new_channel"))
+    return config
+
+
+def _make_lease():
+    """Create a mock lease with a refresh_channel method."""
+    lease = Mock()
+    lease.refresh_channel = Mock()
+    return lease
+
+
+class TestUpdateLeaseChannel:
+    async def test_updates_channel_on_lease(self):
+        config = _make_config()
+        lease = _make_lease()
+
+        await _update_lease_channel(config, lease)
+
+        config.channel.assert_awaited_once()
+        lease.refresh_channel.assert_called_once_with(config.channel.return_value)
+
+    async def test_noop_when_lease_is_none(self):
+        config = _make_config()
+
+        await _update_lease_channel(config, None)
+
+        config.channel.assert_not_awaited()
+
+
+class TestTryRefreshToken:
+    async def test_returns_false_when_no_refresh_token(self):
+        config = _make_config(refresh_token=None)
+        assert await _try_refresh_token(config, _make_lease()) is False
+
+    async def test_returns_false_when_refresh_token_is_empty(self):
+        config = _make_config(refresh_token="")
+        assert await _try_refresh_token(config, _make_lease()) is False
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    @patch("jumpstarter_cli.shell.Config")
+    @patch("jumpstarter_cli.shell.decode_jwt_issuer", return_value="https://issuer")
+    async def test_successful_refresh(self, _mock_issuer, mock_oidc_cls, mock_save):
+        config = _make_config()
+        lease = _make_lease()
+
+        mock_oidc = AsyncMock()
+        mock_oidc.refresh_token_grant.return_value = {
+            "access_token": "new_tok",
+            "refresh_token": "new_rt",
+        }
+        mock_oidc_cls.return_value = mock_oidc
+
+        result = await _try_refresh_token(config, lease)
+
+        assert result is True
+        assert config.token == "new_tok"
+        assert config.refresh_token == "new_rt"
+        lease.refresh_channel.assert_called_once()
+        mock_save.save.assert_called_once()
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    @patch("jumpstarter_cli.shell.Config")
+    @patch("jumpstarter_cli.shell.decode_jwt_issuer", return_value="https://issuer")
+    async def test_successful_refresh_without_new_refresh_token(
+        self, _mock_issuer, mock_oidc_cls, _mock_save
+    ):
+        config = _make_config()
+        lease = _make_lease()
+
+        mock_oidc = AsyncMock()
+        mock_oidc.refresh_token_grant.return_value = {
+            "access_token": "new_tok",
+            # No refresh_token in response
+        }
+        mock_oidc_cls.return_value = mock_oidc
+
+        result = await _try_refresh_token(config, lease)
+
+        assert result is True
+        assert config.token == "new_tok"
+        assert config.refresh_token == "rt"  # unchanged
+
+    @patch("jumpstarter_cli.shell.decode_jwt_issuer", side_effect=ValueError("bad jwt"))
+    async def test_rollback_on_failure(self, _mock_issuer):
+        config = _make_config(token="original_tok", refresh_token="original_rt")
+        lease = _make_lease()
+
+        result = await _try_refresh_token(config, lease)
+
+        assert result is False
+        assert config.token == "original_tok"
+        assert config.refresh_token == "original_rt"
+        lease.refresh_channel.assert_not_called()
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    @patch("jumpstarter_cli.shell.Config")
+    @patch("jumpstarter_cli.shell.decode_jwt_issuer", return_value="https://issuer")
+    async def test_save_failure_does_not_fail_refresh(
+        self, _mock_issuer, mock_oidc_cls, mock_save, caplog
+    ):
+        """Disk save is best-effort; refresh should still succeed."""
+        config = _make_config()
+        lease = _make_lease()
+
+        mock_oidc = AsyncMock()
+        mock_oidc.refresh_token_grant.return_value = {
+            "access_token": "new_tok",
+        }
+        mock_oidc_cls.return_value = mock_oidc
+        mock_save.save.side_effect = OSError("disk full")
+
+        with caplog.at_level(logging.WARNING):
+            result = await _try_refresh_token(config, lease)
+
+        assert result is True
+        assert config.token == "new_tok"
+        assert "Failed to save refreshed token to disk" in caplog.text
+
+
+class TestTryReloadTokenFromDisk:
+    async def test_returns_false_when_no_path(self):
+        config = _make_config(path=None)
+        assert await _try_reload_token_from_disk(config, _make_lease()) is False
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=3600)
+    async def test_successful_reload(self, _mock_remaining, mock_client_cfg):
+        config = _make_config(token="old_tok", refresh_token="old_rt")
+        lease = _make_lease()
+
+        disk_config = Mock()
+        disk_config.token = "disk_tok"
+        disk_config.refresh_token = "disk_rt"
+        mock_client_cfg.from_file.return_value = disk_config
+
+        result = await _try_reload_token_from_disk(config, lease)
+
+        assert result is True
+        assert config.token == "disk_tok"
+        assert config.refresh_token == "disk_rt"
+        lease.refresh_channel.assert_called_once()
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    async def test_returns_false_when_disk_token_is_same(self, mock_client_cfg):
+        config = _make_config(token="same_tok")
+        disk_config = Mock()
+        disk_config.token = "same_tok"
+        mock_client_cfg.from_file.return_value = disk_config
+
+        result = await _try_reload_token_from_disk(config, _make_lease())
+
+        assert result is False
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=-10)
+    async def test_returns_false_when_disk_token_is_expired(
+        self, _mock_remaining, mock_client_cfg
+    ):
+        config = _make_config(token="old_tok")
+        disk_config = Mock()
+        disk_config.token = "disk_tok"
+        mock_client_cfg.from_file.return_value = disk_config
+
+        result = await _try_reload_token_from_disk(config, _make_lease())
+
+        assert result is False
+        assert config.token == "old_tok"  # unchanged
+
+    @patch("jumpstarter_cli.shell.ClientConfigV1Alpha1")
+    async def test_rollback_on_file_error(self, mock_client_cfg):
+        config = _make_config(token="orig_tok", refresh_token="orig_rt")
+        mock_client_cfg.from_file.side_effect = FileNotFoundError("gone")
+
+        result = await _try_reload_token_from_disk(config, _make_lease())
+
+        assert result is False
+        assert config.token == "orig_tok"
+        assert config.refresh_token == "orig_rt"
+
+
+class TestAttemptTokenRecovery:
+    @patch("jumpstarter_cli.shell._try_reload_token_from_disk", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._try_refresh_token", new_callable=AsyncMock)
+    async def test_returns_message_on_oidc_success(self, mock_refresh, mock_disk):
+        mock_refresh.return_value = True
+
+        result = await _attempt_token_recovery(Mock(), Mock(), 60)
+
+        assert result == "Token refreshed automatically."
+        mock_disk.assert_not_awaited()  # should not fall through
+
+    @patch("jumpstarter_cli.shell._try_reload_token_from_disk", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._try_refresh_token", new_callable=AsyncMock)
+    async def test_falls_back_to_disk_reload(self, mock_refresh, mock_disk):
+        mock_refresh.return_value = False
+        mock_disk.return_value = True
+
+        result = await _attempt_token_recovery(Mock(), Mock(), 60)
+
+        assert result == "Token reloaded from login."
+
+    @patch("jumpstarter_cli.shell._try_reload_token_from_disk", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._try_refresh_token", new_callable=AsyncMock)
+    async def test_returns_none_when_all_fail(self, mock_refresh, mock_disk):
+        mock_refresh.return_value = False
+        mock_disk.return_value = False
+
+        result = await _attempt_token_recovery(Mock(), Mock(), 60)
+
+        assert result is None
+
+
+class TestWarnRefreshFailed:
+    @patch("jumpstarter_cli.shell.click")
+    def test_warns_yellow_when_time_remaining(self, mock_click):
+        _warn_refresh_failed(300)
+        mock_click.style.assert_called_once()
+        _, kwargs = mock_click.style.call_args
+        assert kwargs["fg"] == "yellow"
+
+    @patch("jumpstarter_cli.shell.click")
+    def test_warns_red_when_expired(self, mock_click):
+        _warn_refresh_failed(-10)
+        mock_click.style.assert_called_once()
+        _, kwargs = mock_click.style.call_args
+        assert kwargs["fg"] == "red"
+
+
+class TestMonitorTokenExpiry:
+    async def test_returns_immediately_when_no_token(self):
+        config = Mock(spec=[])  # no token attribute
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, None, cancel_scope)
+        # Should return without error
+
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=None)
+    async def test_returns_when_remaining_is_none(self, _mock_remaining, _mock_sleep):
+        config = _make_config()
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, None, cancel_scope)
+
+    @patch("jumpstarter_cli.shell.click")
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._attempt_token_recovery", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds")
+    async def test_refreshes_when_below_threshold(
+        self, mock_remaining, mock_recovery, mock_sleep, mock_click
+    ):
+        # First call: below threshold; second call: raise to exit
+        mock_remaining.side_effect = [60, Exception("done")]
+        mock_recovery.return_value = "Token refreshed automatically."
+        config = _make_config()
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, _make_lease(), cancel_scope)
+
+        mock_recovery.assert_awaited_once()
+        # Should print the green success message
+        mock_click.echo.assert_called()
+
+    @patch("jumpstarter_cli.shell.click")
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._attempt_token_recovery", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds")
+    async def test_warns_when_refresh_fails(
+        self, mock_remaining, mock_recovery, mock_sleep, mock_click
+    ):
+        mock_remaining.side_effect = [60, Exception("done")]
+        mock_recovery.return_value = None  # all recovery failed
+        config = _make_config()
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, _make_lease(), cancel_scope)
+
+        mock_recovery.assert_awaited_once()
+
+    @patch("jumpstarter_cli.shell.click")
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds")
+    async def test_warns_within_expiry_window(
+        self, mock_remaining, mock_sleep, mock_click
+    ):
+        from jumpstarter_cli_common.oidc import TOKEN_EXPIRY_WARNING_SECONDS
+
+        # First iteration: within warning window but above refresh threshold
+        # Second iteration: exit via exception
+        mock_remaining.side_effect = [
+            TOKEN_EXPIRY_WARNING_SECONDS - 10,
+            Exception("done"),
+        ]
+        config = _make_config()
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, _make_lease(), cancel_scope)
+
+        # Verify warning was echoed
+        mock_click.echo.assert_called()
+        args = mock_click.style.call_args
+        assert "auto-refresh" in args[0][0]
+
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=500)
+    async def test_sleeps_30s_when_above_threshold(self, _mock_remaining, mock_sleep):
+        # Exit after one loop via cancel_called
+        call_count = 0
+
+        def check_cancelled():
+            nonlocal call_count
+            call_count += 1
+            return call_count > 1
+
+        config = _make_config()
+        cancel_scope = Mock()
+        type(cancel_scope).cancel_called = property(lambda self: check_cancelled())
+
+        await _monitor_token_expiry(config, _make_lease(), cancel_scope)
+
+        mock_sleep.assert_awaited_with(30)
+
+    @patch("jumpstarter_cli.shell.click")
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._attempt_token_recovery", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds")
+    async def test_sleeps_5s_when_below_threshold(
+        self, mock_remaining, mock_recovery, mock_sleep, _mock_click
+    ):
+        mock_remaining.side_effect = [60, Exception("done")]
+        mock_recovery.return_value = None
+        config = _make_config()
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, _make_lease(), cancel_scope)
+
+        mock_sleep.assert_awaited_with(5)
+
+    @patch("jumpstarter_cli.shell.click")
+    @patch("jumpstarter_cli.shell.anyio.sleep", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell._attempt_token_recovery", new_callable=AsyncMock)
+    @patch("jumpstarter_cli.shell.get_token_remaining_seconds")
+    async def test_does_not_cancel_scope_on_expiry(
+        self, mock_remaining, mock_recovery, mock_sleep, _mock_click
+    ):
+        """The monitor must never cancel the scope — the shell stays alive."""
+        mock_remaining.side_effect = [60, Exception("done")]
+        mock_recovery.return_value = None
+        config = _make_config()
+        cancel_scope = Mock(cancel_called=False)
+
+        await _monitor_token_expiry(config, _make_lease(), cancel_scope)
+
+        cancel_scope.cancel.assert_not_called()

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -289,7 +289,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
 
     def _get_lease_end_time(self, lease) -> datetime | None:
         """Extract the end time from a lease response, or None if not available."""
-        if not (lease.effective_begin_time and lease.effective_duration):
+        if not (lease.effective_begin_time and lease.duration):
             return None
         if lease.effective_end_time:
             return lease.effective_end_time

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -65,6 +65,16 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         self.controller = jumpstarter_pb2_grpc.ControllerServiceStub(self.channel)
         self.svc = ClientService(channel=self.channel, namespace=self.namespace)
 
+    def refresh_channel(self, channel: Channel):
+        """Update the gRPC channel used for controller communication.
+
+        This is used when the auth token is refreshed to update the
+        underlying gRPC channel with new credentials.
+        """
+        self.channel = channel
+        self.controller = jumpstarter_pb2_grpc.ControllerServiceStub(channel)
+        self.svc = ClientService(channel=channel, namespace=self.namespace)
+
     async def _create(self):
         logger.debug("Creating lease request for selector %s for duration %s", self.selector, self.duration)
         with translate_grpc_exceptions():
@@ -272,37 +282,66 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
                 logger.error("Unexpected error while waiting for ready connection to %s: %s", path, e)
                 raise ConnectionError("Unexpected error while waiting for ready connection to %s" % path) from e
 
+    def _notify_lease_ending(self, remaining: timedelta) -> None:
+        """Notify the lease ending callback if one is set."""
+        if self.lease_ending_callback is not None:
+            self.lease_ending_callback(self, remaining)
+
+    def _get_lease_end_time(self, lease) -> datetime | None:
+        """Extract the end time from a lease response, or None if not available."""
+        if not (lease.effective_begin_time and lease.effective_duration):
+            return None
+        if lease.effective_end_time:
+            return lease.effective_end_time
+        return lease.effective_begin_time + lease.duration
+
     @asynccontextmanager
     async def monitor_async(self, threshold: timedelta = timedelta(minutes=5)):
         async def _monitor():
             check_interval = 30  # seconds - check periodically for external lease changes
+            last_known_end_time = None
             while True:
-                lease = await self.get()
-                if lease.effective_begin_time and lease.effective_duration:
-                    if lease.effective_end_time:  # already ended
-                        end_time = lease.effective_end_time
-                    else:
-                        end_time = lease.effective_begin_time + lease.duration
-                    remain = end_time - datetime.now().astimezone()
-                    if remain < timedelta(0):
-                        # lease already expired, stopping monitor
-                        logger.info("Lease {} ended at {}".format(self.name, end_time))
-                        if self.lease_ending_callback is not None:
-                            self.lease_ending_callback(self, timedelta(0))
-                        break
-                    # Log once when entering the threshold window
-                    if threshold - timedelta(seconds=check_interval) <= remain < threshold:
-                        logger.info(
-                            "Lease {} ending in {} minutes at {}".format(
-                                self.name, int((remain.total_seconds() + 30) // 60), end_time
+                try:
+                    lease = await self.get()
+                except Exception as e:
+                    logger.warning("Failed to check lease %s status: %s", self.name, e)
+                    # If we know when the lease should end, use it to bound the sleep
+                    if last_known_end_time is not None:
+                        remain = (last_known_end_time - datetime.now().astimezone()).total_seconds()
+                        if remain <= 0:
+                            logger.info(
+                                "Lease %s estimated to have ended at %s (unable to confirm with server)",
+                                self.name,
+                                last_known_end_time,
                             )
-                        )
-                        # Notify callback about approaching expiration
-                        if self.lease_ending_callback is not None:
-                            self.lease_ending_callback(self, remain)
-                    await sleep(min(remain.total_seconds(), check_interval))
-                else:
+                            self._notify_lease_ending(timedelta(0))
+                            break
+                        await sleep(min(check_interval, remain))
+                    else:
+                        await sleep(check_interval)
+                    continue
+
+                end_time = self._get_lease_end_time(lease)
+                if end_time is None:
                     await sleep(1)
+                    continue
+
+                last_known_end_time = end_time
+                remain = end_time - datetime.now().astimezone()
+                if remain < timedelta(0):
+                    logger.info("Lease {} ended at {}".format(self.name, end_time))
+                    self._notify_lease_ending(timedelta(0))
+                    break
+
+                # Log once when entering the threshold window
+                if threshold - timedelta(seconds=check_interval) <= remain < threshold:
+                    logger.info(
+                        "Lease {} ending in {} minutes at {}".format(
+                            self.name, int((remain.total_seconds() + 30) // 60), end_time
+                        )
+                    )
+                    self._notify_lease_ending(remain)
+                await sleep(min(remain.total_seconds(), check_interval))
 
         async with create_task_group() as tg:
             tg.start_soon(_monitor)

--- a/python/packages/jumpstarter/jumpstarter/client/lease_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease_test.py
@@ -396,7 +396,7 @@ class TestGetLeaseEndTime:
 
     def test_returns_none_when_no_begin_time(self):
         lease = self._make_lease()
-        response = Mock(effective_begin_time=None, effective_duration=timedelta(minutes=30))
+        response = Mock(effective_begin_time=None, duration=timedelta(minutes=30))
 
         assert lease._get_lease_end_time(response) is None
 
@@ -404,7 +404,7 @@ class TestGetLeaseEndTime:
         lease = self._make_lease()
         response = Mock(
             effective_begin_time=datetime.now(tz=timezone.utc),
-            effective_duration=None,
+            duration=None,
         )
 
         assert lease._get_lease_end_time(response) is None
@@ -414,7 +414,7 @@ class TestGetLeaseEndTime:
         end_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
         response = Mock(
             effective_begin_time=datetime(2025, 6, 1, 11, 0, 0, tzinfo=timezone.utc),
-            effective_duration=timedelta(hours=1),
+            duration=timedelta(hours=1),
             effective_end_time=end_time,
         )
 
@@ -426,7 +426,7 @@ class TestGetLeaseEndTime:
         duration = timedelta(hours=2)
         response = Mock(
             effective_begin_time=begin,
-            effective_duration=duration,
+            effective_duration=timedelta(hours=1),  # elapsed time, not used for calculation
             effective_end_time=None,
             duration=duration,
         )


### PR DESCRIPTION
Currently, when token expires, the shell becomes unusable, and even if we recover by refreshing, the shell will remain unusable until it is recreated.

Instead, we do not cancel the monitor when the token expires and give the user a chance to refresh their token (if it wasn't automatically refreshed).

fixes #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proactive token monitoring with automatic refresh and disk-reload recovery; seamless reconnection when credentials change.

* **Improvements**
  * Clearer, actionable expiry warnings and login guidance.
  * More resilient lease/connection monitoring that tolerates transient outages and better estimates remaining time.
  * Preserves existing credentials on refresh failures to avoid disruption.

* **Tests**
  * Extensive unit tests for token refresh/reload, recovery paths, channel updates, and monitoring logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->