### PR TITLE
uboot: fix message formatting and timeout handling

### DIFF
--- a/python/packages/jumpstarter-driver-uboot/jumpstarter_driver_uboot/client.py
+++ b/python/packages/jumpstarter-driver-uboot/jumpstarter_driver_uboot/client.py
@@ -85,7 +85,7 @@ class UbootConsoleClient(CompositeClient):
         while tries > 0:
             tries-=1
             self.logger.info(f"Running command checked: {cmd}")
-            output = self.run_command("{}; echo $?".format(cmd), _internal_log=False)
+            output = self.run_command("{}; echo $?".format(cmd), timeout=timeout, _internal_log=False)
             parsed = output.strip().decode().splitlines()
 
             if len(parsed) < 2:
@@ -167,7 +167,7 @@ class UbootConsoleClient(CompositeClient):
             cmd = "setenv {}".format(key)
 
         try:
-            self.run_command_checked(cmd, timeout=5)
+            self.run_command_checked(cmd, timeout=timeout)
         except TimeoutError as err:
             raise TimeoutError(f"Timed out setting var {key}") from err
 

--- a/python/packages/jumpstarter-driver-uboot/jumpstarter_driver_uboot/client.py
+++ b/python/packages/jumpstarter-driver-uboot/jumpstarter_driver_uboot/client.py
@@ -94,7 +94,7 @@ class UbootConsoleClient(CompositeClient):
             try:
                 retval = int(parsed[-1])
             except ValueError:
-                raise ValueError("Failed to parse command return value: {}", parsed[-1]) from None
+                raise ValueError(f"Failed to parse command return value: {parsed[-1]}") from None
 
             if retval == 0:
                 break


### PR DESCRIPTION
run_command_checked() and set_env() both take a timeout parameter, but
do not relay the timeout to run_command(). Add the timeout parameter to
the run_command() calls to fix this.

While we're in the file, also fix a ValueError message formatting issue pointed out by CodeRabbit.

The timeout handling has been a problem for me because some flash chip erases take minutes to complete, which results in a timeout despite passing a timeout parameter that meets the flash chip's timing specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured timeout values are correctly propagated to underlying command execution so timeouts are consistently applied.
  * Fixed environment-setting to respect provided timeouts instead of a fixed value.
  * Improved error messages for command failures to include the actual returned value for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->