### PR TITLE
NOYITO USB Relay Power Driver

### DIFF
--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -25,6 +25,8 @@ Drivers that control the power state and basic operation of devices:
 * **[Tasmota](tasmota.md)** (`jumpstarter-driver-tasmota`) - Tasmota hardware control
 * **[HTTP Power](http-power.md)** (`jumpstarter-driver-http-power`) - HTTP-based power
   control, useful for smart sockets, like the Shelly Smart Plug or similar
+* **[Noyito Relay](noyito-relay.md)** (`jumpstarter-driver-noyito-relay`) - NOYITO USB relay
+  board control (1/2-channel serial and 4/8-channel HID variants)
 
 ### Communication Drivers
 
@@ -123,6 +125,7 @@ http.md
 http-power.md
 iscsi.md
 network.md
+noyito-relay.md
 opendal.md
 pi-pico.md
 power.md

--- a/python/docs/source/reference/package-apis/drivers/noyito-relay.md
+++ b/python/docs/source/reference/package-apis/drivers/noyito-relay.md
@@ -1,0 +1,1 @@
+../../../../../packages/jumpstarter-driver-noyito-relay/README.md

--- a/python/packages/jumpstarter-driver-noyito-relay/.gitignore
+++ b/python/packages/jumpstarter-driver-noyito-relay/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-noyito-relay/README.md
+++ b/python/packages/jumpstarter-driver-noyito-relay/README.md
@@ -1,0 +1,178 @@
+# NoyitoPowerSerial / NoyitoPowerHID Driver
+
+`jumpstarter-driver-noyito-relay` provides Jumpstarter power drivers for NOYITO
+USB relay boards in 1, 2, 4, and 8-channel variants.
+
+Two hardware series are supported:
+
+- **`NoyitoPowerSerial`** — 1/2-channel boards using a CH340 USB-to-serial chip
+  (serial port, supports status query)
+- **`NoyitoPowerHID`** — 4/8-channel "HID Drive-free" boards presenting as a
+  USB HID device (no serial port, status query not available)
+
+Both use the same 4-byte binary command protocol (`A0` + channel + state +
+checksum).
+
+## Installation
+
+```shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-noyito-relay
+```
+
+If you are using `NoyitoPowerHID`, the `hid` Python package requires the native
+`hidapi` shared library. Install it for your OS before use:
+
+| OS | Command |
+|----|---------|
+| macOS | `brew install hidapi` |
+| Debian/Ubuntu | `sudo apt-get install libhidapi-hidraw0` |
+| Fedora/RHEL | `sudo dnf install hidapi` |
+
+## Board Detection
+
+To determine which driver to use, check whether the board appears as a serial
+port or a HID device:
+
+- **Serial port** (`/dev/ttyUSB*`, `/dev/tty.usbserial-*`): Use `NoyitoPowerSerial`
+  (1/2-channel CH340 board)
+- **No serial port / HID only**: Use `NoyitoPowerHID` (4/8-channel HID
+  Drive-free board). Confirm with `lsusb` — the NOYITO HID module appears with
+  VID `0x1409` / PID `0x07D7` (decimal: 5131 / 2007).
+
+## `NoyitoPowerSerial` (1/2-Channel Serial)
+
+### Hardware Notes
+
+- **Purchase**: [NOYITO 2-Channel USB Relay Module (Amazon)](https://www.amazon.com/NOYITO-2-Channel-Module-Control-Intelligent/dp/B081RM7PMY/)
+- **Chip**: CH340 USB-to-serial
+- **Baud rate**: 9600
+- **Default port**: `/dev/ttyUSB0` (Linux) — may appear as `/dev/tty.usbserial-*` on macOS
+- **Channels**: 1 or 2 independent relay channels on one USB port
+- **Supply voltage**: 5 V via USB
+
+### Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `port` | `str` | *(required)* | Serial port path, e.g. `/dev/ttyUSB0` |
+| `channel` | `int` | `1` | Relay channel to control (`1` or `2`) |
+| `dual` | `bool` | `false` | Switch both channels simultaneously |
+
+Example configuration controlling both channels independently:
+
+```yaml
+export:
+  relay1:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerSerial
+    config:
+      port: "/dev/ttyUSB0"
+      channel: 1
+  relay2:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerSerial
+    config:
+      port: "/dev/ttyUSB0"
+      channel: 2
+```
+
+### API Reference
+
+Implements `PowerInterface` (provides `on`, `off`, `read`, and `cycle` via
+`PowerClient`).
+
+| Method | Description |
+|--------|-------------|
+| `on()` | Energise the configured relay channel |
+| `off()` | De-energise the configured relay channel |
+| `read()` | Yields a single `PowerReading(voltage=0.0, current=0.0)` |
+| `status()` | Returns the channel state string, e.g. `"on"`, `"off"`, or `"partial"` |
+
+### CLI Usage
+
+Inside a `jmp exporter shell`:
+
+```shell
+# Power on relay 1
+j relay1 on
+
+# Query state of relay 1
+j relay1 status
+# on
+
+# Power cycle relay 2 with a 3-second wait
+j relay2 cycle --wait 3
+
+# Power off relay 1
+j relay1 off
+```
+
+## `NoyitoPowerHID` (4/8-Channel HID Drive-free)
+
+### Hardware Notes
+
+- **Purchase (4-channel)**: [NOYITO 4-Channel HID Drive-free USB Relay (Amazon)](https://www.amazon.com/NOYITO-Drive-Free-Computer-2-Channel-Micro-USB/dp/B0B538N95Q)
+- **Purchase (8-channel)**: [NOYITO 8-Channel HID Drive-free USB Relay (Amazon)](https://www.amazon.com/NOYITO-Drive-Free-Computer-2-Channel-Micro-USB/dp/B0B536M5MH)
+- **Interface**: USB HID (no serial port)
+- **Default VID/PID**: `5131` / `2007` (0x1409 / 0x07D7)
+- **Channels**: 4 or 8 independent relay channels
+- **Supply voltage**: 5 V via USB
+- **Status query**: Not supported by this hardware series
+
+### Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_channels` | `int` | `4` | Number of relay channels on the board (`4` or `8`) |
+| `channel` | `int` | `1` | Relay channel to control (`1`..`num_channels`) |
+| `all_channels` | `bool` | `false` | Fire every channel simultaneously |
+| `vendor_id` | `int` | `5131` | USB vendor ID (override if needed) |
+| `product_id` | `int` | `2007` | USB product ID (override if needed) |
+
+Example configuration for a 4-channel board (channel 1) and an 8-channel board
+(all channels simultaneously):
+
+```yaml
+export:
+  relay_4ch_ch1:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID
+    config:
+      num_channels: 4
+      channel: 1
+  relay_8ch_all:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID
+    config:
+      num_channels: 8
+      channel: 1
+      all_channels: true
+```
+
+### API Reference
+
+Implements `PowerInterface` (provides `on`, `off`, `read`, and `cycle` via
+`PowerClient`).
+
+| Method | Description |
+|--------|-------------|
+| `on()` | Energise the configured relay channel(s) |
+| `off()` | De-energise the configured relay channel(s) |
+| `read()` | Yields a single `PowerReading(voltage=0.0, current=0.0)` |
+
+> **Note**: `status()` is not available for HID boards. The hardware does not
+> support a status query command.
+
+### CLI Usage
+
+Inside a `jmp exporter shell`:
+
+```shell
+# Power on relay channel 1 of the 4-ch board
+j relay_4ch_ch1 on
+
+# Power cycle with a 1-second wait
+j relay_4ch_ch1 cycle --wait 1
+
+# Power off
+j relay_4ch_ch1 off
+
+# Power on all 8 channels simultaneously
+j relay_8ch_all on
+```

--- a/python/packages/jumpstarter-driver-noyito-relay/README.md
+++ b/python/packages/jumpstarter-driver-noyito-relay/README.md
@@ -8,7 +8,7 @@ Two hardware series are supported:
 - **`NoyitoPowerSerial`** — 1/2-channel boards using a CH340 USB-to-serial chip
   (serial port, supports status query)
 - **`NoyitoPowerHID`** — 4/8-channel "HID Drive-free" boards presenting as a
-  USB HID device (no serial port, status query not available)
+  USB HID device (no serial port, supports all-channels status query)
 
 Both use the same 4-byte binary command protocol (`A0` + channel + state +
 checksum).
@@ -56,7 +56,7 @@ port or a HID device:
 |-----------|------|---------|-------------|
 | `port` | `str` | *(required)* | Serial port path, e.g. `/dev/ttyUSB0` |
 | `channel` | `int` | `1` | Relay channel to control (`1` or `2`) |
-| `dual` | `bool` | `false` | Switch both channels simultaneously |
+| `all_channels` | `bool` | `false` | Switch both channels simultaneously |
 
 Example configuration controlling both channels independently:
 
@@ -115,7 +115,6 @@ j relay1 off
 - **Default VID/PID**: `5131` / `2007` (0x1409 / 0x07D7)
 - **Channels**: 4 or 8 independent relay channels
 - **Supply voltage**: 5 V via USB
-- **Status query**: Not supported by this hardware series
 
 ### Configuration
 

--- a/python/packages/jumpstarter-driver-noyito-relay/README.md
+++ b/python/packages/jumpstarter-driver-noyito-relay/README.md
@@ -154,9 +154,7 @@ Implements `PowerInterface` (provides `on`, `off`, `read`, and `cycle` via
 | `on()` | Energise the configured relay channel(s) |
 | `off()` | De-energise the configured relay channel(s) |
 | `read()` | Yields a single `PowerReading(voltage=0.0, current=0.0)` |
-
-> **Note**: `status()` is not available for HID boards. The hardware does not
-> support a status query command.
+| `status()` | Returns the channel state string, e.g. `"on"`, `"off"`, or `"partial"` |
 
 ### CLI Usage
 

--- a/python/packages/jumpstarter-driver-noyito-relay/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-noyito-relay/examples/exporter.yaml
@@ -1,0 +1,48 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: noyito-relay-demo
+endpoint: grpc.jumpstarter.192.168.0.203.nip.io:8082
+token: "<token>"
+export:
+  relay1:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerSerial
+    config:
+      port: "/dev/cu.usbserial-9120"
+      channel: 1
+  relay2:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerSerial
+    config:
+      port: "/dev/cu.usbserial-9120"
+      channel: 2
+  # dual=true fires both serial channels simultaneously (high-current wiring)
+  relay_serial_dual:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerSerial
+    config:
+      port: "/dev/cu.usbserial-9120"
+      dual: true
+  # 4-channel HID board — individual channel
+  relay_4ch_ch1:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID
+    config:
+      num_channels: 4
+      channel: 1
+  # 4-channel HID board — all_channels=true fires all 4 channels simultaneously
+  relay_4ch_all:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID
+    config:
+      num_channels: 4
+      all_channels: true
+  # 8-channel HID board — individual channel
+  relay_8ch_ch1:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID
+    config:
+      num_channels: 8
+      channel: 1
+  # 8-channel HID board — all_channels=true fires all 8 channels simultaneously
+  relay_8ch_all:
+    type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID
+    config:
+      num_channels: 8
+      all_channels: true

--- a/python/packages/jumpstarter-driver-noyito-relay/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-noyito-relay/examples/exporter.yaml
@@ -16,12 +16,12 @@ export:
     config:
       port: "/dev/cu.usbserial-9120"
       channel: 2
-  # dual=true fires both serial channels simultaneously (high-current wiring)
-  relay_serial_dual:
+  # all_channels=true switches both channels simultaneously
+  relay_serial_all:
     type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerSerial
     config:
       port: "/dev/cu.usbserial-9120"
-      dual: true
+      all_channels: true
   # 4-channel HID board — individual channel
   relay_4ch_ch1:
     type: jumpstarter_driver_noyito_relay.driver.NoyitoPowerHID

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/client.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/client.py
@@ -1,0 +1,18 @@
+import click
+from jumpstarter_driver_power.client import PowerClient
+
+
+class NoyitoPowerClient(PowerClient):
+    def status(self) -> str:
+        """Query the configured relay channel state."""
+        return self.call("status")
+
+    def cli(self):
+        base = super().cli()
+
+        @base.command()
+        def status():
+            """Query relay channel state"""
+            click.echo(self.status())
+
+        return base

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/conftest.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/conftest.py
@@ -1,0 +1,20 @@
+import sys
+from unittest.mock import MagicMock
+
+# Stub the hid module so tests run without the native hidapi shared library.
+# NoyitoPowerHID._send_command defers `import hid` to call time; this stub
+# ensures that deferred import returns a mock rather than attempting to load
+# the native library.  Tests that verify HID commands patch hid.Device
+# explicitly on top of this stub.
+if "hid" not in sys.modules:
+    sys.modules["hid"] = MagicMock()
+
+import pytest
+import serial
+
+
+def pytest_runtest_call(item):
+    try:
+        item.runtest()
+    except serial.SerialException:
+        pytest.skip("Serial device not available")  # ty: ignore[call-non-callable]

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
@@ -1,0 +1,163 @@
+import os
+import sys
+from collections.abc import Generator
+from dataclasses import dataclass
+
+import serial
+from jumpstarter_driver_power.driver import PowerInterface, PowerReading
+
+from jumpstarter.driver import Driver, export
+
+# Protocol constants
+_CMD_STATUS = bytes([0xFF])
+_BAUD_RATE = 9600
+_SERIAL_TIMEOUT = 2
+
+
+def _build_command(channel: int, state: int) -> bytes:
+    """Build 4-byte relay command. Checksum = (0xA0 + channel + state) & 0xFF."""
+    checksum = (0xA0 + channel + state) & 0xFF
+    return bytes([0xA0, channel, state, checksum])
+
+
+@dataclass(kw_only=True)
+class NoyitoPowerSerial(PowerInterface, Driver):
+    """Driver for the NOYITO 5V 2-Channel USB Relay Module.
+
+    Controls one relay channel on the NOYITO USB relay board via the CH340
+    USB-to-serial chip at 9600 baud with a 4-byte binary protocol.
+
+    Set ``dual=True`` to switch both channels simultaneously for high-current
+    applications where the two relay contacts are wired in parallel.
+    """
+
+    port: str
+    channel: int = 1
+    dual: bool = False
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_noyito_relay.client.NoyitoPowerClient"
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+        if not self.dual and self.channel not in (1, 2):
+            raise ValueError(f"channel must be 1 or 2, got {self.channel!r}")
+
+    def _send_command(self, cmd: bytes) -> None:
+        with serial.Serial(self.port, baudrate=_BAUD_RATE, timeout=_SERIAL_TIMEOUT) as ser:
+            ser.write(cmd)
+
+    def _query_status(self) -> dict[str, str]:
+        with serial.Serial(self.port, baudrate=_BAUD_RATE, timeout=_SERIAL_TIMEOUT) as ser:
+            ser.write(_CMD_STATUS)
+            raw = ser.read(32)
+        text = raw.decode("ascii", errors="replace").strip()
+        result: dict[str, str] = {}
+        for part in text.replace("\r", "").split("\n"):
+            part = part.strip()
+            if ":" in part:
+                key, _, val = part.partition(":")
+                result[key.strip()] = val.strip()
+        if not result:
+            raise ValueError(f"Unexpected status response: {raw!r}")
+        return result
+
+    def _channels(self) -> list[int]:
+        return [1, 2] if self.dual else [self.channel]
+
+    @export
+    def on(self) -> None:
+        for ch in self._channels():
+            self.logger.info("Relay channel %d ON", ch)
+            self._send_command(_build_command(ch, 1))
+
+    @export
+    def off(self) -> None:
+        for ch in self._channels():
+            self.logger.info("Relay channel %d OFF", ch)
+            self._send_command(_build_command(ch, 0))
+
+    @export
+    def read(self) -> Generator[PowerReading, None, None]:
+        yield PowerReading(voltage=0.0, current=0.0)
+
+    @export
+    def status(self) -> str:
+        all_channels = self._query_status()
+        states = set()
+        for ch in self._channels():
+            key = f"CH{ch}"
+            if key not in all_channels:
+                raise ValueError(f"Channel {key} not found in status response: {all_channels!r}")
+            states.add(all_channels[key].lower())
+        if len(states) == 1:
+            return states.pop()
+        return "partial"
+
+
+@dataclass(kw_only=True)
+class NoyitoPowerHID(PowerInterface, Driver):
+    """Driver for the NOYITO 4/8-Channel HID Drive-free USB Relay Module.
+
+    Uses USB HID (hid library) instead of serial. Status query is not
+    supported by this hardware series.
+
+    vendor_id / product_id default to the NOYITO HID module values (5131 / 2007).
+    Set num_channels to 4 or 8 to match the physical board.
+    Set all_channels=True to fire every channel simultaneously for high-current use.
+    """
+
+    vendor_id: int = 5131
+    product_id: int = 2007
+    num_channels: int = 4
+    channel: int = 1
+    all_channels: bool = False
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_noyito_relay.client.NoyitoPowerClient"
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+        if self.num_channels not in (4, 8):
+            raise ValueError(f"num_channels must be 4 or 8, got {self.num_channels!r}")
+        if not self.all_channels and self.channel not in range(1, self.num_channels + 1):
+            raise ValueError(
+                f"channel must be 1..{self.num_channels}, got {self.channel!r}"
+            )
+
+    def _channels(self) -> list[int]:
+        return list(range(1, self.num_channels + 1)) if self.all_channels else [self.channel]
+
+    def _send_command(self, cmd: bytes) -> None:
+        # On Apple Silicon Macs, Homebrew installs hidapi to /opt/homebrew/lib
+        # which is not in ctypes's default search path.  Extend
+        # DYLD_FALLBACK_LIBRARY_PATH before the first import so dlopen finds it.
+        if sys.platform == "darwin":
+            _brew_lib = os.path.join(os.environ.get("HOMEBREW_PREFIX", "/opt/homebrew"), "lib")
+            if os.path.isdir(_brew_lib):
+                _fallback = os.environ.get("DYLD_FALLBACK_LIBRARY_PATH", "")
+                if _brew_lib not in _fallback.split(":"):
+                    os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = _brew_lib + (":" + _fallback if _fallback else "")
+        import hid  # noqa: PLC0415
+        with hid.Device(self.vendor_id, self.product_id) as device:
+            device.write(b"\x00" + cmd)  # 0x00 = HID report ID
+
+    @export
+    def on(self) -> None:
+        for ch in self._channels():
+            self.logger.info("HID Relay channel %d ON", ch)
+            self._send_command(_build_command(ch, 1))
+
+    @export
+    def off(self) -> None:
+        for ch in self._channels():
+            self.logger.info("HID Relay channel %d OFF", ch)
+            self._send_command(_build_command(ch, 0))
+
+    @export
+    def read(self) -> Generator[PowerReading, None, None]:
+        yield PowerReading(voltage=0.0, current=0.0)

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
@@ -170,7 +170,7 @@ class NoyitoPowerHID(PowerInterface, Driver):
         cmd = _build_command(0x0F, 0x02)  # 0x0F = all-channels status query pseudo-channel
         with hid.Device(self.vendor_id, self.product_id) as device:
             device.write(b"\x00" + cmd)
-            raw = device.read(32, timeout_ms=2000)
+            raw = device.read(self.num_channels * 9, timeout_ms=500)
 
         text = bytes(raw).decode("ascii", errors="replace")
         result: dict[str, str] = {}
@@ -185,7 +185,8 @@ class NoyitoPowerHID(PowerInterface, Driver):
 
     @export
     def read(self) -> Generator[PowerReading, None, None]:
-        yield PowerReading(voltage=0.0, current=0.0)
+        raise NotImplementedError
+        yield  # makes this a generator function
 
     @export
     def status(self) -> str:

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
@@ -27,13 +27,13 @@ class NoyitoPowerSerial(PowerInterface, Driver):
     Controls one relay channel on the NOYITO USB relay board via the CH340
     USB-to-serial chip at 9600 baud with a 4-byte binary protocol.
 
-    Set ``dual=True`` to switch both channels simultaneously for high-current
-    applications where the two relay contacts are wired in parallel.
+    Set ``all_channels=True`` in the exporter config to switch both channels
+    simultaneously (e.g. for high-current applications).
     """
 
     port: str
     channel: int = 1
-    dual: bool = False
+    all_channels: bool = False
 
     @classmethod
     def client(cls) -> str:
@@ -42,7 +42,7 @@ class NoyitoPowerSerial(PowerInterface, Driver):
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
             super().__post_init__()
-        if not self.dual and self.channel not in (1, 2):
+        if not self.all_channels and self.channel not in (1, 2):
             raise ValueError(f"channel must be 1 or 2, got {self.channel!r}")
 
     def _send_command(self, cmd: bytes) -> None:
@@ -65,7 +65,7 @@ class NoyitoPowerSerial(PowerInterface, Driver):
         return result
 
     def _channels(self) -> list[int]:
-        return [1, 2] if self.dual else [self.channel]
+        return [1, 2] if self.all_channels else [self.channel]
 
     @export
     def on(self) -> None:
@@ -81,7 +81,8 @@ class NoyitoPowerSerial(PowerInterface, Driver):
 
     @export
     def read(self) -> Generator[PowerReading, None, None]:
-        yield PowerReading(voltage=0.0, current=0.0)
+        # Power reading not supported
+        raise NotImplementedError
 
     @export
     def status(self) -> str:
@@ -101,8 +102,7 @@ class NoyitoPowerSerial(PowerInterface, Driver):
 class NoyitoPowerHID(PowerInterface, Driver):
     """Driver for the NOYITO 4/8-Channel HID Drive-free USB Relay Module.
 
-    Uses USB HID (hid library) instead of serial. Status query is not
-    supported by this hardware series.
+    Uses USB HID (hid library) instead of serial.
 
     vendor_id / product_id default to the NOYITO HID module values (5131 / 2007).
     Set num_channels to 4 or 8 to match the physical board.
@@ -158,6 +158,44 @@ class NoyitoPowerHID(PowerInterface, Driver):
             self.logger.info("HID Relay channel %d OFF", ch)
             self._send_command(_build_command(ch, 0))
 
+    def _query_status(self) -> dict[str, str]:
+        if sys.platform == "darwin":
+            _brew_lib = os.path.join(os.environ.get("HOMEBREW_PREFIX", "/opt/homebrew"), "lib")
+            if os.path.isdir(_brew_lib):
+                _fallback = os.environ.get("DYLD_FALLBACK_LIBRARY_PATH", "")
+                if _brew_lib not in _fallback.split(":"):
+                    os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = _brew_lib + (":" + _fallback if _fallback else "")
+        import hid  # noqa: PLC0415
+
+        cmd = _build_command(0x0F, 0x02)  # 0x0F = all-channels status query pseudo-channel
+        with hid.Device(self.vendor_id, self.product_id) as device:
+            device.write(b"\x00" + cmd)
+            raw = device.read(32, timeout_ms=2000)
+
+        text = bytes(raw).decode("ascii", errors="replace")
+        result: dict[str, str] = {}
+        for line in text.split("\n"):
+            line = line.strip("\r").strip()
+            if ":" in line:
+                key, _, value = line.partition(":")
+                result[key.strip()] = value.strip()
+        if not result:
+            raise ValueError(f"Unexpected status response: {text!r}")
+        return result
+
     @export
     def read(self) -> Generator[PowerReading, None, None]:
         yield PowerReading(voltage=0.0, current=0.0)
+
+    @export
+    def status(self) -> str:
+        states = self._query_status()
+        channel_states = []
+        for ch in self._channels():
+            key = f"CH{ch}"
+            if key not in states:
+                raise ValueError(f"Channel {ch} not found in status response: {states!r}")
+            channel_states.append(states[key].lower())
+        if all(s == channel_states[0] for s in channel_states):
+            return channel_states[0]
+        return "partial"

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver.py
@@ -81,8 +81,8 @@ class NoyitoPowerSerial(PowerInterface, Driver):
 
     @export
     def read(self) -> Generator[PowerReading, None, None]:
-        # Power reading not supported
         raise NotImplementedError
+        yield  # makes this a generator function
 
     @export
     def status(self) -> str:

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
@@ -1,0 +1,312 @@
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from .driver import NoyitoPowerHID, NoyitoPowerSerial, _build_command
+from jumpstarter.common.utils import serve
+
+# ---------------------------------------------------------------------------
+# Protocol unit tests (no mocking needed)
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_ch1_on():
+    assert _build_command(1, 1) == bytes([0xA0, 0x01, 0x01, 0xA2])
+
+
+def test_build_command_ch1_off():
+    assert _build_command(1, 0) == bytes([0xA0, 0x01, 0x00, 0xA1])
+
+
+def test_build_command_ch2_on():
+    assert _build_command(2, 1) == bytes([0xA0, 0x02, 0x01, 0xA3])
+
+
+def test_build_command_ch2_off():
+    assert _build_command(2, 0) == bytes([0xA0, 0x02, 0x00, 0xA2])
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_channel_too_high():
+    with pytest.raises(ValueError):
+        NoyitoPowerSerial(port="/dev/ttyUSB0", channel=3)
+
+
+def test_channel_too_low():
+    with pytest.raises(ValueError):
+        NoyitoPowerSerial(port="/dev/ttyUSB0", channel=0)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via serve() with serial.Serial mocked
+# ---------------------------------------------------------------------------
+
+
+def _make_serial_mock():
+    mock_serial = MagicMock()
+    mock_serial.__enter__ = MagicMock(return_value=mock_serial)
+    mock_serial.__exit__ = MagicMock(return_value=False)
+    return mock_serial
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_on_ch1(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
+        client.on()
+
+    mock_ser.write.assert_called_once_with(bytes([0xA0, 0x01, 0x01, 0xA2]))
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_off_ch1(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
+        client.off()
+
+    mock_ser.write.assert_called_once_with(bytes([0xA0, 0x01, 0x00, 0xA1]))
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_on_ch2(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=2)) as client:
+        client.on()
+
+    mock_ser.write.assert_called_once_with(bytes([0xA0, 0x02, 0x01, 0xA3]))
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_off_ch2(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=2)) as client:
+        client.off()
+
+    mock_ser.write.assert_called_once_with(bytes([0xA0, 0x02, 0x00, 0xA2]))
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_read(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
+        readings = list(client.read())
+
+    assert len(readings) == 1
+    assert readings[0].voltage == 0.0
+    assert readings[0].current == 0.0
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_status_ch1(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_ser.read.return_value = b"CH1:ON \r\nCH2:OFF \r\n"
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
+        assert client.status() == "on"
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_status_ch2(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_ser.read.return_value = b"CH1:ON \r\nCH2:OFF \r\n"
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=2)) as client:
+        assert client.status() == "off"
+
+
+# ---------------------------------------------------------------------------
+# Dual-channel (high-current) mode tests
+# ---------------------------------------------------------------------------
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_dual_on(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+        client.on()
+
+    write_calls = mock_ser.write.call_args_list
+    assert write_calls[0] == call(bytes([0xA0, 0x01, 0x01, 0xA2]))
+    assert write_calls[1] == call(bytes([0xA0, 0x02, 0x01, 0xA3]))
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_dual_off(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+        client.off()
+
+    write_calls = mock_ser.write.call_args_list
+    assert write_calls[0] == call(bytes([0xA0, 0x01, 0x00, 0xA1]))
+    assert write_calls[1] == call(bytes([0xA0, 0x02, 0x00, 0xA2]))
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_dual_status_both_on(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_ser.read.return_value = b"CH1:ON \r\nCH2:ON \r\n"
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+        assert client.status() == "on"
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_dual_status_partial(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_ser.read.return_value = b"CH1:ON \r\nCH2:OFF \r\n"
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+        assert client.status() == "partial"
+
+
+@patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
+def test_cycle(mock_serial_cls):
+    mock_ser = _make_serial_mock()
+    mock_serial_cls.return_value = mock_ser
+
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
+        client.cycle(wait=0)
+
+    write_calls = mock_ser.write.call_args_list
+    assert write_calls[0] == call(bytes([0xA0, 0x01, 0x00, 0xA1]))
+    assert write_calls[1] == call(bytes([0xA0, 0x01, 0x01, 0xA2]))
+
+
+# ---------------------------------------------------------------------------
+# NoyitoPowerHID validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_hid_invalid_num_channels():
+    with pytest.raises(ValueError):
+        NoyitoPowerHID(num_channels=3)
+
+
+def test_hid_channel_too_high_4ch():
+    with pytest.raises(ValueError):
+        NoyitoPowerHID(num_channels=4, channel=5)
+
+
+def test_hid_channel_too_high_8ch():
+    with pytest.raises(ValueError):
+        NoyitoPowerHID(num_channels=8, channel=9)
+
+
+# ---------------------------------------------------------------------------
+# NoyitoPowerHID integration tests via serve() with hid.Device mocked
+# ---------------------------------------------------------------------------
+
+
+def _make_hid_mock():
+    m = MagicMock()
+    m.__enter__ = MagicMock(return_value=m)
+    m.__exit__ = MagicMock(return_value=False)
+    return m
+
+
+@patch("hid.Device")
+def test_hid_on_ch3_4ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, channel=3)) as client:
+        client.on()
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x03, 0x01, 0xA4]))
+
+
+@patch("hid.Device")
+def test_hid_off_ch3_4ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, channel=3)) as client:
+        client.off()
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x03, 0x00, 0xA3]))
+
+
+@patch("hid.Device")
+def test_hid_on_ch8_8ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=8, channel=8)) as client:
+        client.on()
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x08, 0x01, 0xA9]))
+
+
+@patch("hid.Device")
+def test_hid_off_ch8_8ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=8, channel=8)) as client:
+        client.off()
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x08, 0x00, 0xA8]))
+
+
+@patch("hid.Device")
+def test_hid_all_channels_on_4ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, all_channels=True)) as client:
+        client.on()
+
+    assert mock_dev.write.call_count == 4
+    write_calls = mock_dev.write.call_args_list
+    assert write_calls[0] == call(b"\x00" + bytes([0xA0, 0x01, 0x01, 0xA2]))
+    assert write_calls[1] == call(b"\x00" + bytes([0xA0, 0x02, 0x01, 0xA3]))
+    assert write_calls[2] == call(b"\x00" + bytes([0xA0, 0x03, 0x01, 0xA4]))
+    assert write_calls[3] == call(b"\x00" + bytes([0xA0, 0x04, 0x01, 0xA5]))
+
+
+@patch("hid.Device")
+def test_hid_read(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, channel=1)) as client:
+        readings = list(client.read())
+
+    assert len(readings) == 1
+    assert readings[0].voltage == 0.0
+    assert readings[0].current == 0.0
+
+
+@patch("hid.Device")
+def test_hid_cycle(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, channel=1)) as client:
+        client.cycle(wait=0)
+
+    write_calls = mock_dev.write.call_args_list
+    assert write_calls[0] == call(b"\x00" + bytes([0xA0, 0x01, 0x00, 0xA1]))
+    assert write_calls[1] == call(b"\x00" + bytes([0xA0, 0x01, 0x01, 0xA2]))

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
@@ -98,12 +98,12 @@ def test_off_ch2(mock_serial_cls):
 
 
 @patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")
-def test_read(mock_serial_cls):
+def test_read_not_supported(mock_serial_cls):
     mock_ser = _make_serial_mock()
     mock_serial_cls.return_value = mock_ser
 
     with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
-        with pytest.raises(Exception):
+        with pytest.raises(NotImplementedError):
             list(client.read())
 
 
@@ -284,16 +284,13 @@ def test_hid_all_channels_on_4ch(mock_hid_cls):
 
 
 @patch("hid.Device")
-def test_hid_read(mock_hid_cls):
+def test_hid_read_not_supported(mock_hid_cls):
     mock_dev = _make_hid_mock()
     mock_hid_cls.return_value = mock_dev
 
     with serve(NoyitoPowerHID(num_channels=4, channel=1)) as client:
-        readings = list(client.read())
-
-    assert len(readings) == 1
-    assert readings[0].voltage == 0.0
-    assert readings[0].current == 0.0
+        with pytest.raises(NotImplementedError):
+            list(client.read())
 
 
 @patch("hid.Device")
@@ -310,9 +307,8 @@ def test_hid_cycle(mock_hid_cls):
 
 
 def _encode_status(text: str) -> list[int]:
-    """Encode an ASCII status string into a 32-byte HID read buffer."""
-    raw = list(text.encode("ascii"))
-    return raw + [0] * (32 - len(raw))
+    """Encode an ASCII status string into an HID read buffer."""
+    return list(text.encode("ascii"))
 
 
 @patch("hid.Device")

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
@@ -140,7 +140,7 @@ def test_dual_on(mock_serial_cls):
     mock_ser = _make_serial_mock()
     mock_serial_cls.return_value = mock_ser
 
-    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", all_channels=True)) as client:
         client.on()
 
     write_calls = mock_ser.write.call_args_list
@@ -153,7 +153,7 @@ def test_dual_off(mock_serial_cls):
     mock_ser = _make_serial_mock()
     mock_serial_cls.return_value = mock_ser
 
-    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", all_channels=True)) as client:
         client.off()
 
     write_calls = mock_ser.write.call_args_list
@@ -167,7 +167,7 @@ def test_dual_status_both_on(mock_serial_cls):
     mock_ser.read.return_value = b"CH1:ON \r\nCH2:ON \r\n"
     mock_serial_cls.return_value = mock_ser
 
-    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", all_channels=True)) as client:
         assert client.status() == "on"
 
 
@@ -177,7 +177,7 @@ def test_dual_status_partial(mock_serial_cls):
     mock_ser.read.return_value = b"CH1:ON \r\nCH2:OFF \r\n"
     mock_serial_cls.return_value = mock_ser
 
-    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", dual=True)) as client:
+    with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", all_channels=True)) as client:
         assert client.status() == "partial"
 
 
@@ -310,3 +310,57 @@ def test_hid_cycle(mock_hid_cls):
     write_calls = mock_dev.write.call_args_list
     assert write_calls[0] == call(b"\x00" + bytes([0xA0, 0x01, 0x00, 0xA1]))
     assert write_calls[1] == call(b"\x00" + bytes([0xA0, 0x01, 0x01, 0xA2]))
+
+
+def _encode_status(text: str) -> list[int]:
+    """Encode an ASCII status string into a 32-byte HID read buffer."""
+    raw = list(text.encode("ascii"))
+    return raw + [0] * (32 - len(raw))
+
+
+@patch("hid.Device")
+def test_hid_status_ch1_on(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_dev.read.return_value = _encode_status("CH1:ON\r\nCH2:OFF\r\n")
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, channel=1)) as client:
+        assert client.status() == "on"
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x0F, 0x02, 0xB1]))
+
+
+@patch("hid.Device")
+def test_hid_status_ch2_off(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_dev.read.return_value = _encode_status("CH1:ON\r\nCH2:OFF\r\n")
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, channel=2)) as client:
+        assert client.status() == "off"
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x0F, 0x02, 0xB1]))
+
+
+@patch("hid.Device")
+def test_hid_status_all_on_4ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_dev.read.return_value = _encode_status("CH1:ON\r\nCH2:ON\r\nCH3:ON\r\nCH4:ON\r\n")
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, all_channels=True)) as client:
+        assert client.status() == "on"
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x0F, 0x02, 0xB1]))
+
+
+@patch("hid.Device")
+def test_hid_status_partial_4ch(mock_hid_cls):
+    mock_dev = _make_hid_mock()
+    mock_dev.read.return_value = _encode_status("CH1:ON\r\nCH2:OFF\r\nCH3:ON\r\nCH4:OFF\r\n")
+    mock_hid_cls.return_value = mock_dev
+
+    with serve(NoyitoPowerHID(num_channels=4, all_channels=True)) as client:
+        assert client.status() == "partial"
+
+    mock_dev.write.assert_called_once_with(b"\x00" + bytes([0xA0, 0x0F, 0x02, 0xB1]))

--- a/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
+++ b/python/packages/jumpstarter-driver-noyito-relay/jumpstarter_driver_noyito_relay/driver_test.py
@@ -103,11 +103,8 @@ def test_read(mock_serial_cls):
     mock_serial_cls.return_value = mock_ser
 
     with serve(NoyitoPowerSerial(port="/dev/ttyUSB0", channel=1)) as client:
-        readings = list(client.read())
-
-    assert len(readings) == 1
-    assert readings[0].voltage == 0.0
-    assert readings[0].current == 0.0
+        with pytest.raises(Exception):
+            list(client.read())
 
 
 @patch("jumpstarter_driver_noyito_relay.driver.serial.Serial")

--- a/python/packages/jumpstarter-driver-noyito-relay/pyproject.toml
+++ b/python/packages/jumpstarter-driver-noyito-relay/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "jumpstarter-driver-noyito-relay"
+dynamic = ["version", "urls"]
+description = "Jumpstarter driver for the NOYITO 5V 2-Channel USB Relay Module"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "Kirk Brauer", email = "kbrauer@hatci.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "pyserial>=3.5",
+    "hid>=1.0.4",
+    "jumpstarter",
+    "jumpstarter-driver-power",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+NoyitoPowerSerial = "jumpstarter_driver_noyito_relay.driver:NoyitoPowerSerial"
+NoyitoPowerHID = "jumpstarter_driver_noyito_relay.driver:NoyitoPowerHID"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../'}
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=html --cov-report=xml"
+log_cli = true
+log_cli_level = "INFO"
+testpaths = ["jumpstarter_driver_noyito_relay"]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+    "pytest-mock>=3.14.0",
+]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -11,24 +11,20 @@ members = [
     "jumpstarter-cli-admin",
     "jumpstarter-cli-common",
     "jumpstarter-cli-driver",
-    "jumpstarter-driver-adb",
-    "jumpstarter-driver-androidemulator",
     "jumpstarter-driver-ble",
     "jumpstarter-driver-can",
     "jumpstarter-driver-composite",
     "jumpstarter-driver-corellium",
-    "jumpstarter-driver-doip",
     "jumpstarter-driver-dutlink",
     "jumpstarter-driver-energenie",
-    "jumpstarter-driver-esp32",
     "jumpstarter-driver-flashers",
     "jumpstarter-driver-gpiod",
     "jumpstarter-driver-http",
     "jumpstarter-driver-http-power",
     "jumpstarter-driver-iscsi",
     "jumpstarter-driver-network",
+    "jumpstarter-driver-noyito-relay",
     "jumpstarter-driver-opendal",
-    "jumpstarter-driver-pi-pico",
     "jumpstarter-driver-power",
     "jumpstarter-driver-probe-rs",
     "jumpstarter-driver-pyserial",
@@ -43,20 +39,13 @@ members = [
     "jumpstarter-driver-tftp",
     "jumpstarter-driver-tmt",
     "jumpstarter-driver-uboot",
-    "jumpstarter-driver-uds",
-    "jumpstarter-driver-uds-can",
-    "jumpstarter-driver-uds-doip",
     "jumpstarter-driver-ustreamer",
     "jumpstarter-driver-vnc",
-    "jumpstarter-driver-xcp",
     "jumpstarter-driver-yepkit",
-    "jumpstarter-example-android-emulator",
     "jumpstarter-example-automotive",
     "jumpstarter-example-soc-pytest",
-    "jumpstarter-example-xcp-ecu",
     "jumpstarter-imagehash",
     "jumpstarter-kubernetes",
-    "jumpstarter-mcp",
     "jumpstarter-protocol",
     "jumpstarter-testing",
 ]
@@ -65,7 +54,7 @@ members = [
 dev = [
     { name = "esbonio", specifier = ">=0.16.5" },
     { name = "pre-commit", specifier = ">=3.8.0" },
-    { name = "ruff", specifier = "==0.15.6" },
+    { name = "ruff", specifier = "==0.14.14" },
     { name = "ty", specifier = ">=0.0.1a8" },
     { name = "typos", specifier = ">=1.23.6" },
 ]
@@ -82,24 +71,6 @@ docs = [
     { name = "sphinx-substitution-extensions", specifier = ">=2024.10.17" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
     { name = "sphinxcontrib-programoutput", specifier = ">=0.18" },
-]
-
-[[package]]
-name = "adbutils"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecation" },
-    { name = "pillow" },
-    { name = "requests" },
-    { name = "retry2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a9/ebe3356cb224d5bbbf9d3d31ef6d31935d356340b2d37a09b6796ffcf2f4/adbutils-2.12.0.tar.gz", hash = "sha256:3653a8f39735620bc45b15ee2e7a00e502c9f1a259452e1fb2bbba3ea59d0e68", size = 191920, upload-time = "2025-11-12T06:09:33.82Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/7b/9b8e55a9357244148380bce6ce51402f92fe441f2fb7673cedc6d509dd5b/adbutils-2.12.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:adf131c746519f8a9576765d8f1315396d2573c9f178d6104e2a42dc9a714a3f", size = 6707555, upload-time = "2025-11-12T06:09:28.266Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/bd/47dfb989b4a086cf8ca67b4b56c2760dea5e61064e3869175579c9ccad23/adbutils-2.12.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:fe2699b15150c828a7f81c4753e2f22da9c506b72ac785658ddd90c1362701ee", size = 3578510, upload-time = "2025-11-12T06:09:29.857Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2c/4a6c0e7405b61b62698157a50d364348dac1c572f13ec7506b9f9bbc95e9/adbutils-2.12.0-py3-none-win32.whl", hash = "sha256:189e0060737bb84111892ccaf7bcd098603297ecdd89a9224f390c2949ba8a5a", size = 3339129, upload-time = "2025-11-12T06:09:31.322Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b5/da4d7929d2e4db4fe811efcde669e178539e1695ddc33a9c2741998df805/adbutils-2.12.0-py3-none-win_amd64.whl", hash = "sha256:e7629bb5783f4aa40942889da1455c879b21f9d1cc057596003b42f3371543be", size = 3339132, upload-time = "2025-11-12T06:09:32.498Z" },
 ]
 
 [[package]]
@@ -328,21 +299,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
-]
-
-[[package]]
 name = "bcrypt"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -416,91 +372,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
-]
-
-[[package]]
-name = "bitarray"
-version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/06/92fdc84448d324ab8434b78e65caf4fb4c6c90b4f8ad9bdd4c8021bfaf1e/bitarray-3.8.0.tar.gz", hash = "sha256:3eae38daffd77c9621ae80c16932eea3fb3a4af141fb7cc724d4ad93eff9210d", size = 151991, upload-time = "2025-11-02T21:41:15.117Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/7d/63558f1d0eb09217a3d30c1c847890879973e224a728fcff9391fab999b8/bitarray-3.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:25b9cff6c9856bc396232e2f609ea0c5ec1a8a24c500cee4cca96ba8a3cd50b6", size = 148502, upload-time = "2025-11-02T21:39:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7b/f957ad211cb0172965b5f0881b67b99e2b6d41512af0a1001f44a44ddf4a/bitarray-3.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d9984017314da772f5f7460add7a0301a4ffc06c72c2998bb16c300a6253607", size = 145484, upload-time = "2025-11-02T21:39:10.904Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/dc/897973734f14f91467a3a795a4624752238053ecffaec7c8bbda1e363fda/bitarray-3.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbbbfbb7d039b20d289ce56b1beb46138d65769d04af50c199c6ac4cb6054d52", size = 330909, upload-time = "2025-11-02T21:39:12.276Z" },
-    { url = "https://files.pythonhosted.org/packages/67/be/24b4b792426d92de289e73e09682915d567c2e69d47e8857586cbdc865d0/bitarray-3.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1f723e260c35e1c7c57a09d3a6ebe681bd56c83e1208ae3ce1869b7c0d10d4f", size = 358469, upload-time = "2025-11-02T21:39:13.766Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/0e/2eda69a7a59a6998df8fb57cc9d1e0e62888c599fb5237b0a8b479a01afb/bitarray-3.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cbd1660fb48827381ce3a621a4fdc237959e1cd4e98b098952a8f624a0726425", size = 369131, upload-time = "2025-11-02T21:39:15.041Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/7b/8a372d6635a6b2622477b2f96a569b2cd0318a62bc95a4a2144c7942c987/bitarray-3.8.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df6d7bf3e15b7e6e202a16ff4948a51759354016026deb04ab9b5acbbe35e096", size = 337089, upload-time = "2025-11-02T21:39:16.124Z" },
-    { url = "https://files.pythonhosted.org/packages/93/f0/8eca934dbe5dee47a0e5ef44eeb72e85acacc8097c27cd164337bc4ec5d3/bitarray-3.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c931ec1c03111718cabf85f6012bb2815fa0ce578175567fa8d6f2cc15d3b4", size = 328504, upload-time = "2025-11-02T21:39:17.321Z" },
-    { url = "https://files.pythonhosted.org/packages/88/dd/928b8e23a9950f8a8bfc42bc1e7de41f4e27f57de01a716308be5f683c2b/bitarray-3.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:41b53711f89008ba2de62e4c2d2260a8b357072fd4f18e1351b28955db2719dc", size = 356461, upload-time = "2025-11-02T21:39:18.396Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/93/4fb58417aff47fa2fe1874a39c9346b589a1d78c93a9cb24cccede5dc737/bitarray-3.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:4f298daaaea58d45e245a132d6d2bdfb6f856da50dc03d75ebb761439fb626cf", size = 353008, upload-time = "2025-11-02T21:39:19.828Z" },
-    { url = "https://files.pythonhosted.org/packages/da/54/aa04e4a7b45aa5913f08ee377d43319b0979925e3c0407882eb29df3be66/bitarray-3.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:30989a2451b693c3f9359d91098a744992b5431a0be4858f1fdf0ec76b457125", size = 334048, upload-time = "2025-11-02T21:39:20.924Z" },
-    { url = "https://files.pythonhosted.org/packages/da/52/e851f41076df014c05d6ac1ce34fbf7db5fa31241da3e2f09bb2be9e283d/bitarray-3.8.0-cp311-cp311-win32.whl", hash = "sha256:e5aed4754895942ae15ffa48c52d181e1c1463236fda68d2dba29c03aa61786b", size = 142907, upload-time = "2025-11-02T21:39:22.312Z" },
-    { url = "https://files.pythonhosted.org/packages/28/01/db0006148b1dd13b4ac2686df8fa57d12f5887df313a506e939af0cb0997/bitarray-3.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:22c540ed20167d3dbb1e2d868ca935180247d620c40eace90efa774504a40e3b", size = 149670, upload-time = "2025-11-02T21:39:23.341Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/ea/b7d55ee269b1426f758a535c9ec2a07c056f20f403fa981685c3c8b4798c/bitarray-3.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:84b52b2cf77bb7f703d16c4007b021078dbbe6cf8ffb57abe81a7bacfc175ef2", size = 146709, upload-time = "2025-11-02T21:39:24.343Z" },
-    { url = "https://files.pythonhosted.org/packages/82/a0/0c41d893eda756315491adfdbf9bc928aee3d377a7f97a8834d453aa5de1/bitarray-3.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f2fcbe9b3a5996b417e030aa33a562e7e20dfc86271e53d7e841fc5df16268b8", size = 148575, upload-time = "2025-11-02T21:39:25.718Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/30/12ab2f4a4429bd844b419c37877caba93d676d18be71354fbbeb21d9f4cc/bitarray-3.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd761d158f67e288fd0ebe00c3b158095ce80a4bc7c32b60c7121224003ba70d", size = 145454, upload-time = "2025-11-02T21:39:26.695Z" },
-    { url = "https://files.pythonhosted.org/packages/26/58/314b3e3f219533464e120f0c51ac5123e7b1c1b91f725a4073fb70c5a858/bitarray-3.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c394a3f055b49f92626f83c1a0b6d6cd2c628f1ccd72481c3e3c6aa4695f3b20", size = 332949, upload-time = "2025-11-02T21:39:27.801Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ce/ca8c706bd8341c7a22dd92d2a528af71f7e5f4726085d93f81fd768cb03b/bitarray-3.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:969fd67de8c42affdb47b38b80f1eaa79ac0ef17d65407cdd931db1675315af1", size = 360599, upload-time = "2025-11-02T21:39:28.964Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/dc/aa181df85f933052d962804906b282acb433cb9318b08ec2aceb4ee34faf/bitarray-3.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:99d25aff3745c54e61ab340b98400c52ebec04290a62078155e0d7eb30380220", size = 371972, upload-time = "2025-11-02T21:39:30.228Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/d9/b805bfa158c7bcf4df0ac19b1be581b47e1ddb792c11023aed80a7058e78/bitarray-3.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e645b4c365d6f1f9e0799380ad6395268f3c3b898244a650aaeb8d9d27b74c35", size = 340303, upload-time = "2025-11-02T21:39:31.342Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/42/5308cc97ea929e30727292617a3a88293470166851e13c9e3f16f395da55/bitarray-3.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2fa23fdb3beab313950bbb49674e8a161e61449332d3997089fe3944953f1b77", size = 330494, upload-time = "2025-11-02T21:39:32.769Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/89/64f1596cb80433323efdbc8dcd0d6e57c40dfbe6ea3341623f34ec397edd/bitarray-3.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:165052a0e61c880f7093808a0c524ce1b3555bfa114c0dfb5c809cd07918a60d", size = 358123, upload-time = "2025-11-02T21:39:34.331Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fd/f3d49c5443b57087f888b5e118c8dd78bb7c8e8cfeeed250f8e92128a05f/bitarray-3.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:337c8cd46a4c6568d367ed676cbf2d7de16f890bb31dbb54c44c1d6bb6d4a1de", size = 356046, upload-time = "2025-11-02T21:39:35.449Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/db/1fd0b402bd2b47142e958b6930dbb9445235d03fa703c9a24caa6e576ae2/bitarray-3.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:21ca6a47bf20db9e7ad74ca04b3d479e4d76109b68333eb23535553d2705339e", size = 336872, upload-time = "2025-11-02T21:39:36.891Z" },
-    { url = "https://files.pythonhosted.org/packages/58/73/680b47718f1313b4538af479c4732eaca0aeda34d93fc5b869f87932d57d/bitarray-3.8.0-cp312-cp312-win32.whl", hash = "sha256:178c5a4c7fdfb5cd79e372ae7f675390e670f3732e5bc68d327e01a5b3ff8d55", size = 143025, upload-time = "2025-11-02T21:39:38.303Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/11/7792587c19c79a8283e8838f44709fa4338a8f7d2a3091dfd81c07ae89c7/bitarray-3.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:75a3b6e9c695a6570ea488db75b84bb592ff70a944957efa1c655867c575018b", size = 149969, upload-time = "2025-11-02T21:39:39.715Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/00/9df64b5d8a84e8e9ec392f6f9ce93f50626a5b301cb6c6b3fe3406454d66/bitarray-3.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:5591daf81313096909d973fb2612fccd87528fdfdd39f6478bdce54543178954", size = 146907, upload-time = "2025-11-02T21:39:40.815Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/35/480364d4baf1e34c79076750914664373f561c58abb5c31c35b3fae613ff/bitarray-3.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:18214bac86341f1cc413772e66447d6cca10981e2880b70ecaf4e826c04f95e9", size = 148582, upload-time = "2025-11-02T21:39:42.268Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/a8/718b95524c803937f4edbaaf6480f39c80f6ed189d61357b345e8361ffb6/bitarray-3.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:01c5f0dc080b0ebb432f7a68ee1e88a76bd34f6d89c9568fcec65fb16ed71f0e", size = 145433, upload-time = "2025-11-02T21:39:43.552Z" },
-    { url = "https://files.pythonhosted.org/packages/03/66/4a10f30dc9e2e01e3b4ecd44a511219f98e63c86b0e0f704c90fac24059b/bitarray-3.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86685fa04067f7175f9718489ae755f6acde03593a1a9ca89305554af40e14fd", size = 332986, upload-time = "2025-11-02T21:39:44.656Z" },
-    { url = "https://files.pythonhosted.org/packages/53/25/4c08774d847f80a1166e4c704b4e0f1c417c0afe6306eae0bc5e70d35faa/bitarray-3.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56896ceeffe25946c4010320629e2d858ca763cd8ded273c81672a5edbcb1e0a", size = 360634, upload-time = "2025-11-02T21:39:45.798Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8f/bf8ad26169ebd0b2746d5c7564db734453ca467f8aab87e9d43b0a794383/bitarray-3.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9858dcbc23ba7eaadcd319786b982278a1a2b2020720b19db43e309579ff76fb", size = 371992, upload-time = "2025-11-02T21:39:46.968Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/16/ce166754e7c9d10650e02914552fa637cf3b2591f7ed16632bbf6b783312/bitarray-3.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa7dec53c25f1949513457ef8b0ea1fb40e76c672cc4d2daa8ad3c8d6b73491a", size = 340315, upload-time = "2025-11-02T21:39:48.182Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2a/fbba3a106ddd260e84b9a624f730257c32ba51a8a029565248dfedfdf6f2/bitarray-3.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:15a2eff91f54d2b1f573cca8ca6fb58763ce8fea80e7899ab028f3987ef71cd5", size = 330473, upload-time = "2025-11-02T21:39:49.705Z" },
-    { url = "https://files.pythonhosted.org/packages/68/97/56cf3c70196e7307ad32318a9d6ed969dbdc6a4534bbe429112fa7dfe42e/bitarray-3.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b1572ee0eb1967e71787af636bb7d1eb9c6735d5337762c450650e7f51844594", size = 358129, upload-time = "2025-11-02T21:39:51.189Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/be/afd391a5c0896d3339613321b2f94af853f29afc8bd3fbc327431244c642/bitarray-3.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5bfac7f236ba1a4d402644bdce47fb9db02a7cf3214a1f637d3a88390f9e5428", size = 356005, upload-time = "2025-11-02T21:39:52.355Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a8e1a371babba29bad3378bb3a2cdca2b012170711e7fe1f22031a6b7b95/bitarray-3.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f0a55cf02d2cdd739b40ce10c09bbdd520e141217696add7a48b56e67bdfdfe6", size = 336862, upload-time = "2025-11-02T21:39:54.345Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8a/6dc1d0fdc06991c8dc3b1fcfe1ae49fbaced42064cd1b5f24278e73fe05f/bitarray-3.8.0-cp313-cp313-win32.whl", hash = "sha256:a2ba92f59e30ce915e9e79af37649432e3a212ddddf416d4d686b1b4825bcdb2", size = 143018, upload-time = "2025-11-02T21:39:56.361Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/72/76e13f5cd23b8b9071747909663ce3b02da24a5e7e22c35146338625db35/bitarray-3.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:1c8f2a5d8006db5a555e06f9437e76bf52537d3dfd130cb8ae2b30866aca32c9", size = 149977, upload-time = "2025-11-02T21:39:57.718Z" },
-    { url = "https://files.pythonhosted.org/packages/01/37/60f336c32336cc3ec03b0c61076f16ea2f05d5371c8a56e802161d218b77/bitarray-3.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:50ddbe3a7b4b6ab96812f5a4d570f401a2cdb95642fd04c062f98939610bbeee", size = 146930, upload-time = "2025-11-02T21:39:59.308Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/b0/411327a6c7f6b2bead64bb06fe60b92e0344957ec1ab0645d5ccc25fdafe/bitarray-3.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8cbd4bfc933b33b85c43ef4c1f4d5e3e9d91975ea6368acf5fbac02bac06ea89", size = 148563, upload-time = "2025-11-02T21:40:01.006Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/bc/ff80d97c627d774f879da0ea93223adb1267feab7e07d5c17580ffe6d632/bitarray-3.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9d35d8f8a1c9ed4e2b08187b513f8a3c71958600129db3aa26d85ea3abfd1310", size = 145422, upload-time = "2025-11-02T21:40:02.535Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e7/b4cb6c5689aacd0a32f3aa8a507155eaa33528c63de2f182b60843fbf700/bitarray-3.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99f55e14e7c56f4fafe1343480c32b110ef03836c21ff7c48bae7add6818f77c", size = 332852, upload-time = "2025-11-02T21:40:03.645Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/91/fbd1b047e3e2f4b65590f289c8151df1d203d75b005f5aae4e072fe77d76/bitarray-3.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfbe2aa45b273f49e715c5345d94874cb65a28482bf231af408891c260601b8d", size = 360801, upload-time = "2025-11-02T21:40:04.827Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/4a/63064c593627bac8754fdafcb5343999c93ab2aeb27bcd9d270a010abea5/bitarray-3.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64af877116edf051375b45f0bda648143176a017b13803ec7b3a3111dc05f4c5", size = 371408, upload-time = "2025-11-02T21:40:05.985Z" },
-    { url = "https://files.pythonhosted.org/packages/46/97/ddc07723767bdafd170f2ff6e173c940fa874192783ee464aa3c1dedf07d/bitarray-3.8.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cdfbb27f2c46bb5bbdcee147530cbc5ca8ab858d7693924e88e30ada21b2c5e2", size = 340033, upload-time = "2025-11-02T21:40:07.189Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1e/e1ea9f1146fd4af032817069ff118918d73e5de519854ce3860e2ed560ff/bitarray-3.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4d73d4948dcc5591d880db8933004e01f1dd2296df9de815354d53469beb26fe", size = 330774, upload-time = "2025-11-02T21:40:08.496Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/9f/8242296c124a48d1eab471fd0838aeb7ea9c6fd720302d99ab7855d3e6d3/bitarray-3.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:28a85b056c0eb7f5d864c0ceef07034117e8ebfca756f50648c71950a568ba11", size = 358337, upload-time = "2025-11-02T21:40:10.035Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/6b/9095d75264c67d479f298c80802422464ce18c3cdd893252eeccf4997611/bitarray-3.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:79ec4498a545733ecace48d780d22407411b07403a2e08b9a4d7596c0b97ebd7", size = 355639, upload-time = "2025-11-02T21:40:11.485Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/af/c93c0ae5ef824136e90ac7ddf6cceccb1232f34240b2f55a922f874da9b4/bitarray-3.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:33af25c4ff7723363cb8404dfc2eefeab4110b654f6c98d26aba8a08c745d860", size = 336999, upload-time = "2025-11-02T21:40:12.709Z" },
-    { url = "https://files.pythonhosted.org/packages/81/0f/72c951f5997b2876355d5e671f78dd2362493254876675cf22dbd24389ae/bitarray-3.8.0-cp314-cp314-win32.whl", hash = "sha256:2c3bb96b6026643ce24677650889b09073f60b9860a71765f843c99f9ab38b25", size = 142169, upload-time = "2025-11-02T21:40:14.031Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/55/ef1b4de8107bf13823da8756c20e1fbc9452228b4e837f46f6d9ddba3eb3/bitarray-3.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:847c7f61964225fc489fe1d49eda7e0e0d253e98862c012cecf845f9ad45cdf4", size = 148737, upload-time = "2025-11-02T21:40:15.436Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/26/bc0784136775024ac56cc67c0d6f9aa77a7770de7f82c3a7c9be11c217cd/bitarray-3.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:a2cb35a6efaa0e3623d8272471371a12c7e07b51a33e5efce9b58f655d864b4e", size = 146083, upload-time = "2025-11-02T21:40:17.135Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/64/57984e64264bf43d93a1809e645972771566a2d0345f4896b041ce20b000/bitarray-3.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:15e8d0597cc6e8496de6f4dea2a6880c57e1251502a7072f5631108a1aa28521", size = 149455, upload-time = "2025-11-02T21:40:18.558Z" },
-    { url = "https://files.pythonhosted.org/packages/81/c0/0d5f2eaef1867f462f764bdb07d1e116c33a1bf052ea21889aefe4282f5b/bitarray-3.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8ffe660e963ae711cb9e2b8d8461c9b1ad6167823837fc17d59d5e539fb898fa", size = 146491, upload-time = "2025-11-02T21:40:19.665Z" },
-    { url = "https://files.pythonhosted.org/packages/65/c6/bc1261f7a8862c0c59220a484464739e52235fd1e2afcb24d7f7d3fb5702/bitarray-3.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4779f356083c62e29b4198d290b7b17a39a69702d150678b7efff0fdddf494a8", size = 339721, upload-time = "2025-11-02T21:40:21.277Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d8/289ca55dd2939ea17b1108dc53bffc0fdc5160ba44f77502dfaae35d08c6/bitarray-3.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:025d133bf4ca8cf75f904eeb8ea946228d7c043231866143f31946a6f4dd0bf3", size = 367823, upload-time = "2025-11-02T21:40:22.463Z" },
-    { url = "https://files.pythonhosted.org/packages/91/a2/61e7461ca9ac0fcb70f327a2e84b006996d2a840898e69037a39c87c6d06/bitarray-3.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:451f9958850ea98440d542278368c8d1e1ea821e2494b204570ba34a340759df", size = 377341, upload-time = "2025-11-02T21:40:23.789Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/87/4a0c9c8bdb13916d443e04d8f8542eef9190f31425da3c17c3478c40173f/bitarray-3.8.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d79f659965290af60d6acc8e2716341865fe74609a7ede2a33c2f86ad893b8f", size = 344985, upload-time = "2025-11-02T21:40:25.261Z" },
-    { url = "https://files.pythonhosted.org/packages/17/4c/ff9259b916efe53695b631772e5213699c738efc2471b5ffe273f4000994/bitarray-3.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fbf05678c2ae0064fb1b8de7e9e8f0fc30621b73c8477786dd0fb3868044a8c8", size = 336796, upload-time = "2025-11-02T21:40:26.942Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/4b/51b2468bbddbade5e2f3b8d5db08282c5b309e8687b0f02f75a8b5ff559c/bitarray-3.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:c396358023b876cff547ce87f4e8ff8a2280598873a137e8cc69e115262260b8", size = 365085, upload-time = "2025-11-02T21:40:28.224Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/79/53473bfc2e052c6dbb628cdc1b156be621c77aaeb715918358b01574be55/bitarray-3.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed3493a369fe849cce98542d7405c88030b355e4d2e113887cb7ecc86c205773", size = 361012, upload-time = "2025-11-02T21:40:29.635Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b1/242bf2e44bfc69e73fa2b954b425d761a8e632f78ea31008f1c3cfad0854/bitarray-3.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c764fb167411d5afaef88138542a4bfa28bd5e5ded5e8e42df87cef965efd6e9", size = 340644, upload-time = "2025-11-02T21:40:31.089Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/01/12e5ecf30a5de28a32485f226cad4b8a546845f65f755ce0365057ab1e92/bitarray-3.8.0-cp314-cp314t-win32.whl", hash = "sha256:e12769d3adcc419e65860de946df8d2ed274932177ac1cdb05186e498aaa9149", size = 143630, upload-time = "2025-11-02T21:40:32.351Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/92/6b6ade587b08024a8a890b07724775d29da9cf7497be5c3cbe226185e463/bitarray-3.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0ca70ccf789446a6dfde40b482ec21d28067172cd1f8efd50d5548159fccad9e", size = 150250, upload-time = "2025-11-02T21:40:33.596Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/40/be3858ffed004e47e48a2cefecdbf9b950d41098b780f9dc3aa609a88351/bitarray-3.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2a3d1b05ffdd3e95687942ae7b13c63689f85d3f15c39b33329e3cb9ce6c015f", size = 147015, upload-time = "2025-11-02T21:40:35.064Z" },
-]
-
-[[package]]
-name = "bitstring"
-version = "4.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bitarray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/a8/a80c890db75d5bdd5314b5de02c4144c7de94fd0cefcae51acaeb14c6a3f/bitstring-4.3.1.tar.gz", hash = "sha256:a08bc09d3857216d4c0f412a1611056f1cc2b64fd254fb1e8a0afba7cfa1a95a", size = 251426, upload-time = "2025-03-22T09:39:06.978Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/2d/174566b533755ddf8efb32a5503af61c756a983de379f8ad3aed6a982d38/bitstring-4.3.1-py3-none-any.whl", hash = "sha256:69d1587f0ac18dc7d93fc7e80d5f447161a33e57027e726dc18a0a8bacf1711a", size = 71930, upload-time = "2025-03-22T09:39:05.163Z" },
 ]
 
 [[package]]
@@ -622,15 +493,6 @@ wheels = [
 ]
 
 [[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -680,14 +542,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -697,15 +559,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "construct"
-version = "2.10.70"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/77/8c84b98eca70d245a2a956452f21d57930d22ab88cbeed9290ca630cf03f/construct-2.10.70.tar.gz", hash = "sha256:4d2472f9684731e58cc9c56c463be63baa1447d674e0d66aeb5627b22f512c29", size = 86337, upload-time = "2023-11-29T08:44:49.545Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/fb/08b3f4bf05da99aba8ffea52a558758def16e8516bc75ca94ff73587e7d3/construct-2.10.70-py3-none-any.whl", hash = "sha256:c80be81ef595a1a821ec69dc16099550ed22197615f4320b57cc9ce2a672cb30", size = 63020, upload-time = "2023-11-29T08:44:46.876Z" },
 ]
 
 [[package]]
@@ -859,18 +712,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecation"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -903,15 +744,6 @@ wheels = [
 ]
 
 [[package]]
-name = "doipclient"
-version = "1.1.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/39/28684a9cdc9c2c5e836a802a4457685c777d89ce9d47ff1261d578957f45/doipclient-1.1.8.tar.gz", hash = "sha256:5728b46ca150baa48bfc63d7783371d0425771c99aeaeb822784bb48b440b0fc", size = 25044, upload-time = "2025-12-17T06:44:23.96Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/54/1336b3b1176d2cccbeccbe1935867d8cebfc4a3e7271d31089195875bcc4/doipclient-1.1.8-py3-none-any.whl", hash = "sha256:cbc7d538f0e1c9ce040753d9a8066710c646c27aacd679d1da8bc66687ff435e", size = 20211, upload-time = "2025-12-17T06:44:22.846Z" },
-]
-
-[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -934,22 +766,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/67/c5/0c89af3da1f3133b5
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/ca/a0296fca375d4324f471bb34d2ce8a585b48fb9eae21cf9abe00913eb899/esbonio-0.16.5-py3-none-any.whl", hash = "sha256:04ba926e3603f7b1fde1abc690b47afd60749b64b1029b6bce8e1de0bb284921", size = 170830, upload-time = "2024-09-23T18:57:56.568Z" },
 ]
-
-[[package]]
-name = "esptool"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bitstring" },
-    { name = "click" },
-    { name = "cryptography" },
-    { name = "intelhex" },
-    { name = "pyserial" },
-    { name = "pyyaml" },
-    { name = "reedsolo" },
-    { name = "rich-click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/25/7b50d81a66f600a60f23258fa134201e97e854271b478ca4e21e9f694355/esptool-5.2.0.tar.gz", hash = "sha256:9c355b7d6331cc92979cc710ae5c41f59830d1ea29ec24c467c6005a092c06d6", size = 463000, upload-time = "2026-02-18T16:10:52.641Z" }
 
 [[package]]
 name = "fabric"
@@ -1220,40 +1036,12 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
+name = "hid"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/f8/0357a8aa8874a243e96d08a8568efaf7478293e1a3441ddca18039b690c1/hid-1.0.9.tar.gz", hash = "sha256:f4471f11f0e176d1b0cb1b243e55498cc90347a3aede735655304395694ac182", size = 4973, upload-time = "2026-02-05T15:35:20.595Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/f0e1ad95179f44a6fc7a9140be025812cc7a62cf7390442b685a57ee1417/hid-1.0.9-py3-none-any.whl", hash = "sha256:6b9289e00bbc1e1589bec0c7f376a63fe03a4a4a1875575d0ad60e3e11a349f4", size = 4959, upload-time = "2026-02-05T15:35:19.269Z" },
 ]
 
 [[package]]
@@ -1305,15 +1093,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "intelhex"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/37/1e7522494557d342a24cb236e2aec5d078fac8ed03ad4b61372586406b01/intelhex-2.3.0.tar.gz", hash = "sha256:892b7361a719f4945237da8ccf754e9513db32f5628852785aea108dcd250093", size = 44513, upload-time = "2020-10-20T20:35:51.526Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/78/79461288da2b13ed0a13deb65c4ad1428acb674b95278fa9abf1cefe62a2/intelhex-2.3.0-py2.py3-none-any.whl", hash = "sha256:87cc5225657524ec6361354be928adfd56bcf2a3dcc646c40f8f094c39c07db4", size = 50914, upload-time = "2020-10-20T20:35:50.162Z" },
 ]
 
 [[package]]
@@ -1443,15 +1222,12 @@ dependencies = [
     { name = "jumpstarter-driver-can" },
     { name = "jumpstarter-driver-composite" },
     { name = "jumpstarter-driver-corellium" },
-    { name = "jumpstarter-driver-doip" },
     { name = "jumpstarter-driver-dutlink" },
-    { name = "jumpstarter-driver-esp32" },
     { name = "jumpstarter-driver-flashers" },
     { name = "jumpstarter-driver-gpiod" },
     { name = "jumpstarter-driver-http" },
     { name = "jumpstarter-driver-network" },
     { name = "jumpstarter-driver-opendal" },
-    { name = "jumpstarter-driver-pi-pico" },
     { name = "jumpstarter-driver-power" },
     { name = "jumpstarter-driver-probe-rs" },
     { name = "jumpstarter-driver-pyserial" },
@@ -1464,9 +1240,6 @@ dependencies = [
     { name = "jumpstarter-driver-tftp" },
     { name = "jumpstarter-driver-tmt" },
     { name = "jumpstarter-driver-uboot" },
-    { name = "jumpstarter-driver-uds" },
-    { name = "jumpstarter-driver-uds-can" },
-    { name = "jumpstarter-driver-uds-doip" },
     { name = "jumpstarter-driver-ustreamer" },
     { name = "jumpstarter-driver-vnc" },
     { name = "jumpstarter-driver-yepkit" },
@@ -1487,15 +1260,12 @@ requires-dist = [
     { name = "jumpstarter-driver-can", editable = "packages/jumpstarter-driver-can" },
     { name = "jumpstarter-driver-composite", editable = "packages/jumpstarter-driver-composite" },
     { name = "jumpstarter-driver-corellium", editable = "packages/jumpstarter-driver-corellium" },
-    { name = "jumpstarter-driver-doip", editable = "packages/jumpstarter-driver-doip" },
     { name = "jumpstarter-driver-dutlink", editable = "packages/jumpstarter-driver-dutlink" },
-    { name = "jumpstarter-driver-esp32", editable = "packages/jumpstarter-driver-esp32" },
     { name = "jumpstarter-driver-flashers", editable = "packages/jumpstarter-driver-flashers" },
     { name = "jumpstarter-driver-gpiod", editable = "packages/jumpstarter-driver-gpiod" },
     { name = "jumpstarter-driver-http", editable = "packages/jumpstarter-driver-http" },
     { name = "jumpstarter-driver-network", editable = "packages/jumpstarter-driver-network" },
     { name = "jumpstarter-driver-opendal", editable = "packages/jumpstarter-driver-opendal" },
-    { name = "jumpstarter-driver-pi-pico", editable = "packages/jumpstarter-driver-pi-pico" },
     { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
     { name = "jumpstarter-driver-probe-rs", editable = "packages/jumpstarter-driver-probe-rs" },
     { name = "jumpstarter-driver-pyserial", editable = "packages/jumpstarter-driver-pyserial" },
@@ -1508,9 +1278,6 @@ requires-dist = [
     { name = "jumpstarter-driver-tftp", editable = "packages/jumpstarter-driver-tftp" },
     { name = "jumpstarter-driver-tmt", editable = "packages/jumpstarter-driver-tmt" },
     { name = "jumpstarter-driver-uboot", editable = "packages/jumpstarter-driver-uboot" },
-    { name = "jumpstarter-driver-uds", editable = "packages/jumpstarter-driver-uds" },
-    { name = "jumpstarter-driver-uds-can", editable = "packages/jumpstarter-driver-uds-can" },
-    { name = "jumpstarter-driver-uds-doip", editable = "packages/jumpstarter-driver-uds-doip" },
     { name = "jumpstarter-driver-ustreamer", editable = "packages/jumpstarter-driver-ustreamer" },
     { name = "jumpstarter-driver-vnc", editable = "packages/jumpstarter-driver-vnc" },
     { name = "jumpstarter-driver-yepkit", editable = "packages/jumpstarter-driver-yepkit" },
@@ -1526,7 +1293,6 @@ source = { editable = "packages/jumpstarter-cli" }
 dependencies = [
     { name = "jumpstarter-cli-admin" },
     { name = "jumpstarter-cli-driver" },
-    { name = "jumpstarter-mcp" },
     { name = "pytimeparse2" },
 ]
 
@@ -1542,7 +1308,6 @@ dev = [
 requires-dist = [
     { name = "jumpstarter-cli-admin", editable = "packages/jumpstarter-cli-admin" },
     { name = "jumpstarter-cli-driver", editable = "packages/jumpstarter-cli-driver" },
-    { name = "jumpstarter-mcp", editable = "packages/jumpstarter-mcp" },
     { name = "pytimeparse2", specifier = ">=1.7.1" },
 ]
 
@@ -1656,78 +1421,6 @@ dev = [
     { name = "pytest-anyio", specifier = ">=0.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-driver-adb"
-source = { editable = "packages/jumpstarter-driver-adb" }
-dependencies = [
-    { name = "click" },
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-network" },
-]
-
-[package.optional-dependencies]
-python-api = [
-    { name = "adbutils" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "adbutils", marker = "extra == 'python-api'", specifier = ">=2.8.7" },
-    { name = "click", specifier = ">=8.0.0" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-network", editable = "packages/jumpstarter-driver-network" },
-]
-provides-extras = ["python-api"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-driver-androidemulator"
-source = { editable = "packages/jumpstarter-driver-androidemulator" }
-dependencies = [
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-adb" },
-    { name = "jumpstarter-driver-composite" },
-    { name = "jumpstarter-driver-power" },
-]
-
-[package.optional-dependencies]
-python-api = [
-    { name = "adbutils" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "adbutils", marker = "extra == 'python-api'", specifier = ">=2.8.7" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-adb", editable = "packages/jumpstarter-driver-adb" },
-    { name = "jumpstarter-driver-composite", editable = "packages/jumpstarter-driver-composite" },
-    { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
-]
-provides-extras = ["python-api"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -1855,32 +1548,6 @@ dev = [
 ]
 
 [[package]]
-name = "jumpstarter-driver-doip"
-source = { editable = "packages/jumpstarter-driver-doip" }
-dependencies = [
-    { name = "doipclient" },
-    { name = "jumpstarter" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "doipclient", specifier = ">=1.1.0" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
 name = "jumpstarter-driver-dutlink"
 source = { editable = "packages/jumpstarter-driver-dutlink" }
 dependencies = [
@@ -1948,40 +1615,6 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-httpserver", specifier = ">=1.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-driver-esp32"
-source = { editable = "packages/jumpstarter-driver-esp32" }
-dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "esptool" },
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-opendal" },
-    { name = "jumpstarter-driver-pyserial" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=4.10.0" },
-    { name = "click", specifier = ">=8.3.1" },
-    { name = "esptool", specifier = ">=4.0" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-opendal", editable = "packages/jumpstarter-driver-opendal" },
-    { name = "jumpstarter-driver-pyserial", editable = "packages/jumpstarter-driver-pyserial" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -2198,6 +1831,38 @@ dev = [
 ]
 
 [[package]]
+name = "jumpstarter-driver-noyito-relay"
+source = { editable = "packages/jumpstarter-driver-noyito-relay" }
+dependencies = [
+    { name = "hid" },
+    { name = "jumpstarter" },
+    { name = "jumpstarter-driver-power" },
+    { name = "pyserial" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hid", specifier = ">=1.0.4" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
+    { name = "pyserial", specifier = ">=3.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+]
+
+[[package]]
 name = "jumpstarter-driver-opendal"
 source = { editable = "packages/jumpstarter-driver-opendal" }
 dependencies = [
@@ -2216,45 +1881,13 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.7.2" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "opendal", specifier = ">=0.45.8,<0.46" },
+    { name = "opendal", specifier = ">=0.45.8" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-driver-pi-pico"
-source = { editable = "packages/jumpstarter-driver-pi-pico" }
-dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-opendal" },
-    { name = "jumpstarter-driver-pyserial" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=4.10.0" },
-    { name = "click", specifier = ">=8.3.1" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-opendal", editable = "packages/jumpstarter-driver-opendal" },
-    { name = "jumpstarter-driver-pyserial", editable = "packages/jumpstarter-driver-pyserial" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -2720,96 +2353,6 @@ dev = [
 ]
 
 [[package]]
-name = "jumpstarter-driver-uds"
-source = { editable = "packages/jumpstarter-driver-uds" }
-dependencies = [
-    { name = "jumpstarter" },
-    { name = "udsoncan" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "udsoncan", specifier = ">=1.21" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-driver-uds-can"
-source = { editable = "packages/jumpstarter-driver-uds-can" }
-dependencies = [
-    { name = "can-isotp" },
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-can" },
-    { name = "jumpstarter-driver-uds" },
-    { name = "python-can" },
-    { name = "udsoncan" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "can-isotp", specifier = ">=2.0.6" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-can", editable = "packages/jumpstarter-driver-can" },
-    { name = "jumpstarter-driver-uds", editable = "packages/jumpstarter-driver-uds" },
-    { name = "python-can", specifier = ">=4.5.0" },
-    { name = "udsoncan", specifier = ">=1.21" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-driver-uds-doip"
-source = { editable = "packages/jumpstarter-driver-uds-doip" }
-dependencies = [
-    { name = "doipclient" },
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-uds" },
-    { name = "udsoncan" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "doipclient", specifier = ">=1.1.0" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-uds", editable = "packages/jumpstarter-driver-uds" },
-    { name = "udsoncan", specifier = ">=1.21" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
 name = "jumpstarter-driver-ustreamer"
 source = { editable = "packages/jumpstarter-driver-ustreamer" }
 dependencies = [
@@ -2868,32 +2411,6 @@ dev = [
 ]
 
 [[package]]
-name = "jumpstarter-driver-xcp"
-source = { editable = "packages/jumpstarter-driver-xcp" }
-dependencies = [
-    { name = "jumpstarter" },
-    { name = "pyxcp" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "pyxcp", specifier = ">=0.27.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-]
-
-[[package]]
 name = "jumpstarter-driver-yepkit"
 source = { editable = "packages/jumpstarter-driver-yepkit" }
 dependencies = [
@@ -2924,38 +2441,15 @@ dev = [
 ]
 
 [[package]]
-name = "jumpstarter-example-android-emulator"
-version = "0.1.0"
-source = { virtual = "examples/android-emulator" }
-dependencies = [
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-androidemulator", extra = ["python-api"] },
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-androidemulator", extras = ["python-api"], editable = "packages/jumpstarter-driver-androidemulator" },
-    { name = "pytest", specifier = ">=8.3.2" },
-]
-
-[[package]]
 name = "jumpstarter-example-automotive"
 version = "0.1.0"
 source = { virtual = "examples/automotive" }
 dependencies = [
     { name = "jumpstarter" },
-    { name = "jumpstarter-driver-uds-doip" },
-    { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-uds-doip", editable = "packages/jumpstarter-driver-uds-doip" },
-    { name = "pytest", specifier = ">=8.3.2" },
-]
+requires-dist = [{ name = "jumpstarter", editable = "packages/jumpstarter" }]
 
 [[package]]
 name = "jumpstarter-example-soc-pytest"
@@ -2977,23 +2471,6 @@ requires-dist = [
     { name = "jumpstarter-driver-network", editable = "packages/jumpstarter-driver-network" },
     { name = "jumpstarter-imagehash", editable = "packages/jumpstarter-imagehash" },
     { name = "jumpstarter-testing", editable = "packages/jumpstarter-testing" },
-    { name = "pytest", specifier = ">=8.3.2" },
-]
-
-[[package]]
-name = "jumpstarter-example-xcp-ecu"
-version = "0.1.0"
-source = { virtual = "examples/xcp-ecu" }
-dependencies = [
-    { name = "jumpstarter" },
-    { name = "jumpstarter-driver-xcp" },
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-driver-xcp", editable = "packages/jumpstarter-driver-xcp" },
     { name = "pytest", specifier = ">=8.3.2" },
 ]
 
@@ -3053,42 +2530,6 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "semver", specifier = "~=2.13" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-anyio", specifier = ">=0.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.0.0" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-]
-
-[[package]]
-name = "jumpstarter-mcp"
-source = { editable = "packages/jumpstarter-mcp" }
-dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "jumpstarter" },
-    { name = "jumpstarter-cli-common" },
-    { name = "mcp" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-anyio" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anyio", specifier = ">=4.0.0" },
-    { name = "click", specifier = ">=8.1.7.2" },
-    { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "jumpstarter-cli-common", editable = "packages/jumpstarter-cli-common" },
-    { name = "mcp", specifier = ">=1.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3199,65 +2640,6 @@ wheels = [
 ]
 
 [[package]]
-name = "line-profiler"
-version = "5.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/b6/6d18ad201417a9c5168995541d0fd7981b5652b2b34f6e46a3a93c0f1beb/line_profiler-5.0.2.tar.gz", hash = "sha256:8d8a990c84c64bcde45af22af502d17bc0ae107be405ce41bba92af5c39c0000", size = 407075, upload-time = "2026-02-23T23:31:20.698Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/cd/a92661cb24987d0a4cf86f7ec9f6a0f74ea981c520b6458275d41b11ec0a/line_profiler-5.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:602370a9bb8d020ea28ddac3bb7fd4331c91d495e6e81d5f75752cbb2f2bb802", size = 650547, upload-time = "2026-02-23T23:30:00.593Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/77/5489458f8cc01ea00cdf25bc6fa74e748a30e7b758275cc98b485b59de91/line_profiler-5.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:26956eef9668f641c9c6f9adb6b1b236252a73405e238452768812af14f9a145", size = 507989, upload-time = "2026-02-23T23:30:01.848Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/4f/14aace66e067fb5a774580bc71b348c323c91a4e2ac223a98822de67ecda/line_profiler-5.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:64376a726009b7842706a3fef2a6dba051f0bf5a98cbbcafa4c23d6c83bac53c", size = 497137, upload-time = "2026-02-23T23:30:03.515Z" },
-    { url = "https://files.pythonhosted.org/packages/52/48/ea92cc96538a192fdf74249f28ad9e9c0526743b12817f920985e7fdbbe2/line_profiler-5.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68432878d7598916f02be3fbb83e3a4727443cfd96af9cbea05cc1ae9749ed82", size = 1526617, upload-time = "2026-02-23T23:30:05.211Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/8d/c73544fba5683a50d7579f21614942d9223e2dd618986be56d5beff561e5/line_profiler-5.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7956e79526dc4898ca63dd8e3f435ff674b35d7e06457bfff883efae3ecb8359", size = 1540576, upload-time = "2026-02-23T23:30:07.234Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/33/a3255c143148e5886179b689b0413bb0b7edbd6af1531db577f8bf8b69fd/line_profiler-5.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:29370b9d239c0e68ea017bbf2b582beed6122a439ef97a8e38228708b52ba595", size = 2480641, upload-time = "2026-02-23T23:30:08.638Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c8/d398438f9af55c4bd799c15c6a9fc5d349c36ef461edce8ed3569768c964/line_profiler-5.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f47682cb1cef2a3b3865e59fdaf2f486196476fa508ddcdd838e3484626c2a68", size = 2565285, upload-time = "2026-02-23T23:30:10.015Z" },
-    { url = "https://files.pythonhosted.org/packages/74/08/663f3dd52ebebcb98cddca9ca4f4b51fcd43ce2c8c6b676de28e2ad6f384/line_profiler-5.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:b74416342261d0434e2ae0ff074ec0ecf0ea4e66ec2db5a95dd8b0ec7f2b1a8b", size = 480440, upload-time = "2026-02-23T23:30:11.588Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/c4/12ac6f1c139780301d23b9f64ccb160366063124e91134fcccfb24d8b9b7/line_profiler-5.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f0d51ddb054d38a37607b335475c8be9fae4152b01873d1fc1d6b6a317b66398", size = 464965, upload-time = "2026-02-23T23:30:13.262Z" },
-    { url = "https://files.pythonhosted.org/packages/99/92/fb766e6355118d2a681c18525d4c005c146ec44b064ccfd70f4529d8d260/line_profiler-5.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:256c1d5e84a93254dbe656d0486322190cc68f6b517544edef17a9f00167e680", size = 646920, upload-time = "2026-02-23T23:30:14.692Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9d/3583c1cdc740206de9e4734bdcf377d649b89ea876bc36001d95b3dea67d/line_profiler-5.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:892f0cd9967b101ce7528be2d388616037c73cb27830effd7493fa021165c622", size = 505695, upload-time = "2026-02-23T23:30:16.375Z" },
-    { url = "https://files.pythonhosted.org/packages/27/60/412476a1d09beac783d11d3bbf85fe6c1e3d50058e3c28967fee59c46649/line_profiler-5.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d2d02735843c14337dae3e80d95a732b4657ef759def75162ef97a1aa7466aac", size = 495859, upload-time = "2026-02-23T23:30:18.036Z" },
-    { url = "https://files.pythonhosted.org/packages/37/75/65028bad08264fd8f9c3f0fd405c539ff552c2d1cf2a00965157ad148973/line_profiler-5.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d2e166a86dc9c78c349ee18b592b98ebfb9dae615f63fc77cce5f5f751a6ad0", size = 1464882, upload-time = "2026-02-23T23:30:19.273Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/6c/2d0286f67e6bb2b00ae23f9af6df18bfc6bb1ac5d803a8f46bd3eb22a8f1/line_profiler-5.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a870b68af1539d718d030f4c4726d35cff4b14ab605147e65222933c5c0e10e", size = 1484331, upload-time = "2026-02-23T23:30:20.571Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/a4/b01359733214a1a85c5f86f3953b07deb61b267efa0328e8d436a1ad80ea/line_profiler-5.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:fe8cd787caa2a02ca7e138832fa4cab1f198377eaf6e5e8263e8b7506157c454", size = 2411802, upload-time = "2026-02-23T23:30:21.995Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/f4/1fa91206a6c50091cf614fdd5c9d349eb3a57d23f5eb8be8fffe7e0525b9/line_profiler-5.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:70ff915ade9e3ec38ff043ff093b590bbb3055e6fc8b311e0fe14cd78fb2a7f7", size = 2495790, upload-time = "2026-02-23T23:30:23.448Z" },
-    { url = "https://files.pythonhosted.org/packages/87/18/d389c72dce6c8318c088a7c29ee8961a913c8a1c6469888b517e8f47ddaf/line_profiler-5.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:026779b9dfca0f367174f5d34bcccffce2755db40a4389f0d8a531a2e3ca7cfc", size = 478790, upload-time = "2026-02-23T23:30:24.848Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/54/d171600a4190c07215090a88846ef0093b5bf34a81f8059115592dbb1354/line_profiler-5.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:fe22b927f05a61a0149976bf0d22d8e56fa742ec89f3d72358db71a1f440c77b", size = 462269, upload-time = "2026-02-23T23:30:26.237Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/64/856b920e026fbd239df875ec05e63583f7bd7f250805215ab6e132da11d1/line_profiler-5.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:016effba91d34d15229d41984e921a27f66a7b634f1d7adf6c57c743f3d6a0eb", size = 642642, upload-time = "2026-02-23T23:30:27.63Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/08/0a56fab0a36818af6ffc8073700db2f402db5a62477b69d938c19871d631/line_profiler-5.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:506e800dd408a8aafadf39ff4e4a1375ae7794910d00098f191520a2f390cb99", size = 503787, upload-time = "2026-02-23T23:30:29.226Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/9a/0ab45cf92b2c13261b475c440e18bb18d9497cc2ad5dfaf38c231c72b02b/line_profiler-5.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e67f77bcb349a663cb22819f65621bcd2a39889524dd890d1d88f8736841b7b", size = 493631, upload-time = "2026-02-23T23:30:30.502Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/15/a5b603f0c7c795aa656a95e2a70d139dc499b5d153b6a3129bbba6b6f913/line_profiler-5.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6b9d08e85fd48d254ae253e76dc72598e94200ef7002eb1ae0bab4cc9c5e41a", size = 1464022, upload-time = "2026-02-23T23:30:31.793Z" },
-    { url = "https://files.pythonhosted.org/packages/27/6f/0f399c72eecaf8f8c00e84238b5786afc34d0a4ef5ad10c63c712715ba86/line_profiler-5.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31290e06ac25cd87fee46ebe979541d4ec7c8d6f15c5cbe5874a932b1cee95bb", size = 1483425, upload-time = "2026-02-23T23:30:33.15Z" },
-    { url = "https://files.pythonhosted.org/packages/65/18/f4c642a29719a84d17ea8b58cd6e60943573a28228c30c568565ed5512aa/line_profiler-5.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1d7fbcc2dbd8534fc6f7d2b440076749b2235cdc525eb177fefafeaf7550373f", size = 2410276, upload-time = "2026-02-23T23:30:34.943Z" },
-    { url = "https://files.pythonhosted.org/packages/90/33/701203686e7d27a545e3bbc8e81fffc7d091c42ed33564be4e72376ef45b/line_profiler-5.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:55f04671f48afcd90858c18fbdb2509463c77d717ed5424664f096e902206b6b", size = 2495283, upload-time = "2026-02-23T23:30:36.616Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e1/59fe065f67ed1fb8f974a9e3434685af1fc1f6a154489f7ab0992eab1c73/line_profiler-5.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:d2262d4bbbcf72bd430fc5763073792a0f1cb20e64de0f7ecf6e8ae16627d876", size = 479287, upload-time = "2026-02-23T23:30:38.152Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/83/89f6ae52fa77960404ee88fc078ee680e504bf1ab8724ac01430cee0f5a5/line_profiler-5.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:abf755b020d91b639cbc563015eca381ca64e6bd27ee55ef9004a3a17b6d4dcf", size = 461960, upload-time = "2026-02-23T23:30:39.657Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ae/43caf21edd10a7f5e138bdffcad01ade9a704462a923054402bbadbe5364/line_profiler-5.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a1cc30f3f7877fec826d0f40f400ee6c99239dc6a2f587b8d90d06a42d29c8a5", size = 648335, upload-time = "2026-02-23T23:30:41.042Z" },
-    { url = "https://files.pythonhosted.org/packages/34/90/8a1fb985dc582d140fc92608dec3037a484c5f8ab99ae05c24031aa68000/line_profiler-5.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f90923e1cc4ff8eda1d18e525089fca7bfd6dfe8817ec530a913a2c7444ba0fd", size = 508823, upload-time = "2026-02-23T23:30:42.16Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/01/855c55e195ac0aadb8ca4e4c65311f945ed02a2491b436bc33cee318d841/line_profiler-5.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cc3d0ecccb14f014d05b32f687d22adcb98bf59fdcc721e7a4330f0372a56f92", size = 499868, upload-time = "2026-02-23T23:30:44.188Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/48/fe73d6192a37637534366306a7871ef0f7ff5973bd87da082e4bf5ec0764/line_profiler-5.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5341f36e532e7ed28e323f5502a29b397b66a6708c6427a77f965148a2e5ddec", size = 1460660, upload-time = "2026-02-23T23:30:45.601Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1c/e1236e0f3c7ec1e19e74d61ac15143a7826b5767296de87bcf3aa26548a1/line_profiler-5.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cce501f9d996b317b599c0ae99e3eb1bd447874ef8fef1da330b27f3a23eb50", size = 1475222, upload-time = "2026-02-23T23:30:47.014Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ad/02302fd2a82949277036bc557ecebddb9bc6282b76a4da7660258fe82111/line_profiler-5.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b237d82fb792c3db7c80a8675d3c48993d4421b14d96ae602f7fe9ccf1f85903", size = 2413428, upload-time = "2026-02-23T23:30:48.828Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/b3efe646c8b9fdc6fe26720860276c8a2bb745ffe30f5bcbc9726b975673/line_profiler-5.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:74febeca89128a37a32e6500c99665943c0d11e6043f46ce95596d7d1e1732a7", size = 2494741, upload-time = "2026-02-23T23:30:50.755Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/ad/ddadd39eb92900f063f27e8f6d748c03dc2638873f07ebf3cee75f29711f/line_profiler-5.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:d6ce98faff60d9552a30e233648a848682b5d664a7e09e9669163a8f01e28147", size = 485700, upload-time = "2026-02-23T23:30:52.373Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/45/a529f355eea8fb790fbdee0273d6c0049dba3232a36e82c30d849b00e996/line_profiler-5.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:8be7cc5f4ed9ad87352129d1a494cf5ba7f0fced0472201d83ac9fbfa20f798b", size = 469781, upload-time = "2026-02-23T23:30:53.747Z" },
-]
-
-[[package]]
-name = "line-profiler-pycharm"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "line-profiler" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/b0/d7437c668ce49d45b8e28548d863ffccf4c067c66f147444594c1e531a92/line_profiler_pycharm-1.2.0.tar.gz", hash = "sha256:16cacf234952420fc324f17704c0cc2145d5afd2ec0593e359796927bcc0debb", size = 4386, upload-time = "2024-09-23T18:50:41.351Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/5e/b0331bf5e3f9f193b776fc0b22348143fc36f59bb931f0679a473ee667eb/line_profiler_pycharm-1.2.0-py3-none-any.whl", hash = "sha256:2d4c47c6894ab81f48fbb132ac4830490813b13c297016ae0d97bc7ef12041ad", size = 4762, upload-time = "2024-09-23T18:50:39.553Z" },
-]
-
-[[package]]
 name = "lsprotocol"
 version = "2023.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3268,18 +2650,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434, upload-time = "2024-01-09T17:21:12.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826, upload-time = "2024-01-09T17:21:14.491Z" },
-]
-
-[[package]]
-name = "mako"
-version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]
@@ -3340,31 +2710,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
-]
-
-[[package]]
-name = "mcp"
-version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [[package]]
@@ -4029,20 +3374,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyjwt"
-version = "2.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
-]
-
-[package.optional-dependencies]
-crypto = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "pynacl"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4253,6 +3584,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "pytest-mqtt"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4302,30 +3645,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-multipart"
-version = "0.0.22"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
-]
-
-[[package]]
 name = "pytimeparse2"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/10/cc63fecd69905eb4d300fe71bd580e4a631483e9f53fdcb8c0ad345ce832/pytimeparse2-1.7.1.tar.gz", hash = "sha256:98668cdcba4890e1789e432e8ea0059ccf72402f13f5d52be15bdfaeb3a8b253", size = 10431, upload-time = "2023-05-11T21:40:55.774Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/9e/85abf91ef5df452f56498927affdb7128194d15644084f6c6722477c305b/pytimeparse2-1.7.1-py3-none-any.whl", hash = "sha256:a162ea6a7707fd0bb82dd99556efb783935f51885c8bdced0fce3fffe85ab002", size = 6136, upload-time = "2023-05-11T21:40:46.051Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2026.1.post1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]
@@ -4403,51 +3728,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyxcp"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bandit" },
-    { name = "chardet" },
-    { name = "construct" },
-    { name = "line-profiler-pycharm" },
-    { name = "mako" },
-    { name = "pydantic" },
-    { name = "pyserial" },
-    { name = "python-can" },
-    { name = "pytz" },
-    { name = "pyusb" },
-    { name = "rich" },
-    { name = "toml" },
-    { name = "tomlkit" },
-    { name = "traitlets" },
-    { name = "uptime" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/24/24/5d98e62560ab5fd895cdefe131c96eaa9bbcdee1c03ea7d240d17e6a24d1/pyxcp-0.28.1.tar.gz", hash = "sha256:a0109476c4427d0d6e87b7f50b2a5c44f31d14d817bb2b97ed0db4dad0750741", size = 299281, upload-time = "2026-03-01T06:50:48.536Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/2f/0052ba201bfbc957bf7ba85b63c0b150d19144057830877bc832fc180aca/pyxcp-0.28.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99c76538db44f4d8dcd0288164f26d6157988125f383ea5b29dd0b3a12290405", size = 1794599, upload-time = "2026-03-01T06:50:15.043Z" },
-    { url = "https://files.pythonhosted.org/packages/da/d8/0f756c35ae8180089fe836379e27d70ffea1ea3eb105b3faa56b9b70a3d3/pyxcp-0.28.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6cf8529d6370658deaf619b5af9cb7d00606e010c9a4707ce6fd0e93cbe8673e", size = 2100970, upload-time = "2026-03-01T06:50:16.819Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ce/0007cb48bfc198d37aa08533b029712aaa29084df8026a539e7c3a45ce31/pyxcp-0.28.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa6641c0eb1d9c48378dee3566bfe65e7bc685ccadb27325cd88aa511472852e", size = 2290045, upload-time = "2026-03-01T06:50:18.552Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/88/efc85b9af66aa691af131bbfbd98b916ef80c3f170822b1621e8daf0c1ae/pyxcp-0.28.1-cp311-cp311-win_amd64.whl", hash = "sha256:6a27e908917cebf27c9a2d35a21d1dfa4ac6922856bda225079d4bc62e8085bc", size = 1570483, upload-time = "2026-03-01T06:50:20.192Z" },
-    { url = "https://files.pythonhosted.org/packages/93/4d/5d21e380b9c123af8e2a06eb9fb7e4de7a53f4bf684666f70c88c63c73a3/pyxcp-0.28.1-cp311-cp311-win_arm64.whl", hash = "sha256:06281f0335762d4888eaf0427856228b668bb829cd6e62588ad968e650db17b3", size = 1566013, upload-time = "2026-03-01T06:50:21.763Z" },
-    { url = "https://files.pythonhosted.org/packages/72/38/aebb30debf40b762c65fd77cda9061976b47b91d1642cb1802574566f8d5/pyxcp-0.28.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06cd5788955b95a8abfa44c52e20b0c9af5cbcd4f7f6eecba0bbdec9b1d88bdc", size = 2520918, upload-time = "2026-03-01T06:50:23.471Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/c9/e2e920d7e9f922bb49b92a549dafe477b246683dad718a71addbd92bd3a6/pyxcp-0.28.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8414f3f4cb27f86748eb8fe6b0dcd6eeaf959d75c65bf3ba3f690fec0c0e7d77", size = 2977582, upload-time = "2026-03-01T06:50:25.162Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/63/5ebc80de26068a581746ccc79a5f2cdea9717c91c8bfebb9b70bfa1fd1a2/pyxcp-0.28.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a727664989c594e3113002fb6e95c55b1a228089ccd072570cd44c976686ae5", size = 3262767, upload-time = "2026-03-01T06:50:26.824Z" },
-    { url = "https://files.pythonhosted.org/packages/88/68/8c446ea90d534ff08b08b290e9da1d9b8ce21258f0085ea165b9045b4fde/pyxcp-0.28.1-cp312-cp312-win_amd64.whl", hash = "sha256:859636570978f95628af11db48d23968e11ace859b637903fc2d70ba0676d457", size = 2183577, upload-time = "2026-03-01T06:50:28.943Z" },
-    { url = "https://files.pythonhosted.org/packages/98/10/6c4c59ba6ad51fa9f33d619db91c6319e105a5f94fc3f2859b39e7b2dde1/pyxcp-0.28.1-cp312-cp312-win_arm64.whl", hash = "sha256:0b7c1bd6d818c5ff9c480fa8f5979d176f85862648b3c40dab0f359527bde02b", size = 2163147, upload-time = "2026-03-01T06:50:30.614Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/5f/030531db98ff05c1d7a1c00cd6c0c19af6f0418e9176f2ed1162f32c7427/pyxcp-0.28.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e1088931517c5f51112e47d780a61ee613149423a066a435d82fe94fe81d7249", size = 3247180, upload-time = "2026-03-01T06:50:31.883Z" },
-    { url = "https://files.pythonhosted.org/packages/94/6c/7e0532245c56ea3db4307b06056882740499079741df2d17143089250350/pyxcp-0.28.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ba7605bfbc3b51c27cfd5469e1ec2067ba1caba95094b68b7a8b4161530b2dd", size = 3854267, upload-time = "2026-03-01T06:50:33.302Z" },
-    { url = "https://files.pythonhosted.org/packages/48/f3/1f1053eca225be359f9f6d9e199114b321d60700b61c9cfea90bf6da7b3e/pyxcp-0.28.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6a59b7858c8aa897fc555957571fdfe28ff8820efbb53fb2c847107eb36fb23", size = 4235621, upload-time = "2026-03-01T06:50:35.066Z" },
-    { url = "https://files.pythonhosted.org/packages/55/6e/09b7e8b66a29508b105699eaeaa6991a4976cf78675dfaf651a7ba23772a/pyxcp-0.28.1-cp313-cp313-win_amd64.whl", hash = "sha256:47a1d7686f2f5e7898cc5f9a4227945a07f849e64d232d299ca1ea94e73daaed", size = 2796672, upload-time = "2026-03-01T06:50:36.908Z" },
-    { url = "https://files.pythonhosted.org/packages/db/bb/d07483ec266377db0b573b49050ba0d88bbd22b9c86f2686035519f76e7c/pyxcp-0.28.1-cp313-cp313-win_arm64.whl", hash = "sha256:2e862a134acd2f4fbe6ea697e14a10c468b477aaccc502adc6ef7da39b1b90bb", size = 2760297, upload-time = "2026-03-01T06:50:38.273Z" },
-    { url = "https://files.pythonhosted.org/packages/64/8f/11514be79db3ac063f24dbf5021e0a412d7d93296fa7673bb4d733c99644/pyxcp-0.28.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c5f11549a782140831ccac3348cb4a36f4c99aaf77fc44a3b5a4797eb28fbfe", size = 3975125, upload-time = "2026-03-01T06:50:39.801Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a3/500e57e0ec01e125fa0afd3d0b997d7d2cd6c5e914bdf2cc14709eb6a973/pyxcp-0.28.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e4212c1f08cc44e50c5f6e2c14f01835a776efbd2c4953db4fe7916c956ea17", size = 4733487, upload-time = "2026-03-01T06:50:41.645Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4c/f7cbcf3871f0da6b6e8693bd199331623ba148a96f52f6b2c69cc250c22a/pyxcp-0.28.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:810a208d66ed8554e19cca9cba6e2c20bd9b2912e658edaa14d90475333716b1", size = 5208830, upload-time = "2026-03-01T06:50:43.186Z" },
-    { url = "https://files.pythonhosted.org/packages/55/83/b99ef260f5c064282691bbd6784aeebf5d7ae602f1392d092f4343d8dd32/pyxcp-0.28.1-cp314-cp314-win_amd64.whl", hash = "sha256:45abfda1b5462aa5ac1aee0f61bb76c819ec648330a2a59a6f82b4e20988da1d", size = 3505288, upload-time = "2026-03-01T06:50:45.085Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/9c/222f4961742c6b5e157478bc417612cd9266264196a736375df07e90a990/pyxcp-0.28.1-cp314-cp314-win_arm64.whl", hash = "sha256:2decf194a3b24c0503d205f7ef3210af392007e8352502111a4f1d21acc322a2", size = 3449043, upload-time = "2026-03-01T06:50:46.753Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4489,15 +3769,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/6c/96c9c30e7bfef81de67ba82b569672c5c9547bcb895457bb24a5d3b8b28e/qemu.qmp-0.0.3.tar.gz", hash = "sha256:cbc88fbcc115ee943d84447d172c642da120220451416c2f621acf33df1e1010", size = 78802, upload-time = "2023-07-10T17:52:07.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/80/85263c535be9f9de8104e567658b0879c063c3d9bde3a39a7d27beea00eb/qemu.qmp-0.0.3-py3-none-any.whl", hash = "sha256:9abf451e22c0964580135aef7e2b95c5da0bf63c692426da24fc38b56ff0ac8e", size = 71139, upload-time = "2023-07-10T17:52:05.551Z" },
-]
-
-[[package]]
-name = "reedsolo"
-version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/61/a67338cbecf370d464e71b10e9a31355f909d6937c3a8d6b17dd5d5beb5e/reedsolo-1.7.0.tar.gz", hash = "sha256:c1359f02742751afe0f1c0de9f0772cc113835aa2855d2db420ea24393c87732", size = 59723, upload-time = "2023-01-17T05:10:19.733Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/19/1bb346c0e581557c88946d2bb979b2bee8992e72314cfb418b5440e383db/reedsolo-1.7.0-py3-none-any.whl", hash = "sha256:2b6a3e402a1ee3e1eea3f932f81e6c0b7bbc615588074dca1dbbcdeb055002bd", size = 32360, upload-time = "2023-01-17T05:10:17.652Z" },
 ]
 
 [[package]]
@@ -4555,17 +3826,6 @@ wheels = [
 ]
 
 [[package]]
-name = "retry2"
-version = "0.9.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "decorator" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/49/1cae6d9b932378cc75f902fa70648945b7ea7190cb0d09ff83b47de3e60a/retry2-0.9.5-py2.py3-none-any.whl", hash = "sha256:f7fee13b1e15d0611c462910a6aa72a8919823988dd0412152bc3719c89a4e55", size = 6013, upload-time = "2023-01-11T21:49:08.397Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4576,20 +3836,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
-]
-
-[[package]]
-name = "rich-click"
-version = "1.9.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
 ]
 
 [[package]]
@@ -4701,27 +3947,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.6"
+version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732, upload-time = "2026-01-22T22:30:17.527Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
-    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650, upload-time = "2026-01-22T22:30:08.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245, upload-time = "2026-01-22T22:30:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273, upload-time = "2026-01-22T22:30:34.642Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753, upload-time = "2026-01-22T22:30:31.781Z" },
+    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052, upload-time = "2026-01-22T22:30:24.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637, upload-time = "2026-01-22T22:30:13.239Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761, upload-time = "2026-01-22T22:30:22.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701, upload-time = "2026-01-22T22:30:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455, upload-time = "2026-01-22T22:29:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882, upload-time = "2026-01-22T22:29:57.032Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549, upload-time = "2026-01-22T22:30:27.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416, upload-time = "2026-01-22T22:30:01.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491, upload-time = "2026-01-22T22:30:29.51Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525, upload-time = "2026-01-22T22:30:06.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626, upload-time = "2026-01-22T22:30:36.848Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
 ]
 
 [[package]]
@@ -5014,38 +4261,16 @@ wheels = [
 ]
 
 [[package]]
-name = "sse-starlette"
-version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/2f/9223c24f568bb7a0c03d751e609844dce0968f13b39a3f73fbb3a96cd27a/sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049", size = 32420, upload-time = "2026-03-17T20:05:55.529Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/e2/b8cff57a67dddf9a464d7e943218e031617fb3ddc133aeeb0602ff5f6c85/sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d", size = 14329, upload-time = "2026-03-17T20:05:54.35Z" },
-]
-
-[[package]]
 name = "starlette"
-version = "0.52.1"
+version = "0.47.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072, upload-time = "2025-06-21T04:03:17.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
-]
-
-[[package]]
-name = "stevedore"
-version = "5.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+    { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747, upload-time = "2025-06-21T04:03:15.705Z" },
 ]
 
 [[package]]
@@ -5055,15 +4280,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -5112,24 +4328,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
-]
-
-[[package]]
-name = "traitlets"
-version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -5259,21 +4457,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/91/913e49bbd440dfcaf2ca994ae5e23d672255be9c54f930e1a3c4353836c4/typos-1.33.1-py3-none-win32.whl", hash = "sha256:88717b9849faa363534b79fa20526d1e9ada506501c9f0f4ab52fdbc9085fa8a", size = 2755043, upload-time = "2025-06-02T17:58:32.87Z" },
     { url = "https://files.pythonhosted.org/packages/48/69/edc11139256a27b9917fa0c9efba5dbe9403f7cfd8822349725aab1b397a/typos-1.33.1-py3-none-win_amd64.whl", hash = "sha256:05dc54433a296acde0bfb729dda122ff86723568f2d38f8a9de8708b3d4866dc", size = 2904956, upload-time = "2025-06-02T17:58:35.033Z" },
 ]
-
-[[package]]
-name = "udsoncan"
-version = "1.25.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/b5/50bdde3a075808038236f629382eeb3c29504546bdc41556035d7422e734/udsoncan-1.25.2.tar.gz", hash = "sha256:ae9e3c240c7d143106611d17a9a32ac6b8e0cec210520e7ca6c912c85f293774", size = 95063, upload-time = "2026-02-13T02:11:28.355Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/b7/3ce55ec6ad06ded79d93ba09f217a8f7d4b277abc79158bb1d1f7eb66666/udsoncan-1.25.2-py3-none-any.whl", hash = "sha256:96b34b643558ab0dfbb56947c15d6d8c5106aa8c8739553dad7c896170deb684", size = 119927, upload-time = "2026-02-13T02:11:26.907Z" },
-]
-
-[[package]]
-name = "uptime"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/53/6c420ddf6949097d6f9406358951c9322505849bea9cb79efe3acc0bb55d/uptime-3.0.1.tar.gz", hash = "sha256:7c300254775b807ce46e3dcbcda30aa3b9a204b9c57a7ac1e79ee6dbe3942973", size = 6630, upload-time = "2013-10-07T14:19:58.456Z" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
## Add `jumpstarter-driver-noyito-relay` — NOYITO USB Relay Power Driver

### Summary

Adds a new driver package supporting the full NOYITO USB relay board family
across two distinct hardware series:

- **`NoyitoPowerSerial`** — 1/2-channel boards using a CH340 USB-to-serial chip
  (9600 baud). Supports the `0xFF` status query to read channel state.
  Controlled via `pyserial`.
- **`NoyitoPowerHID`** — 4/8-channel "HID Drive-free" boards that enumerate as
  USB HID devices (no serial port). Status query is not available on this
  hardware. Controlled via the `hid` Python package.

Both classes share the same 4-byte command protocol
(`0xA0` + channel + state + checksum) via a common `_build_command` helper.

### Key configuration parameters

| Class | Parameters | Notes |
|---|---|---|
| `NoyitoPowerSerial` | `port`, `channel` (1–2), `dual` | `dual=True` fires both contacts simultaneously for high-current wiring |
| `NoyitoPowerHID` | `num_channels` (4 or 8), `channel`, `all_channels`, `vendor_id`, `product_id` | `all_channels=True` fires every channel simultaneously |

### macOS / Apple Silicon note

The `hid` package requires the native `hidapi` shared library
(`brew install hidapi`). On Apple Silicon, Homebrew installs to
`/opt/homebrew/lib` which is not in `dlopen`'s default search path.
`NoyitoPowerHID._send_command` automatically prepends the Homebrew prefix to
`DYLD_FALLBACK_LIBRARY_PATH` before the first `import hid`, so no manual
environment setup is needed on Intel or Apple Silicon Macs.

### Files added

| Path | Description |
|---|---|
| `jumpstarter_driver_noyito_relay/driver.py` | `NoyitoPowerSerial` + `NoyitoPowerHID` driver classes |
| `jumpstarter_driver_noyito_relay/client.py` | `NoyitoPowerClient` (thin `PowerClient` subclass) |
| `jumpstarter_driver_noyito_relay/driver_test.py` | 28 unit/integration tests (serial + HID, no hardware required) |
| `jumpstarter_driver_noyito_relay/conftest.py` | Stubs `hid` in `sys.modules` so tests run without native `hidapi` |
| `examples/exporter.yaml` | Serial (ch1, ch2, dual), 4-ch HID (single, all), 8-ch HID (single, all) |
| `README.md` | Board detection guide, per-class config tables, CLI usage, Amazon purchase links |
| `pyproject.toml` | Declares `pyserial>=3.5`, `hid>=1.0.4` deps; registers both entry points |
| `python/uv.lock` | Adds `hid 1.0.9` from pypi.org |

### Test plan

- [ ] All 28 pytest tests pass with `hid.Device` mocked (no hardware needed):
  `make pkg-test-jumpstarter-driver-noyito-relay`
- [ ] `ruff check` passes clean
- [ ] Smoke test with physical 2-ch serial board: `on` / `off` / `status` / `cycle`
- [ ] Smoke test with physical 4-ch or 8-ch HID board: `on` / `off` / `cycle`,
  confirm `status` is not available