### PR TITLE
controller: hack allow basedomain override

### DIFF
--- a/controller/hack/deploy_vars
+++ b/controller/hack/deploy_vars
@@ -3,8 +3,8 @@
 # This file should be sourced after utils
 
 # Calculate external IP and networking configuration
-IP=$(get_external_ip)
-BASEDOMAIN="jumpstarter.${IP}.nip.io"
+IP=${IP:-$(get_external_ip)}
+BASEDOMAIN=${BASEDOMAIN:-"jumpstarter.${IP}.nip.io"}
 IMG=${IMG:-quay.io/jumpstarter-dev/jumpstarter-controller:latest}
 OPERATOR_IMG=${OPERATOR_IMG:-quay.io/jumpstarter-dev/jumpstarter-operator:latest}
 


### PR DESCRIPTION
a small change to allow overriding the ip or basedomain for controller in local deployment such as kind. needed this while manually tested the hooks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment configuration now respects pre-set IP and domain environment variables; if not provided, it auto-detects the external IP and constructs a sensible default domain (e.g., jumpstarter.<ip>.nip.io), improving flexibility for custom and default deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->