### PR TITLE
raise presigned download timeouts

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/driver/base.py
+++ b/python/packages/jumpstarter/jumpstarter/driver/base.py
@@ -227,7 +227,7 @@ class Driver(
         )
 
     @asynccontextmanager
-    async def resource(self, handle: str, timeout: int = 300):
+    async def resource(self, handle: str, timeout: int = 7200):
         handle = TypeAdapter(Resource).validate_python(handle)
         match handle:
             case ClientStreamResource(uuid=uuid, x_jmp_content_encoding=content_encoding):


### PR DESCRIPTION
Those happen exactly after 300 seconds for pre-signed http resources.

```
2026-02-11T13:39:47.636499924Z status = StatusCode.DEADLINE_EXCEEDED
2026-02-11T13:39:47.636499924Z details = ""
2026-02-11T13:39:47.636499924Z debug_error_string = "UNKNOWN:Error received from peer {grpc_message:"", grpc_status:4}"
2026-02-11T13:39:47.636499924Z >)
```

this will avoid downloads timing out after 300 seconds, sometimes the 300 sec timeouts don't happen, but I wonder if those are for non https paths... which may result on non-presigned opendal resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased default timeout for resource operations from 300 to 7200 seconds, providing more time for longer-running operations to complete without premature timeout errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->