### PR TITLE
ridesx: fix cleanup of decompressed files

### DIFF
--- a/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/driver.py
+++ b/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/driver.py
@@ -238,6 +238,19 @@ class Opendal(Driver):
         """Get set of all paths that have been created during this session."""
         return self._created_paths.copy()
 
+    @export
+    @validate_call(validate_return=True)
+    def register_path(self, path: str) -> None:
+        """Register a path for cleanup on close.
+
+        This allows external callers to register files they've created outside
+        of Opendal's normal file operations for automatic cleanup when
+        remove_created_on_close=True.
+
+        Args:
+            path: Path to register (will be normalized)
+        """
+        self._created_paths.add(self._normalize_path(path))
 
     def close(self):
         """Close driver and report what was created."""

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
@@ -110,6 +110,12 @@ class RideSXDriver(Driver):
                 raise RuntimeError("decompression failed: output file is missing or empty")
 
             self.logger.info(f"successfully decompressed {compressed_file.name}")
+
+            # Register with Opendal for automatic cleanup on close
+            storage = self.children["storage"]
+            relative_path = decompressed_file.relative_to(Path(self.storage_dir))
+            storage.register_path(str(relative_path))
+
             return decompressed_file
 
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
currently decompressed files were not tracked for cleanup by opendal, and thus are left on the storage consuming space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to register additional storage paths for automatic cleanup.
* **Bug Fixes**
  * Ensures decompressed files are now registered with storage for proper cleanup on close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->