### PR TITLE
Increase pyserial RX StreamReader limit

### DIFF
--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver.py
@@ -134,7 +134,7 @@ class PySerial(Driver):
         cps_info = f", cps: {self.cps}" if self.cps is not None else ""
         self.logger.info("Connecting to %s, baudrate: %d%s", self.url, self.baudrate, cps_info)
         if self.url != LOOP:
-            reader, writer = await open_serial_connection(url=self.url, baudrate=self.baudrate, limit=1)
+            reader, writer = await open_serial_connection(url=self.url, baudrate=self.baudrate)
             writer.transport.set_write_buffer_limits(high=4096, low=0)
             self._maybe_disable_hupcl(getattr(writer.transport, "serial", None))
             async with AsyncSerial(

--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/nvdemux/driver.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/nvdemux/driver.py
@@ -109,7 +109,7 @@ class NVDemuxSerial(Driver):
         cps_info = f", cps: {self.cps}" if self.cps is not None else ""
         self.logger.info("Connecting to %s at %s, baudrate: %d%s", self.target, pts_path, self.baudrate, cps_info)
 
-        reader, writer = await open_serial_connection(url=pts_path, baudrate=self.baudrate, limit=1)
+        reader, writer = await open_serial_connection(url=pts_path, baudrate=self.baudrate)
         writer.transport.set_write_buffer_limits(high=4096, low=0)
         async with AsyncSerial(
             reader=StreamReaderWrapper(reader),


### PR DESCRIPTION
## Summary
- Remove the explicit `limit=1` from `open_serial_connection()` in both pyserial drivers.
- Let asyncio use the default StreamReader limit (64 KiB) to avoid overly aggressive read pause/resume behavior under bursty UART output.
- Keep all existing write-side behavior (including CPS throttling) unchanged.

## Test plan
- [x] `make pkg-test-jumpstarter-driver-pyserial`
- [ ] Validate on a CPS-enabled board that `j serial start-console` no longer pauses at boot log checkpoints.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated serial connection configuration in pyserial drivers to use default buffer handling instead of explicit write-buffer limits, simplifying the connection setup code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->