### PR TITLE
prevent BrokenResourceError message during normal stream connection teardown

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/streams/common.py
+++ b/python/packages/jumpstarter/jumpstarter/streams/common.py
@@ -27,9 +27,13 @@ async def copy_stream(dst: AnyByteStream, src: AnyByteStream):
         ):
             await dst.send_eof()
     except (BrokenResourceError, ClosedResourceError, asyncio.InvalidStateError) as e:
-        logger.warning("stream copy interrupted (%s): %s", type(e).__name__, e)
-        if e.__cause__ is not None:
-            logger.debug("stream copy root cause: %r", e.__cause__)
+        if isinstance(e.__cause__, BrokenPipeError):
+            # BrokenPipeError (EPIPE) = writing to a closed pipe during normal teardown
+            logger.debug("stream copy interrupted (%s): %s", type(e).__name__, e)
+        else:
+            logger.warning("stream copy interrupted (%s): %s", type(e).__name__, e)
+            if e.__cause__ is not None:
+                logger.debug("stream copy root cause: %r", e.__cause__)
 
 
 @asynccontextmanager


### PR DESCRIPTION
in https://github.com/jumpstarter-dev/jumpstarter/pull/247, we're no longer suppressing BrokenResourceError, however during a normal stream connection teardown, the exception occurs with an BrokenPipeError which afaik is expected in this case, causing a warning that is repeated at the end of every connection over and over:
```
[02/23/26 14:32:05] WARNING  WARNING:jumpstarter.streams.common:stream copy    common.py:30
                             interrupted (BrokenResourceError):                            

```

this PR is excluding the specific condition from the warning, while preserving other potentially useful messages.

discussed in https://github.com/jumpstarter-dev/jumpstarter/pull/256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging to reduce unnecessary log noise during normal shutdown scenarios while preserving detailed diagnostic information for actual errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->