### PR TITLE
ridesx: do not compare hash for remote urls

### DIFF
--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
@@ -36,7 +36,7 @@ class RideSXClient(FlasherClient, CompositeClient):
 
         filename = Path(path_buf).name
 
-        if self._should_upload_file(self.storage, filename, path_buf, operator):
+        if self._should_upload_file(self.storage, filename, path_buf, operator, operator_scheme):
             if operator_scheme == "http":
                 self.logger.info(f"Downloading {file_path} to storage as {filename}")
             else:


### PR DESCRIPTION
It requires redownloading the entire file, and doesn't make sense. Instead, just redownload the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced file upload decision logic to support multiple storage backend types through operator scheme awareness.
  * Optimized hash comparison algorithm for determining when file uploads are required.
  * Improved handling of non-filesystem storage sources with streamlined control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->