### PR TITLE
better handling of disconnections and rpc driver call issues

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/client/core.py
+++ b/python/packages/jumpstarter/jumpstarter/client/core.py
@@ -84,7 +84,7 @@ class AsyncDriverClient(
         except Exception:
             debug = ""
         if debug:
-            message = f"{message} | debug={debug}"
+            self.logger.debug("gRPC debug for %s: %s", method, debug)
         return message
 
     async def call_async(self, method, *args):

--- a/python/packages/jumpstarter/jumpstarter/streams/common.py
+++ b/python/packages/jumpstarter/jumpstarter/streams/common.py
@@ -26,7 +26,7 @@ async def copy_stream(dst: AnyByteStream, src: AnyByteStream):
             OSError,
         ):
             await dst.send_eof()
-    except (BrokenResourceError, ClosedResourceError, asyncio.exceptions.InvalidStateError) as e:
+    except (BrokenResourceError, ClosedResourceError, asyncio.InvalidStateError) as e:
         logger.warning("stream copy interrupted (%s): %s", type(e).__name__, e)
         if e.__cause__ is not None:
             logger.debug("stream copy root cause: %r", e.__cause__)


### PR DESCRIPTION
This PR improves the error information received by a user when performing a j storage flash , specially from http targets, when the remote server closes connection you end up with a very silent 
"Error:"

which is hard to interpret, so this is trying to surface the details to the user.

NOTE:

I tested HTTP server resets by creating : 

    iptables -I OUTPUT -d x.x.x.x -p tcp -j REJECT --reject-with tcp-reset

during the download, makes the http client receive TCP RSTs for any packet, this could be helpful for e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust error handling for file uploads and image flashing with clearer failure messages and source reporting.
  * Improved cleanup after flashing to ensure power-off attempts and preserve successful outcomes.
  * Standardized and more informative gRPC error messages including debug details.
  * Better handling of presigned HTTP resources and client streams with enhanced exception mapping, cleanup, and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->