### PR TITLE
update fls default version to 0.2.0

### DIFF
--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -1343,7 +1343,7 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         @click.option(
             "--fls-version",
             type=str,
-            default="0.1.9",  # TODO(majopela): set default to "" once fls is included in our images
+            default="0.2.0",  # TODO(majopela): set default to "" once fls is included in our images
             help="Download an specific fls version from the github releases",
         )
         @click.option(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default FLS version from 0.1.9 to 0.2.0. Users will now use the newer version by default when no explicit version is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->