### PR TITLE
flashers: chunk long credentials over serial

### DIFF
--- a/python/packages/jumpstarter-driver-flashers/README.md
+++ b/python/packages/jumpstarter-driver-flashers/README.md
@@ -150,8 +150,6 @@ Options:
   --insecure-tls                 Skip TLS certificate verification
   --header TEXT                  Custom HTTP header in 'Key: Value' format
   --bearer TEXT                  Bearer token for HTTP authentication
-  --oci-username TEXT            OCI registry username (or OCI_USERNAME environment variable)
-  --oci-password TEXT            OCI registry password (or OCI_PASSWORD environment variable)
   --retries INTEGER              Number of retry attempts for flash operation
                                  (default: 3)
   --method [fls|shell]           Method to use for flash operation (default:


### PR DESCRIPTION
serial access cannot handle very long strings we need to pass, for example, jwt token from openshift. instead chunk into smaller pieces and write incrementally

also remove the cmdline --oci-username and --oci-password, and leave only env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCI registry credentials can be sourced from environment variables for OCI image flows.

* **Documentation**
  * CLI docs updated to remove OCI credential command-line options.

* **Improvements**
  * Credential files are now written as base64-encoded chunks, decoded on target, and created with stricter permissions; redaction limited to passwords.

* **Tests**
  * Added tests for env-sourced credentials, chunked encoding/decoding, long-token handling, and HTTP vs OCI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->