### PR TITLE
flashers: add support for passing OCI credentials to fls

### DIFF
--- a/python/packages/jumpstarter-driver-flashers/README.md
+++ b/python/packages/jumpstarter-driver-flashers/README.md
@@ -126,6 +126,10 @@ Options:
   --console-debug                Enable console debug mode
   --cacert FILE                  CA certificate to use for HTTPS
   --insecure-tls                 Skip TLS certificate verification
+  --header TEXT                  Custom HTTP header in 'Key: Value' format
+  --bearer TEXT                  Bearer token for HTTP authentication
+  --oci-username TEXT            OCI registry username (or OCI_USERNAME environment variable)
+  --oci-password TEXT            OCI registry password (or OCI_PASSWORD environment variable)
   --help                         Show this message and exit.
 ```
 
@@ -161,6 +165,16 @@ BaseFlasherClient - INFO - Flushing buffers
 BaseFlasherClient - INFO - Flashing completed in 7:26
 BaseFlasherClient - INFO - Powering off target
 ```
+
+Flash from a private OCI registry with credentials:
+```shell
+OCI_USERNAME=myuser OCI_PASSWORD=mypassword \
+  j storage flash oci://registry.example.com/org/image:tag
+```
+
+Environment variables for OCI auth:
+- `OCI_USERNAME`: registry username
+- `OCI_PASSWORD`: registry password
 
 ### bootloader-shell
 ```shell


### PR DESCRIPTION
Currently OCI credentials weren't passed, so it was not possible to work with private registries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added private OCI registry authentication (username/password), CLI options and environment-variable support; credentials are applied when flashing OCI images.
  * Improved flashing progress reporting and safer console output by redacting sensitive values.

* **Documentation**
  * README updated with OCI auth examples, env-var usage, and a private-OCI flashing example.

* **Tests**
  * Added tests for OCI credential validation, env construction, redaction, credential file handling, and flash behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->