### PR TITLE
Feat/driver/pyserial no output

### DIFF
--- a/python/packages/jumpstarter-driver-pyserial/README.md
+++ b/python/packages/jumpstarter-driver-pyserial/README.md
@@ -155,6 +155,8 @@ Pipe serial port data to stdout or a file. Automatically detects if stdin is pip
 
 When stdin is used, commands are sent until EOF, then continues monitoring serial output until Ctrl+C.
 
+Use `--no-output` for fire-and-forget mode: send stdin to serial and exit at EOF without reading serial output.
+
 ```bash
 # Log serial output to stdout
 j serial pipe
@@ -176,6 +178,9 @@ j serial pipe -o serial.log -a
 
 # Disable stdin input even when piped
 cat data.txt | j serial pipe --no-input
+
+# Fire-and-forget: send stdin to serial and exit at EOF (no serial output)
+cat commands.txt | j serial pipe --no-output
 ```
 
 #### Options
@@ -184,6 +189,11 @@ cat data.txt | j serial pipe --no-input
 - `-i, --input`: Force enable stdin to serial port (auto-detected if piped)
 - `--no-input`: Disable stdin to serial port, even if stdin is piped
 - `-a, --append`: Append to output file instead of overwriting
+- `--no-output`: Disable serial output handling (stdin -> serial only, exits at EOF)
+
+Notes:
+- `--no-output` cannot be combined with `--output` or `--append`.
+- `--no-output` requires stdin input (piped stdin or `--input`).
 
 Exit with Ctrl+C.
 

--- a/python/packages/jumpstarter-driver-pyserial/README.md
+++ b/python/packages/jumpstarter-driver-pyserial/README.md
@@ -24,6 +24,19 @@ export:
       cps: 10  # Optional: throttle to 10 characters per second
 ```
 
+Example configuration to send commands to a MCU over serial port, with --no-output (fire-and-forget mode):
+```yaml
+export:
+  serial:
+    type: jumpstarter_driver_pyserial.driver.PySerial
+    config:
+      url: "/dev/ttyUSB0"
+      baudrate: 115200
+      disable_hupcl: true # Prevents MCU reset on each command/close.
+      #cps: Avoid using cps when using --no-output.
+```
+
+
 ### Config parameters
 
 | Parameter      | Description                                                                                                                                          | Type  | Required | Default |
@@ -32,6 +45,7 @@ export:
 | baudrate       | The baudrate to use for the serial connection                                                                                                        | int   | no       | 115200  |
 | check_present | Check if the serial port exists during exporter initialization, disable if you are connecting to a dynamically created port (i.e. USB from your DUT) | bool  | no       | True    |
 | cps            | Characters per second throttling limit. When set, data transmission will be throttled to simulate slow typing. Useful for devices that can't handle fast input | float | no       | None    |
+| disable_hupcl  | Disable HUPCL on POSIX systems to avoid toggling DTR/RTS on close (can prevent MCU reset on serial disconnect)                                       | bool  | no       | False   |
 
 ## NVDemuxSerial Driver
 

--- a/python/packages/jumpstarter-driver-pyserial/README.md
+++ b/python/packages/jumpstarter-driver-pyserial/README.md
@@ -24,7 +24,7 @@ export:
       cps: 10  # Optional: throttle to 10 characters per second
 ```
 
-Example configuration to send commands to a MCU over serial port, with --no-output (fire-and-forget mode):
+Example configuration to send commands to a MCU with DTR/RTS controlling boot process over serial port, with --no-output (fire-and-forget mode):
 ```yaml
 export:
   serial:

--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
@@ -176,6 +176,8 @@ def test_disable_hupcl_applies_termios_flags(monkeypatch):
         calls["when"] = when
         calls["attrs"] = attrs
 
+    monkeypatch.setattr(driver_module.os, "name", "posix")
+
     monkeypatch.setattr(
         driver_module,
         "termios",

--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
@@ -1,12 +1,12 @@
 import time
-from typing import cast
 from types import SimpleNamespace
+from typing import cast
 
 from anyio import create_memory_object_stream
 from anyio.streams.stapled import StapledObjectStream
 
-from .client import PySerialClient
 from . import driver as driver_module
+from .client import PySerialClient
 from .driver import PySerial, ThrottledStream
 from jumpstarter.common.utils import serve
 


### PR DESCRIPTION
Adds two improvements to the pyserial driver to better support non-interactive command execution on MCU-based targets.

## 1) New --no-output option for j pipe
A new CLI flag, --no-output, enables a fire-and-forget mode for serial commands.
Behavior:
forwards stdin -> serial
does not start serial -> stdout/file output handling
exits when stdin reaches EOF
Validation:
rejects incompatible combinations with --output and --append
requires input to be enabled (piped stdin or --input)
Goal:
allow single-shot command dispatch over serial without keeping a long-running read session open.

## 2) New driver config: disable_hupcl
A new PySerial configuration field, disable_hupcl (default: false), was added to reduce unwanted MCU resets when serial connections are closed.
When enabled on POSIX systems, the driver clears HUPCL on the serial file descriptor.
This prevents toggling of modem control lines (e.g., DTR/RTS) on close in environments where that can trigger board reset.
This is especially useful for development boards and USB-serial setups where each serial disconnect may reboot the MCU.
Why this matters

---
Together, these changes make serial command execution more reliable for automation workflows:
--no-output supports efficient one-shot command sending.
disable_hupcl mitigates reset-on-close behavior that can interrupt command effects on MCU targets.

## Additional updates
CLI tests were expanded for --no-output behavior and argument validation.
Driver tests were added for disable_hupcl handling.
README documentation was updated with the new CLI option and config parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fire-and-forget mode (--no-output) for the serial pipe: forwards stdin to the device and exits without reading serial output.
  * New disable_hupcl option to control POSIX hang-up-on-close behavior for serial connections.

* **Documentation**
  * README and CLI docs include example config and usage notes for --no-output (requires stdin; incompatible with --output/--append).

* **Tests**
  * Added tests covering --no-output behavior, its conflicts and requirements, and hupcl handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->