### PR TITLE
Add fastboot set_active slot support to RideSX driver

### DIFF
--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
@@ -29,6 +29,10 @@ class RideSXClient(FlasherClient, CompositeClient):
     def boot_to_fastboot(self):
         return self.call("boot_to_fastboot")
 
+    def set_active_slot(self, slot: str):
+        """Boot to fastboot and set the active boot slot."""
+        return self.call("set_active_slot", slot)
+
     def _upload_file_if_needed(self, file_path: str, operator: Operator | None = None) -> str:
         if not file_path or not file_path.strip():
             raise ValueError("File path cannot be empty. Please provide a valid file path.")
@@ -453,6 +457,18 @@ class RideSXClient(FlasherClient, CompositeClient):
         def boot_to_fastboot():
             """Boot to fastboot"""
             self.boot_to_fastboot()
+
+        @base.command()
+        @click.argument("slot", type=click.Choice(["a", "b"]))
+        def set_active(slot):
+            """Set the active boot slot (boots to fastboot first).
+
+            \b
+            Examples:
+              j storage set-active a
+              j storage set-active b
+            """
+            self.set_active_slot(slot)
 
         return base
 

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
@@ -174,6 +174,62 @@ class RideSXDriver(Driver):
         return {"status": "no_device_found", "device_id": None}
 
     @export
+    async def set_active_slot(self, slot: str):
+        """Boot to fastboot, detect device, and set the active boot slot.
+
+        Args:
+            slot: Boot slot to activate (e.g. "a" or "b")
+        """
+        slot = str(slot).strip().lower()
+        if slot not in ("a", "b"):
+            raise ValueError(f"Invalid slot '{slot}', must be 'a' or 'b'")
+
+        detection_result = await self.boot_to_fastboot()
+        device_id = detection_result["device_id"]
+        self.logger.info(f"Setting active slot to {slot} on device {device_id}")
+
+        cmd = ["fastboot", "-s", device_id, "set_active", slot]
+        self.logger.debug(f"Running command: {' '.join(cmd)}")
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+            self.logger.info(f"Successfully set active slot to {slot}")
+            self.logger.debug(f"set_active stdout: {result.stdout}")
+            if result.stderr:
+                self.logger.debug(f"set_active stderr: {result.stderr}")
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"Failed to set active slot to {slot} - return code: {e.returncode}")
+            self.logger.error(f"stdout: {e.stdout}")
+            self.logger.error(f"stderr: {e.stderr}")
+            raise RuntimeError(f"Failed to set active slot to {slot}: {e}") from e
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"Timeout while setting active slot to {slot}")
+            raise RuntimeError(f"Timeout while setting active slot to {slot}") from None
+
+        return {"status": "success", "slot": slot, "device_id": device_id}
+
+    def _reset_active_slot(self, device_id: str):
+        """Cycle active slot b -> a to ensure clean slot state before flashing."""
+        for slot in ("b", "a"):
+            self.logger.info(f"Setting active slot to {slot}...")
+            cmd = ["fastboot", "-s", device_id, "set_active", slot]
+            self.logger.debug(f"Running command: {' '.join(cmd)}")
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+                self.logger.info(f"Successfully set active slot to {slot}")
+                self.logger.debug(f"set_active stdout: {result.stdout}")
+                if result.stderr:
+                    self.logger.debug(f"set_active stderr: {result.stderr}")
+            except subprocess.CalledProcessError as e:
+                self.logger.error(f"Failed to set active slot to {slot} - return code: {e.returncode}")
+                self.logger.error(f"stdout: {e.stdout}")
+                self.logger.error(f"stderr: {e.stderr}")
+                raise RuntimeError(f"Failed to set active slot to {slot}: {e}") from e
+            except subprocess.TimeoutExpired:
+                self.logger.error(f"Timeout while setting active slot to {slot}")
+                raise RuntimeError(f"Timeout while setting active slot to {slot}") from None
+
+    @export
     def flash_with_fastboot(self, device_id: str, partitions: Dict[str, str]):
         """Flash partitions using fastboot
 
@@ -185,6 +241,8 @@ class RideSXDriver(Driver):
             raise ValueError("At least one partition must be provided")
 
         self.logger.info(f"Flashing device {device_id} with partitions: {list(partitions.keys())}")
+
+        self._reset_active_slot(device_id)
 
         for partition_name, filename in partitions.items():
             file_path = Path(self.storage_dir) / filename
@@ -311,7 +369,7 @@ class RideSXDriver(Driver):
 
     @export
     async def boot_to_fastboot(self):
-        """Boot device to fastboot mode"""
+        """Boot device to fastboot mode and detect the fastboot device."""
         self.logger.info("Booting device to fastboot mode")
         commands = [
             # power off
@@ -347,6 +405,12 @@ class RideSXDriver(Driver):
                 self.logger.debug(f"prompt returned after command: {command}")
                 await asyncio.sleep(delay)
         self.logger.info("device should now be in fastboot mode")
+
+        detection_result = self.detect_fastboot_device()
+        if detection_result["status"] != "device_found":
+            raise RuntimeError("Device booted to fastboot but no fastboot device was detected")
+
+        return detection_result
 
 
 @dataclass(kw_only=True)

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
@@ -328,6 +328,11 @@ class RideSXDriver(Driver):
         if bool(oci_username) != bool(oci_password):
             raise ValueError("OCI authentication requires both --username and --password")
 
+        detection_result = self.detect_fastboot_device()
+        if detection_result["status"] != "device_found":
+            raise RuntimeError("No fastboot device found")
+        self._reset_active_slot(detection_result["device_id"])
+
         fls_cmd = self._build_fls_command(oci_url, partitions)
 
         fls_env = os.environ.copy()

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver_test.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver_test.py
@@ -231,6 +231,19 @@ def _set_active_results():
     return [_make_ok_result("set_active b"), _make_ok_result("set_active a")]
 
 
+def _detect_result(device_id="ABC123"):
+    """A successful detect_fastboot_device subprocess result."""
+    r = MagicMock()
+    r.stdout = f"{device_id}    fastboot\n"
+    r.returncode = 0
+    return r
+
+
+def _detect_and_reset_results(device_id="ABC123"):
+    """Results for detect_fastboot_device + _reset_active_slot (3 calls total)."""
+    return [_detect_result(device_id), *_set_active_results()]
+
+
 def test_flash_with_fastboot_single_partition(temp_storage_dir, ridesx_driver):
     image_file = Path(temp_storage_dir) / "boot.img"
     image_file.write_bytes(b"boot image data")
@@ -602,41 +615,43 @@ def test_flash_oci_image_success(temp_storage_dir, ridesx_driver):
     with serve(ridesx_driver) as client:
         with patch("jumpstarter_driver_ridesx.driver.get_fls_binary", return_value="/usr/local/bin/fls"):
             with patch("subprocess.run") as mock_subprocess:
-                mock_result = MagicMock()
-                mock_result.stdout = "Flashing complete"
-                mock_result.stderr = ""
-                mock_result.returncode = 0
-                mock_subprocess.return_value = mock_result
+                mock_subprocess.side_effect = [
+                    *_detect_and_reset_results(),
+                    _make_ok_result("Flashing complete"),
+                ]
 
                 result = client.call("flash_oci_image", "oci://quay.io/image:tag", None)
 
                 assert result["status"] == "success"
-                mock_subprocess.assert_called_once()
-                call_args = mock_subprocess.call_args[0][0]
-                assert call_args[0] == "/usr/local/bin/fls"
-                assert call_args[1] == "fastboot"
-                assert call_args[2] == "oci://quay.io/image:tag"
+                assert mock_subprocess.call_count == 4
+                # First 3 calls: detect + set_active b + set_active a
+                assert mock_subprocess.call_args_list[0][0][0] == ["fastboot", "devices", "-l"]
+                assert mock_subprocess.call_args_list[1][0][0] == ["fastboot", "-s", "ABC123", "set_active", "b"]
+                assert mock_subprocess.call_args_list[2][0][0] == ["fastboot", "-s", "ABC123", "set_active", "a"]
+                # 4th call: FLS
+                fls_args = mock_subprocess.call_args_list[3][0][0]
+                assert fls_args[0] == "/usr/local/bin/fls"
+                assert fls_args[1] == "fastboot"
+                assert fls_args[2] == "oci://quay.io/image:tag"
 
 
 def test_flash_oci_image_with_partitions(temp_storage_dir, ridesx_driver):
     with serve(ridesx_driver) as client:
         with patch("jumpstarter_driver_ridesx.driver.get_fls_binary", return_value="fls"):
             with patch("subprocess.run") as mock_subprocess:
-                mock_result = MagicMock()
-                mock_result.stdout = "Flashing complete"
-                mock_result.stderr = ""
-                mock_result.returncode = 0
-                mock_subprocess.return_value = mock_result
+                mock_subprocess.side_effect = [
+                    *_detect_and_reset_results(),
+                    _make_ok_result("Flashing complete"),
+                ]
 
                 partitions = {"boot_a": "boot.img", "system_a": "rootfs.simg"}
                 result = client.call("flash_oci_image", "oci://image:tag", partitions)
 
                 assert result["status"] == "success"
-                call_args = mock_subprocess.call_args[0][0]
-                # Check that -t flags are present for partitions
-                assert "-t" in call_args
-                assert "boot_a:boot.img" in call_args
-                assert "system_a:rootfs.simg" in call_args
+                fls_args = mock_subprocess.call_args_list[3][0][0]
+                assert "-t" in fls_args
+                assert "boot_a:boot.img" in fls_args
+                assert "system_a:rootfs.simg" in fls_args
 
 
 def test_flash_oci_image_error_cases(temp_storage_dir, ridesx_driver):
@@ -644,29 +659,37 @@ def test_flash_oci_image_error_cases(temp_storage_dir, ridesx_driver):
     from jumpstarter.client.core import DriverError
 
     with serve(ridesx_driver) as client:
-        # Reject non-oci:// schemes
+        # Reject non-oci:// schemes (fails before detect)
         with pytest.raises(DriverError, match="OCI URL must start with oci://"):
             client.call("flash_oci_image", "docker://image:tag", None)
 
         with patch("jumpstarter_driver_ridesx.driver.get_fls_binary", return_value="fls"):
+            # CalledProcessError from FLS
             with patch("subprocess.run") as mock_subprocess:
-                # CalledProcessError
                 error = subprocess.CalledProcessError(1, "fls")
                 error.stdout = ""
                 error.stderr = "Flash failed"
-                mock_subprocess.side_effect = error
+                mock_subprocess.side_effect = [*_detect_and_reset_results(), error]
 
                 with pytest.raises(DriverError, match="FLS fastboot failed: Flash failed"):
                     client.call("flash_oci_image", "oci://image:tag", None)
 
-                # TimeoutExpired
-                mock_subprocess.side_effect = subprocess.TimeoutExpired("fls", 1800)
+            # TimeoutExpired from FLS
+            with patch("subprocess.run") as mock_subprocess:
+                mock_subprocess.side_effect = [
+                    *_detect_and_reset_results(),
+                    subprocess.TimeoutExpired("fls", 1800),
+                ]
 
                 with pytest.raises(DriverError, match="FLS fastboot auto-detection timeout"):
                     client.call("flash_oci_image", "oci://image:tag", None)
 
-                # FileNotFoundError
-                mock_subprocess.side_effect = FileNotFoundError("fls not found")
+            # FileNotFoundError from FLS
+            with patch("subprocess.run") as mock_subprocess:
+                mock_subprocess.side_effect = [
+                    *_detect_and_reset_results(),
+                    FileNotFoundError("fls not found"),
+                ]
 
                 with pytest.raises(DriverError, match="FLS command not found"):
                     client.call("flash_oci_image", "oci://image:tag", None)
@@ -677,26 +700,24 @@ def test_flash_oci_image_with_credentials(temp_storage_dir, ridesx_driver):
     with serve(ridesx_driver) as client:
         with patch("jumpstarter_driver_ridesx.driver.get_fls_binary", return_value="fls"):
             with patch("subprocess.run") as mock_subprocess:
-                mock_result = MagicMock()
-                mock_result.stdout = "Flashing complete"
-                mock_result.stderr = ""
-                mock_result.returncode = 0
-                mock_subprocess.return_value = mock_result
+                mock_subprocess.side_effect = [
+                    *_detect_and_reset_results(),
+                    _make_ok_result("Flashing complete"),
+                ]
 
                 result = client.call(
                     "flash_oci_image", "oci://quay.io/private/image:tag", None, "myuser", "mypass"
                 )
 
                 assert result["status"] == "success"
-                # Credentials should NOT appear in the command args
-                call_args = mock_subprocess.call_args[0][0]
-                assert "-u" not in call_args
-                assert "-p" not in call_args
-                assert "myuser" not in call_args
-                assert "mypass" not in call_args
-                # Credentials should be passed via env vars
-                call_kwargs = mock_subprocess.call_args[1]
-                env = call_kwargs["env"]
+                # FLS call is the last one (index 3)
+                fls_call_args = mock_subprocess.call_args_list[3][0][0]
+                assert "-u" not in fls_call_args
+                assert "-p" not in fls_call_args
+                assert "myuser" not in fls_call_args
+                assert "mypass" not in fls_call_args
+                fls_call_kwargs = mock_subprocess.call_args_list[3][1]
+                env = fls_call_kwargs["env"]
                 assert env["FLS_REGISTRY_USERNAME"] == "myuser"
                 assert env["FLS_REGISTRY_PASSWORD"] == "mypass"
 
@@ -718,17 +739,16 @@ def test_flash_oci_image_no_credentials(temp_storage_dir, ridesx_driver):
     with serve(ridesx_driver) as client:
         with patch("jumpstarter_driver_ridesx.driver.get_fls_binary", return_value="fls"):
             with patch("subprocess.run") as mock_subprocess:
-                mock_result = MagicMock()
-                mock_result.stdout = "Flashing complete"
-                mock_result.stderr = ""
-                mock_result.returncode = 0
-                mock_subprocess.return_value = mock_result
+                mock_subprocess.side_effect = [
+                    *_detect_and_reset_results(),
+                    _make_ok_result("Flashing complete"),
+                ]
 
                 result = client.call("flash_oci_image", "oci://image:tag", None, None, None)
 
                 assert result["status"] == "success"
-                call_kwargs = mock_subprocess.call_args[1]
-                env = call_kwargs["env"]
+                fls_call_kwargs = mock_subprocess.call_args_list[3][1]
+                env = fls_call_kwargs["env"]
                 assert "FLS_REGISTRY_USERNAME" not in env
                 assert "FLS_REGISTRY_PASSWORD" not in env
 
@@ -738,6 +758,6 @@ def test_flash_oci_image_requires_oci_scheme(temp_storage_dir, ridesx_driver):
     from jumpstarter.client.core import DriverError
 
     with serve(ridesx_driver) as client:
-        # Bare registry URL should be rejected
+        # Bare registry URL should be rejected (fails before detect)
         with pytest.raises(DriverError, match="OCI URL must start with oci://"):
             client.call("flash_oci_image", "quay.io/org/image:v1", None)

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver_test.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver_test.py
@@ -218,40 +218,43 @@ def test_decompress_file_timeout(temp_storage_dir, ridesx_driver):
 # Fastboot Flashing Tests
 
 
+def _make_ok_result(stdout="OK"):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = ""
+    r.returncode = 0
+    return r
+
+
+def _set_active_results():
+    """Two successful results for _reset_active_slot (set_active b, set_active a)."""
+    return [_make_ok_result("set_active b"), _make_ok_result("set_active a")]
+
+
 def test_flash_with_fastboot_single_partition(temp_storage_dir, ridesx_driver):
-    # Create test image file
     image_file = Path(temp_storage_dir) / "boot.img"
     image_file.write_bytes(b"boot image data")
 
     with serve(ridesx_driver) as client:
         with patch("subprocess.run") as mock_subprocess:
-            # Mock flash command
-            flash_result = MagicMock()
-            flash_result.stdout = "Flashing boot..."
-            flash_result.stderr = ""
-            flash_result.returncode = 0
-
-            # Mock continue command
-            continue_result = MagicMock()
-            continue_result.stdout = "Continuing..."
-            continue_result.stderr = ""
-            continue_result.returncode = 0
-
-            mock_subprocess.side_effect = [flash_result, continue_result]
+            mock_subprocess.side_effect = [
+                *_set_active_results(),
+                _make_ok_result("Flashing boot..."),
+                _make_ok_result("Continuing..."),
+            ]
 
             client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img"})
 
-            assert mock_subprocess.call_count == 2
-            # Check flash command
-            flash_call = mock_subprocess.call_args_list[0]
-            assert flash_call[0][0] == ["fastboot", "-s", "ABC123", "flash", "boot", str(image_file)]
-            # Check continue command
-            continue_call = mock_subprocess.call_args_list[1]
-            assert continue_call[0][0] == ["fastboot", "-s", "ABC123", "continue"]
+            assert mock_subprocess.call_count == 4
+            assert mock_subprocess.call_args_list[0][0][0] == ["fastboot", "-s", "ABC123", "set_active", "b"]
+            assert mock_subprocess.call_args_list[1][0][0] == ["fastboot", "-s", "ABC123", "set_active", "a"]
+            assert mock_subprocess.call_args_list[2][0][0] == [
+                "fastboot", "-s", "ABC123", "flash", "boot", str(image_file),
+            ]
+            assert mock_subprocess.call_args_list[3][0][0] == ["fastboot", "-s", "ABC123", "continue"]
 
 
 def test_flash_with_fastboot_multiple_partitions(temp_storage_dir, ridesx_driver):
-    # Create test image files
     boot_file = Path(temp_storage_dir) / "boot.img"
     boot_file.write_bytes(b"boot image data")
     system_file = Path(temp_storage_dir) / "system.img"
@@ -259,57 +262,40 @@ def test_flash_with_fastboot_multiple_partitions(temp_storage_dir, ridesx_driver
 
     with serve(ridesx_driver) as client:
         with patch("subprocess.run") as mock_subprocess:
-            flash_result = MagicMock()
-            flash_result.stdout = "Flashing..."
-            flash_result.stderr = ""
-            flash_result.returncode = 0
-
-            continue_result = MagicMock()
-            continue_result.stdout = "Continuing..."
-            continue_result.stderr = ""
-            continue_result.returncode = 0
-
-            mock_subprocess.side_effect = [flash_result, flash_result, continue_result]
+            mock_subprocess.side_effect = [
+                *_set_active_results(),
+                _make_ok_result("Flashing boot..."),
+                _make_ok_result("Flashing system..."),
+                _make_ok_result("Continuing..."),
+            ]
 
             client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img", "system": "system.img"})
 
-            assert mock_subprocess.call_count == 3
-            # Verify both partitions were flashed
-            flash_calls = [call[0][0] for call in mock_subprocess.call_args_list[:2]]
+            assert mock_subprocess.call_count == 5
+            flash_calls = [call[0][0] for call in mock_subprocess.call_args_list[2:4]]
             assert ["fastboot", "-s", "ABC123", "flash", "boot", str(boot_file)] in flash_calls
             assert ["fastboot", "-s", "ABC123", "flash", "system", str(system_file)] in flash_calls
 
 
 def test_flash_with_fastboot_compressed_file(temp_storage_dir, ridesx_driver):
-    # Create compressed file
     compressed_file = Path(temp_storage_dir) / "boot.img.gz"
     compressed_file.write_bytes(b"compressed data")
-
-    # Create decompressed file that will be "created" by decompression
     decompressed_file = Path(temp_storage_dir) / "boot.img"
     decompressed_file.write_bytes(b"decompressed data")
 
     with serve(ridesx_driver) as client:
         with patch.object(ridesx_driver, "_decompress_file", return_value=decompressed_file):
             with patch("subprocess.run") as mock_subprocess:
-                flash_result = MagicMock()
-                flash_result.stdout = "Flashing..."
-                flash_result.stderr = ""
-                flash_result.returncode = 0
-
-                continue_result = MagicMock()
-                continue_result.stdout = "Continuing..."
-                continue_result.stderr = ""
-                continue_result.returncode = 0
-
-                mock_subprocess.side_effect = [flash_result, continue_result]
+                mock_subprocess.side_effect = [
+                    *_set_active_results(),
+                    _make_ok_result("Flashing..."),
+                    _make_ok_result("Continuing..."),
+                ]
 
                 client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img.gz"})
 
-                # Verify decompression was called
                 ridesx_driver._decompress_file.assert_called_once_with(compressed_file)
-                # Verify flash used decompressed file
-                flash_call = mock_subprocess.call_args_list[0]
+                flash_call = mock_subprocess.call_args_list[2]
                 assert str(decompressed_file) in flash_call[0][0]
 
 
@@ -317,9 +303,11 @@ def test_flash_with_fastboot_file_not_found(temp_storage_dir, ridesx_driver):
     with serve(ridesx_driver) as client:
         from jumpstarter.client.core import DriverError
 
-        # When called through client, FileNotFoundError becomes DriverError
-        with pytest.raises(DriverError, match="Image not found in storage"):
-            client.call("flash_with_fastboot", "ABC123", {"boot": "nonexistent.img"})
+        with patch("subprocess.run") as mock_subprocess:
+            mock_subprocess.side_effect = [*_set_active_results()]
+
+            with pytest.raises(DriverError, match="Image not found in storage"):
+                client.call("flash_with_fastboot", "ABC123", {"boot": "nonexistent.img"})
 
 
 def test_flash_with_fastboot_empty_partitions(ridesx_driver):
@@ -336,9 +324,11 @@ def test_flash_with_fastboot_flash_failure(temp_storage_dir, ridesx_driver):
         from jumpstarter.client.core import DriverError
 
         with patch("subprocess.run") as mock_subprocess:
-            mock_subprocess.side_effect = subprocess.CalledProcessError(1, "fastboot", stderr=b"flash failed")
+            mock_subprocess.side_effect = [
+                *_set_active_results(),
+                subprocess.CalledProcessError(1, "fastboot", stderr=b"flash failed"),
+            ]
 
-            # When called through client, RuntimeError becomes DriverError
             with pytest.raises(DriverError, match="Failed to flash"):
                 client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img"})
 
@@ -351,9 +341,11 @@ def test_flash_with_fastboot_flash_timeout(temp_storage_dir, ridesx_driver):
         from jumpstarter.client.core import DriverError
 
         with patch("subprocess.run") as mock_subprocess:
-            mock_subprocess.side_effect = subprocess.TimeoutExpired("fastboot", 20 * 60)
+            mock_subprocess.side_effect = [
+                *_set_active_results(),
+                subprocess.TimeoutExpired("fastboot", 20 * 60),
+            ]
 
-            # When called through client, RuntimeError becomes DriverError
             with pytest.raises(DriverError, match="timeout while flashing"):
                 client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img"})
 
@@ -364,22 +356,15 @@ def test_flash_with_fastboot_continue_success(temp_storage_dir, ridesx_driver):
 
     with serve(ridesx_driver) as client:
         with patch("subprocess.run") as mock_subprocess:
-            flash_result = MagicMock()
-            flash_result.stdout = "Flashing..."
-            flash_result.stderr = ""
-            flash_result.returncode = 0
-
-            continue_result = MagicMock()
-            continue_result.stdout = "Continuing..."
-            continue_result.stderr = ""
-            continue_result.returncode = 0
-
-            mock_subprocess.side_effect = [flash_result, continue_result]
+            mock_subprocess.side_effect = [
+                *_set_active_results(),
+                _make_ok_result("Flashing..."),
+                _make_ok_result("Continuing..."),
+            ]
 
             client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img"})
 
-            # Verify continue was called
-            continue_call = mock_subprocess.call_args_list[1]
+            continue_call = mock_subprocess.call_args_list[3]
             assert continue_call[0][0] == ["fastboot", "-s", "ABC123", "continue"]
 
 
@@ -389,22 +374,178 @@ def test_flash_with_fastboot_continue_failure(temp_storage_dir, ridesx_driver):
 
     with serve(ridesx_driver) as client:
         with patch("subprocess.run") as mock_subprocess:
-            flash_result = MagicMock()
-            flash_result.stdout = "Flashing..."
-            flash_result.stderr = ""
-            flash_result.returncode = 0
-
-            # First call succeeds (flash), second call fails (continue)
             mock_subprocess.side_effect = [
-                flash_result,
+                *_set_active_results(),
+                _make_ok_result("Flashing..."),
                 subprocess.CalledProcessError(1, "fastboot", stderr=b"continue failed"),
             ]
 
-            # Should not raise, just log warning
             client.call("flash_with_fastboot", "ABC123", {"boot": "boot.img"})
 
-            # Verify both flash and continue were called
-            assert mock_subprocess.call_count == 2
+            assert mock_subprocess.call_count == 4
+
+
+# Reset Active Slot Tests
+
+
+def test_reset_active_slot(ridesx_driver):
+    """_reset_active_slot runs set_active b then set_active a"""
+    with patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.side_effect = _set_active_results()
+
+        ridesx_driver._reset_active_slot("ABC123")
+
+        assert mock_subprocess.call_count == 2
+        assert mock_subprocess.call_args_list[0][0][0] == ["fastboot", "-s", "ABC123", "set_active", "b"]
+        assert mock_subprocess.call_args_list[1][0][0] == ["fastboot", "-s", "ABC123", "set_active", "a"]
+
+
+def test_reset_active_slot_failure(ridesx_driver):
+    """_reset_active_slot raises on fastboot failure"""
+    with patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.side_effect = subprocess.CalledProcessError(1, "fastboot", stderr=b"error")
+
+        with pytest.raises(RuntimeError, match="Failed to set active slot to b"):
+            ridesx_driver._reset_active_slot("ABC123")
+
+
+def test_reset_active_slot_timeout(ridesx_driver):
+    """_reset_active_slot raises on timeout"""
+    with patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.side_effect = subprocess.TimeoutExpired("fastboot", 30)
+
+        with pytest.raises(RuntimeError, match="Timeout while setting active slot to b"):
+            ridesx_driver._reset_active_slot("ABC123")
+
+
+def test_reset_active_slot_second_slot_failure(ridesx_driver):
+    """_reset_active_slot raises if second set_active (a) fails"""
+    with patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.side_effect = [
+            _make_ok_result(),
+            subprocess.CalledProcessError(1, "fastboot", stderr=b"error"),
+        ]
+
+        with pytest.raises(RuntimeError, match="Failed to set active slot to a"):
+            ridesx_driver._reset_active_slot("ABC123")
+
+
+# Set Active Slot Tests
+
+
+def test_set_active_slot_success(ridesx_driver):
+    """set_active_slot boots to fastboot, detects device, and sets active slot"""
+    with serve(ridesx_driver) as client:
+        with patch.object(ridesx_driver, "boot_to_fastboot", new_callable=AsyncMock) as mock_boot:
+            mock_boot.return_value = {"status": "device_found", "device_id": "ABC123"}
+
+            with patch("subprocess.run") as mock_subprocess:
+                mock_subprocess.return_value = _make_ok_result()
+
+                result = client.call("set_active_slot", "a")
+
+                assert result["status"] == "success"
+                assert result["slot"] == "a"
+                assert result["device_id"] == "ABC123"
+                mock_boot.assert_called_once()
+                mock_subprocess.assert_called_once()
+                assert mock_subprocess.call_args[0][0] == ["fastboot", "-s", "ABC123", "set_active", "a"]
+
+
+def test_set_active_slot_b(ridesx_driver):
+    """set_active_slot works for slot b"""
+    with serve(ridesx_driver) as client:
+        with patch.object(ridesx_driver, "boot_to_fastboot", new_callable=AsyncMock) as mock_boot:
+            mock_boot.return_value = {"status": "device_found", "device_id": "DEV456"}
+
+            with patch("subprocess.run") as mock_subprocess:
+                mock_subprocess.return_value = _make_ok_result()
+
+                result = client.call("set_active_slot", "b")
+
+                assert result["status"] == "success"
+                assert result["slot"] == "b"
+                assert result["device_id"] == "DEV456"
+                assert mock_subprocess.call_args[0][0] == ["fastboot", "-s", "DEV456", "set_active", "b"]
+
+
+def test_set_active_slot_invalid(ridesx_driver):
+    """set_active_slot rejects invalid slot names"""
+    with serve(ridesx_driver) as client:
+        with pytest.raises(ValueError, match="Invalid slot 'c'"):
+            client.call("set_active_slot", "c")
+
+
+def test_set_active_slot_fastboot_failure(ridesx_driver):
+    """set_active_slot raises when fastboot set_active fails"""
+    from jumpstarter.client.core import DriverError
+
+    with serve(ridesx_driver) as client:
+        with patch.object(ridesx_driver, "boot_to_fastboot", new_callable=AsyncMock) as mock_boot:
+            mock_boot.return_value = {"status": "device_found", "device_id": "ABC123"}
+
+            with patch("subprocess.run") as mock_subprocess:
+                mock_subprocess.side_effect = subprocess.CalledProcessError(1, "fastboot", stderr=b"failed")
+
+                with pytest.raises(DriverError, match="Failed to set active slot to a"):
+                    client.call("set_active_slot", "a")
+
+
+def test_set_active_slot_fastboot_timeout(ridesx_driver):
+    """set_active_slot raises when fastboot times out"""
+    from jumpstarter.client.core import DriverError
+
+    with serve(ridesx_driver) as client:
+        with patch.object(ridesx_driver, "boot_to_fastboot", new_callable=AsyncMock) as mock_boot:
+            mock_boot.return_value = {"status": "device_found", "device_id": "ABC123"}
+
+            with patch("subprocess.run") as mock_subprocess:
+                mock_subprocess.side_effect = subprocess.TimeoutExpired("fastboot", 30)
+
+                with pytest.raises(DriverError, match="Timeout while setting active slot to a"):
+                    client.call("set_active_slot", "a")
+
+
+# Boot to Fastboot Tests
+
+
+@pytest.mark.asyncio
+async def test_boot_to_fastboot_detects_device(ridesx_driver):
+    """boot_to_fastboot calls detect_fastboot_device and returns result"""
+    mock_stream = AsyncMock()
+    mock_stream.receive.return_value = b"ok CMD >> "
+
+    mock_connect = AsyncMock()
+    mock_connect.__aenter__ = AsyncMock(return_value=mock_stream)
+    mock_connect.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.object(ridesx_driver.children["serial"], "connect", return_value=mock_connect):
+        with patch.object(ridesx_driver, "detect_fastboot_device") as mock_detect:
+            mock_detect.return_value = {"status": "device_found", "device_id": "ABC123"}
+
+            result = await ridesx_driver.boot_to_fastboot()
+
+            assert result["status"] == "device_found"
+            assert result["device_id"] == "ABC123"
+            mock_detect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_boot_to_fastboot_no_device(ridesx_driver):
+    """boot_to_fastboot raises when no fastboot device is detected after boot"""
+    mock_stream = AsyncMock()
+    mock_stream.receive.return_value = b"ok CMD >> "
+
+    mock_connect = AsyncMock()
+    mock_connect.__aenter__ = AsyncMock(return_value=mock_stream)
+    mock_connect.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.object(ridesx_driver.children["serial"], "connect", return_value=mock_connect):
+        with patch.object(ridesx_driver, "detect_fastboot_device") as mock_detect:
+            mock_detect.return_value = {"status": "no_device_found", "device_id": None}
+
+            with pytest.raises(RuntimeError, match="no fastboot device was detected"):
+                await ridesx_driver.boot_to_fastboot()
 
 
 def test_power_missing_serial():


### PR DESCRIPTION
## Summary

- Add A/B slot reset (`set_active b` then `set_active a`) before flashing partitions in the oci and fls paths.
- Add `set_active_slot` exported driver method that boots to fastboot, detects the device, and sets the active slot
- Add corresponding client method and `set-active <a|b>` CLI command
- `boot_to_fastboot` now also detects the fastboot device after the serial boot sequence and returns the detection result

## Test plan

- [ ] Verify `j storage set-active a` boots to fastboot and sets slot A
- [ ] Verify `j storage set-active b` boots to fastboot and sets slot B
- [ ] Verify non-FLS flash path resets slots before flashing partitions
- [ ] Verify `boot_to_fastboot` raises if no fastboot device is detected after boot


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command and programmatic control to set the active boot slot ("a" or "b") for RideSX storage.
  * Boot/flash flow now resets active slots before flashing and improves fastboot device detection for more reliable operations.

* **Tests**
  * Expanded test coverage for slot-reset sequencing, fastboot detection, success and failure/error/time-out scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->