### PR TITLE
SSHWrapperClient.stream_async should be a asynccontextmanager

### DIFF
--- a/python/packages/jumpstarter-driver-ssh/jumpstarter_driver_ssh/client.py
+++ b/python/packages/jumpstarter-driver-ssh/jumpstarter_driver_ssh/client.py
@@ -2,6 +2,7 @@ import os
 import shlex
 import subprocess
 import tempfile
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -88,11 +89,10 @@ class SSHWrapperClient(CompositeClient):
 
     # wrap the underlying tcp stream connections, so we can still use tcp forwarding or
     # the fabric driver adapter on top of client.ssh
-    def stream(self, method="connect"):
-        return self.tcp.stream(method)
-
+    @asynccontextmanager
     async def stream_async(self, method):
-        return await self.tcp.stream_async(method)
+        async with self.tcp.stream_async(method) as stream:
+            yield stream
 
     @property
     def command(self) -> str:


### PR DESCRIPTION
And the stream method is provided by DriverClient base class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved asynchronous stream handling in the SSH driver component through enhanced context management, resulting in better resource lifecycle control and increased operational robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->