### PR TITLE
docs:fix broken links

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -110,3 +110,6 @@ copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: 
 copybutton_prompt_is_regexp = True
 copybutton_only_copy_prompt_lines = True
 copybutton_line_continuation_character = "\\"
+
+# matrix.to uses client-side fragment routing; anchor checks are false positives.
+linkcheck_anchors_ignore_for_url = [r"^https://matrix\.to/"]

--- a/python/docs/source/contributing/development-environment.md
+++ b/python/docs/source/contributing/development-environment.md
@@ -1,8 +1,8 @@
 # Development Environment
 
 You can use
-[devspaces](https://github.com/jumpstarter-dev/jumpstarter/blob/main/.devfile.yaml),
-[devcontainers](https://github.com/jumpstarter-dev/jumpstarter/tree/main/.devcontainer),
+[devspaces](https://github.com/jumpstarter-dev/jumpstarter/blob/main/python/.devfile.yaml),
+[devcontainers](https://github.com/jumpstarter-dev/jumpstarter/tree/main/python/.devcontainer),
 or your favorite OS/distro to develop Jumpstarter, however the following
 examples are for Fedora 43.
 

--- a/python/docs/source/getting-started/guides/setup-distributed-mode.md
+++ b/python/docs/source/getting-started/guides/setup-distributed-mode.md
@@ -8,7 +8,7 @@ The jumpstarter-controller endpoints are secured by TLS. However, in release 0.7
 the certificates are self-signed and rotated on every restart. This means the client
 will not be able to verify the server certificate. To bypass this, you should use the
 `--insecure-tls-config` flag when creating clients and exporters. This issue will be
-resolved in the next release. See [issue #455](https://github.com/jumpstarter-dev/jumpstarter/issues/455)
+resolved in the next release. See [issue #72](https://github.com/jumpstarter-dev/jumpstarter/issues/72)
 for more details.
 Alternatively, you can configure the ingress/route in reencrypt mode with your own key and certificate.
 ```

--- a/python/docs/source/reference/package-apis/drivers/ridesx.md
+++ b/python/docs/source/reference/package-apis/drivers/ridesx.md
@@ -3,7 +3,7 @@
 `jumpstarter-driver-ridesx` provides functionality for Qualcomm RideSX devices,
 supporting fastboot flashing operations and power control through serial communication.
 
-This is mainly tailored towards images that were produced using [automotive-image-builder](https://sigs.centos.org/automotive/getting-started/about-automotive-image-builder/):
+This is mainly tailored towards images that were produced using [automotive-image-builder](https://sigs.centos.org/automotive/latest/getting-started/about-automotive-image-builder.html):
 
 ```{code-block} console
 automotive-image-builder build --target ridesx4 --export aboot.simg --mode package manifest.aib.yml ridesx.img

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -93,7 +93,7 @@ Human-readable: 30m, 3h30m, 1d, 1d3h40m, etc.
 ISO 8601: PT1H30M, P1DT2H30M, etc.
 Time format: 01:30:00, 2 days, 01:30:00, etc.
 
-See https://github.com/wroberts/pytimeparse2 for details
+See https://github.com/onegreyonewhite/pytimeparse2 for details
 """,
 )
 

--- a/python/packages/jumpstarter-driver-flashers/README.md
+++ b/python/packages/jumpstarter-driver-flashers/README.md
@@ -352,4 +352,4 @@ An example bundle for the TI J784S4XEVM looks like this:
 ```
 
 You can find a script to build and push a bundle to a registry here:
-[oci_bundles](https://github.com/jumpstarter-dev/jumpstarter/tree/main/packages/jumpstarter-driver-flashers/oci_bundles)
+[oci_bundles](https://github.com/jumpstarter-dev/jumpstarter/tree/main/python/packages/jumpstarter-driver-flashers/oci_bundles)

--- a/python/packages/jumpstarter-driver-ridesx/README.md
+++ b/python/packages/jumpstarter-driver-ridesx/README.md
@@ -3,7 +3,7 @@
 `jumpstarter-driver-ridesx` provides functionality for Qualcomm RideSX devices,
 supporting fastboot flashing operations and power control through serial communication.
 
-This is mainly tailored towards images that were produced using [automotive-image-builder](https://sigs.centos.org/automotive/getting-started/about-automotive-image-builder/):
+This is mainly tailored towards images that were produced using [automotive-image-builder](https://sigs.centos.org/automotive/latest/getting-started/about-automotive-image-builder.html):
 
 ```{code-block} console
 automotive-image-builder build --target ridesx4 --export aboot.simg --mode package manifest.aib.yml ridesx.img


### PR DESCRIPTION
a few went broken, mostly as the result of the migration to monorepo

## Broken Links Found - and fixed

- `contributing/development-environment` -> `https://github.com/jumpstarter-dev/jumpstarter/blob/main/.devfile.yaml` (404)
- `contributing/development-environment` -> `https://github.com/jumpstarter-dev/jumpstarter/tree/main/.devcontainer` (404)
- `getting-started/guides/setup-distributed-mode` -> `https://github.com/jumpstarter-dev/jumpstarter/issues/455` (404)
- `reference/package-apis/drivers/flashers` -> `https://github.com/jumpstarter-dev/jumpstarter/tree/main/packages/jumpstarter-driver-flashers/oci_bundles` (404)
- `reference/man-pages/jmp` -> `https://github.com/wroberts/pytimeparse2` (404)
- `contributing` -> `https://matrix.to/#/#jumpstarter:matrix.org` (anchor not found)
- `reference/package-apis/drivers/ridesx` -> `https://sigs.centos.org/automotive/getting-started/about-automotive-image-builder/` (404)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links and references to point to correct resource locations and versions across guides and API references.

* **Chores**
  * Updated link checking configuration to improve URL validation accuracy.
  * Updated external library references in help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->