### PR TITLE
fix: hide BrokenResourceError warnings that polute logs

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/streams/common.py
+++ b/python/packages/jumpstarter/jumpstarter/streams/common.py
@@ -26,7 +26,10 @@ async def copy_stream(dst: AnyByteStream, src: AnyByteStream):
             OSError,
         ):
             await dst.send_eof()
-    except (BrokenResourceError, ClosedResourceError, asyncio.InvalidStateError) as e:
+    except BrokenResourceError:
+        # Expected during normal stream teardown when the remote end disconnects
+        pass
+    except (ClosedResourceError, asyncio.InvalidStateError) as e:
         logger.warning("stream copy interrupted (%s): %s", type(e).__name__, e)
         if e.__cause__ is not None:
             logger.debug("stream copy root cause: %r", e.__cause__)


### PR DESCRIPTION
when the remote end closes the call (the call has ended) we get a BrokenResourceError in the stream. We need unecessary warnings, we add masking that was removed in e756ba93.

Fixes this:
```
j power on
~ ⚡qti-snapdragon-ride4-sa8775p-03 ➤ 
[02/24/26 13:29:42] WARNING  WARNING:jumpstarter.streams.common:stream copy interrupted (BrokenResourceError):                   common.py:30
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling during streaming operations to improve reliability and provide enhanced diagnostic logging for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->