### PR TITLE
ci: run make bundle before trying to create the image

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -39,6 +39,7 @@ jobs:
           - image_name: jumpstarter-dev/jumpstarter-operator-bundle
             dockerfile: controller/deploy/operator/bundle.Dockerfile
             context: controller/deploy/operator
+            generate_bundle: true
           # Python images (use repo root context for .git access needed by hatch-vcs)
           - image_name: jumpstarter-dev/jumpstarter
             dockerfile: python/Dockerfile
@@ -85,6 +86,11 @@ jobs:
           echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
           echo "GIT_COMMIT=${GIT_COMMIT}"
           echo "BUILD_DATE=${BUILD_DATE}"
+
+      - name: Generate operator bundle
+        if: ${{ matrix.generate_bundle }}
+        run: make bundle VERSION=${{ env.VERSION }}
+        working-directory: controller/deploy/operator
 
       - name: Set image tags
         if: ${{ env.PUSH == 'true' }}


### PR DESCRIPTION
On a previous PR, I removed controller/deploy/operator/bundle from being shipped in the git repository since it can be regenerated automatically with make bundle.

Now the CI job responsible of creating the image and pushing to quay can't find the files. This patch ensures that make bundle is ran before the image is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to conditionally generate operator bundles during the image build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->