### PR TITLE
Feat/xcp driver

### DIFF
--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -43,6 +43,8 @@ Drivers that provide various communication interfaces:
 * **[TFTP](tftp.md)** (`jumpstarter-driver-tftp`) - Trivial File Transfer
   Protocol
 * **[VNC](vnc.md)** (`jumpstarter-driver-vnc`) - VNC (Virtual Network Computing) remote desktop protocol
+* **[XCP](xcp.md)** (`jumpstarter-driver-xcp`) - Universal Measurement and
+  Calibration Protocol communication
 
 ### Storage and Data Drivers
 
@@ -133,5 +135,6 @@ uds-can.md
 uds-doip.md
 ustreamer.md
 vnc.md
+xcp.md
 yepkit.md
 ```

--- a/python/docs/source/reference/package-apis/drivers/xcp.md
+++ b/python/docs/source/reference/package-apis/drivers/xcp.md
@@ -1,0 +1,1 @@
+../../../../../packages/jumpstarter-driver-xcp/README.md

--- a/python/examples/xcp-ecu/README.md
+++ b/python/examples/xcp-ecu/README.md
@@ -1,0 +1,35 @@
+# XCP ECU Example
+
+Representative end-to-end tests demonstrating XCP (Universal Measurement and
+Calibration Protocol) workflows with Jumpstarter.
+
+## What This Example Tests
+
+A stateful mock ECU (`mock_ecu.py`) simulates a realistic automotive ECU with:
+
+- **Addressable memory regions**: calibration parameters, measurement signals, and a 64 KB flash area
+- **Resource protection**: CAL/PAG and PGM resources require unlock before modification
+- **DAQ list management**: dynamic allocation, ODT configuration, start/stop
+- **Flash programming lifecycle**: strict sequence enforcement (start → clear → program → reset)
+
+### Test Scenarios
+
+| Test | Workflow |
+|------|----------|
+| `test_full_measurement_and_calibration_workflow` | Connect → identify → read measurements → unlock → calibrate → verify → checksum → disconnect |
+| `test_full_flash_programming_workflow` | Connect → unlock → erase flash → write firmware → verify → reset |
+| `test_full_daq_configuration_workflow` | Connect → query DAQ → allocate lists → configure ODTs → start/stop → cleanup |
+| `test_read_all_calibration_parameters` | Verify all pre-populated calibration values |
+| `test_read_all_measurement_signals` | Verify all pre-populated measurement signals |
+| `test_multiple_calibration_changes` | Modify several parameters and verify independently |
+| `test_program_clear_before_start_fails` | Sequence enforcement: clear without start |
+| `test_program_without_clear_fails` | Sequence enforcement: program without clear |
+| `test_operations_before_connect_fail` | Connection-required enforcement |
+| `test_reconnect_preserves_memory` | Non-volatile memory across disconnect/reconnect |
+
+## Running
+
+```bash
+cd python
+uv run --directory examples/xcp-ecu pytest -v
+```

--- a/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/conftest.py
+++ b/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/conftest.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+import pytest
+from jumpstarter_driver_xcp.driver import Xcp
+
+from .mock_ecu import MockXcpEcu
+from jumpstarter.common.utils import serve
+
+
+@pytest.fixture
+def mock_ecu():
+    """Provide a fresh stateful mock XCP ECU."""
+    return MockXcpEcu()
+
+
+@pytest.fixture
+def ecu_client(mock_ecu):
+    """XCP driver connected to the mock ECU via the jumpstarter harness."""
+    driver = Xcp(
+        transport="ETH",
+        host="127.0.0.1",
+        port=5555,
+        protocol="TCP",
+    )
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_ecu,
+    ):
+        with serve(driver) as client:
+            yield client

--- a/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/mock_ecu.py
+++ b/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/mock_ecu.py
@@ -31,6 +31,7 @@ MEASUREMENT_MAP: dict[int, bytes] = {
 }
 
 # Flash region: uses 0x00 as erased state (UTF-8 safe, unlike 0xFF)
+FLASH_ERASED_BYTE = b"\x00"
 FLASH_BASE = 0x0800_0000
 FLASH_SIZE = 0x0001_0000  # 64 KB
 
@@ -111,8 +112,7 @@ class MockXcpEcu:
             self._memory[addr] = data
         for addr, data in MEASUREMENT_MAP.items():
             self._memory[addr] = data
-        # Flash region: pre-filled with 0x00 (erased state, UTF-8 safe)
-        self._memory[FLASH_BASE] = b"\x00" * FLASH_SIZE
+        self._memory[FLASH_BASE] = FLASH_ERASED_BYTE * FLASH_SIZE
 
         self.slaveProperties = _AttrDict(
             maxCto=self.MAX_CTO,
@@ -189,6 +189,8 @@ class MockXcpEcu:
 
     def download(self, data: bytes):
         self._require_connected()
+        if self._protection.get("calpag", False):
+            raise RuntimeError("CAL/PAG resource is protected – unlock first")
         self._memory[self._mta_address] = data
 
     # -- Checksum ------------------------------------------------------------
@@ -206,7 +208,7 @@ class MockXcpEcu:
         return {
             "processor": {
                 "minDaq": 0,
-                "maxDaq": max(len(self._daq_lists), 4),
+                "maxDaq": max(4, len(self._daq_lists)),
                 "properties": {"configType": "DYNAMIC"},
             },
             "resolution": {
@@ -286,7 +288,7 @@ class MockXcpEcu:
         if FLASH_BASE in self._memory:
             flash = bytearray(self._memory[FLASH_BASE])
             erase_len = min(clear_range, len(flash))
-            flash[:erase_len] = b"\x00" * erase_len
+            flash[:erase_len] = FLASH_ERASED_BYTE * erase_len
             self._memory[FLASH_BASE] = bytes(flash)
 
     def program(self, data: bytes, block_length: int, last: bool = False):
@@ -297,7 +299,7 @@ class MockXcpEcu:
             raise RuntimeError("programClear must be called before program")
         # Write to flash at MTA address
         if FLASH_BASE <= self._mta_address < FLASH_BASE + FLASH_SIZE:
-            flash = bytearray(self._memory.get(FLASH_BASE, b"\xFF" * FLASH_SIZE))
+            flash = bytearray(self._memory.get(FLASH_BASE, FLASH_ERASED_BYTE * FLASH_SIZE))
             offset = self._mta_address - FLASH_BASE
             flash[offset:offset + len(data)] = data
             self._memory[FLASH_BASE] = bytes(flash)

--- a/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/mock_ecu.py
+++ b/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/mock_ecu.py
@@ -1,0 +1,310 @@
+"""Stateful mock XCP ECU for representative integration testing.
+
+Simulates a realistic ECU with:
+- Addressable memory regions (calibration area, measurement area, flash)
+- Resource protection (CAL/PAG, DAQ, PGM) with seed/key unlock
+- Calibration parameters pre-populated with known values
+- DAQ list management with configurable measurement channels
+- Flash programming lifecycle with sequence enforcement
+- Connection state tracking
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Pre-populated calibration parameters (address -> value)
+# All byte values kept in 0x00-0x7F range (UTF-8 safe for gRPC transport)
+CALIBRATION_MAP: dict[int, bytes] = {
+    0x0010_0000: b"\x64\x00\x00\x00",     # int32 100    – max engine RPM scale
+    0x0010_0004: b"\x32\x00\x00\x00",     # int32 50     – idle RPM target
+    0x0010_0008: b"\x0A\x00\x00\x00",     # int32 10     – fuel trim %
+    0x0010_000C: b"\x01",                  # bool  True   – traction control enabled
+}
+
+# Pre-populated measurement signals (address -> initial value)
+MEASUREMENT_MAP: dict[int, bytes] = {
+    0x0020_0000: b"\x5A\x00\x00\x00",     # int32 90     – coolant temperature (C)
+    0x0020_0004: b"\x00\x00\x00\x00",     # int32 0      – vehicle speed (km/h)
+    0x0020_0008: b"\x37\x00\x00\x00",     # int32 55     – battery voltage (x10)
+    0x0020_000C: b"\x03\x04\x00\x00",     # int32 1027   – engine RPM
+}
+
+# Flash region: uses 0x00 as erased state (UTF-8 safe, unlike 0xFF)
+FLASH_BASE = 0x0800_0000
+FLASH_SIZE = 0x0001_0000  # 64 KB
+
+# ECU identification
+ECU_ID = "XCP_ECU_SIM_v1.0"
+
+
+def derive_key(seed: bytes) -> bytes:
+    """Derive a security key from a seed (XOR each byte with 0xA5)."""
+    return bytes(b ^ 0xA5 for b in seed)
+
+
+class _AttrDict(dict):
+    """Dict that also supports attribute access (like pyxcp SlaveProperties)."""
+
+    def __getattr__(self, name: str):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __setattr__(self, name: str, value) -> None:
+        self[name] = value
+
+
+@dataclass
+class DaqList:
+    """Represents one allocated DAQ list."""
+
+    odt_count: int = 0
+    entries: list[tuple[int, int, int, int]] = field(default_factory=list)
+    mode: int = 0
+    event_channel: int = 0
+    running: bool = False
+
+
+class MockXcpEcu:
+    """Stateful mock XCP ECU that acts as a drop-in for pyxcp's Master.
+
+    Enforces realistic ECU behavior:
+    - connect() must be called before any other operation
+    - Protected resources require cond_unlock() first
+    - Programming follows strict sequence: programStart -> programClear -> program -> programReset
+    - Memory is addressable with pre-populated calibration and measurement regions
+    """
+
+    MAX_CTO = 8
+    MAX_DTO = 256
+
+    def __init__(self) -> None:
+        self._connected = False
+        self._memory: dict[int, bytes] = {}
+        self._mta_address = 0
+        self._mta_ext = 0
+
+        # Protection state
+        self._protection = {
+            "dbg": False,
+            "pgm": True,
+            "stim": False,
+            "daq": False,
+            "calpag": True,
+        }
+        self._unlocked = False
+        self._seed: bytes = b""
+
+        # DAQ state
+        self._daq_lists: list[DaqList] = []
+        self._daq_ptr: tuple[int, int, int] | None = None
+
+        # Programming state
+        self._programming = False
+        self._program_cleared = False
+        self._flash_erased_range = 0
+
+        # Pre-populate memory regions
+        for addr, data in CALIBRATION_MAP.items():
+            self._memory[addr] = data
+        for addr, data in MEASUREMENT_MAP.items():
+            self._memory[addr] = data
+        # Flash region: pre-filled with 0x00 (erased state, UTF-8 safe)
+        self._memory[FLASH_BASE] = b"\x00" * FLASH_SIZE
+
+        self.slaveProperties = _AttrDict(
+            maxCto=self.MAX_CTO,
+            maxDto=self.MAX_DTO,
+            byteOrder="INTEL",
+            supportsPgm=True,
+            supportsStim=False,
+            supportsDaq=True,
+            supportsCalpag=True,
+            protocolLayerVersion=1,
+            transportLayerVersion=1,
+            addressGranularity="BYTE",
+            slaveBlockMode=False,
+        )
+
+    def _require_connected(self):
+        if not self._connected:
+            raise RuntimeError("Not connected – call connect() first")
+
+    def _require_unlocked(self):
+        if not self._unlocked:
+            raise RuntimeError("Resource protected – unlock required")
+
+    # -- Session Management --------------------------------------------------
+
+    def connect(self, mode: int = 0):
+        self._connected = True
+
+    def close(self):
+        self._connected = False
+        self._programming = False
+        self._program_cleared = False
+
+    def identifier(self, id_type: int) -> str:
+        self._require_connected()
+        return ECU_ID
+
+    def getStatus(self):
+        self._require_connected()
+        return _AttrDict(store_cal_req=False, store_daq_req=False)
+
+    def getCurrentProtectionStatus(self) -> dict[str, bool]:
+        return dict(self._protection)
+
+    # -- Security (Seed & Key) -----------------------------------------------
+
+    def cond_unlock(self, resources=None):
+        self._require_connected()
+        self._unlocked = True
+        for key in self._protection:
+            self._protection[key] = False
+
+    # -- Memory Access -------------------------------------------------------
+
+    def setMta(self, address: int, ext: int = 0):
+        self._require_connected()
+        self._mta_address = address
+        self._mta_ext = ext
+
+    def shortUpload(self, length: int, address: int, ext: int = 0) -> bytes:
+        self._require_connected()
+        # Check for exact-address match first
+        if address in self._memory:
+            stored = self._memory[address]
+            if len(stored) >= length:
+                return stored[:length]
+            return stored.ljust(length, b"\x00")
+        # Check if address falls within a larger block (flash region)
+        for base_addr, block in self._memory.items():
+            if base_addr <= address < base_addr + len(block):
+                offset = address - base_addr
+                return block[offset:offset + length].ljust(length, b"\x00")
+        return b"\x00" * length
+
+    def download(self, data: bytes):
+        self._require_connected()
+        self._memory[self._mta_address] = data
+
+    # -- Checksum ------------------------------------------------------------
+
+    def buildChecksum(self, block_size: int):
+        self._require_connected()
+        raw = self.shortUpload(block_size, self._mta_address, self._mta_ext)
+        csum = sum(raw) & 0xFFFFFFFF
+        return _AttrDict(checksumType=0x01, checksum=csum)
+
+    # -- DAQ -----------------------------------------------------------------
+
+    def getDaqInfo(self):
+        self._require_connected()
+        return {
+            "processor": {
+                "minDaq": 0,
+                "maxDaq": max(len(self._daq_lists), 4),
+                "properties": {"configType": "DYNAMIC"},
+            },
+            "resolution": {
+                "timestampTicks": 1,
+                "maxOdtEntrySizeDaq": 8,
+                "maxOdtEntrySizeStim": 8,
+            },
+            "channels": [],
+        }
+
+    def freeDaq(self):
+        self._require_connected()
+        self._daq_lists.clear()
+        self._daq_ptr = None
+
+    def allocDaq(self, daq_count: int):
+        self._require_connected()
+        self._daq_lists = [DaqList() for _ in range(daq_count)]
+
+    def allocOdt(self, daq_list_number: int, odt_count: int):
+        self._require_connected()
+        if daq_list_number >= len(self._daq_lists):
+            raise RuntimeError(f"DAQ list {daq_list_number} not allocated")
+        self._daq_lists[daq_list_number].odt_count = odt_count
+
+    def allocOdtEntry(self, daq_list_number: int, odt_number: int, odt_entries_count: int):
+        self._require_connected()
+
+    def setDaqPtr(self, daq_list: int, odt: int, entry: int):
+        self._require_connected()
+        self._daq_ptr = (daq_list, odt, entry)
+
+    def writeDaq(self, bit_offset: int, size: int, ext: int, address: int):
+        self._require_connected()
+        if self._daq_ptr is None:
+            raise RuntimeError("setDaqPtr must be called before writeDaq")
+        daq_idx = self._daq_ptr[0]
+        if daq_idx < len(self._daq_lists):
+            self._daq_lists[daq_idx].entries.append((bit_offset, size, ext, address))
+
+    def setDaqListMode(self, mode: int, daq_list: int, event: int, prescaler: int, priority: int):
+        self._require_connected()
+        if daq_list < len(self._daq_lists):
+            self._daq_lists[daq_list].mode = mode
+            self._daq_lists[daq_list].event_channel = event
+
+    def startStopDaqList(self, mode: int, daq_list: int):
+        self._require_connected()
+        if daq_list < len(self._daq_lists):
+            self._daq_lists[daq_list].running = (mode == 1)
+
+    def startStopSynch(self, mode: int):
+        self._require_connected()
+        for dl in self._daq_lists:
+            dl.running = (mode == 1)
+
+    # -- Programming (Flashing) ----------------------------------------------
+
+    def programStart(self):
+        self._require_connected()
+        if self._protection.get("pgm", False):
+            raise RuntimeError("PGM resource is protected – unlock first")
+        self._programming = True
+        self._program_cleared = False
+        return _AttrDict(
+            commModePgm=0, maxCtoPgm=self.MAX_CTO,
+            maxBsPgm=0, minStPgm=0, queueSizePgm=0,
+        )
+
+    def programClear(self, mode: int, clear_range: int):
+        self._require_connected()
+        if not self._programming:
+            raise RuntimeError("programStart must be called before programClear")
+        self._program_cleared = True
+        self._flash_erased_range = clear_range
+        # Erase flash region (fill with 0x00)
+        if FLASH_BASE in self._memory:
+            flash = bytearray(self._memory[FLASH_BASE])
+            erase_len = min(clear_range, len(flash))
+            flash[:erase_len] = b"\x00" * erase_len
+            self._memory[FLASH_BASE] = bytes(flash)
+
+    def program(self, data: bytes, block_length: int, last: bool = False):
+        self._require_connected()
+        if not self._programming:
+            raise RuntimeError("programStart must be called before program")
+        if not self._program_cleared:
+            raise RuntimeError("programClear must be called before program")
+        # Write to flash at MTA address
+        if FLASH_BASE <= self._mta_address < FLASH_BASE + FLASH_SIZE:
+            flash = bytearray(self._memory.get(FLASH_BASE, b"\xFF" * FLASH_SIZE))
+            offset = self._mta_address - FLASH_BASE
+            flash[offset:offset + len(data)] = data
+            self._memory[FLASH_BASE] = bytes(flash)
+        else:
+            self._memory[self._mta_address] = data
+
+    def programReset(self, wait_for_optional_response: bool = True):
+        self._require_connected()
+        self._programming = False
+        self._program_cleared = False

--- a/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/test_xcp_flow.py
+++ b/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/test_xcp_flow.py
@@ -13,6 +13,7 @@ from .mock_ecu import (
     CALIBRATION_MAP,
     ECU_ID,
     FLASH_BASE,
+    FLASH_ERASED_BYTE,
     FLASH_SIZE,
     MEASUREMENT_MAP,
 )
@@ -89,45 +90,47 @@ def test_full_flash_programming_workflow(ecu_client, mock_ecu):
     firmware, verify, reset."""
 
     ecu_client.connect()
-
-    # 1. Read flash region before programming (should be 0x00 = erased)
-    flash_data = _to_bytes(ecu_client.upload(4, FLASH_BASE, 0))
-    assert flash_data == b"\x00\x00\x00\x00"
-
-    # 2. Unlock PGM resource
     ecu_client.unlock()
 
-    # 3. Start programming session
+    # 1. Seed flash with non-erased data so program_clear has something to erase
+    non_erased = b"\x7F\x45\x4C\x46"
+    mock_ecu._memory[FLASH_BASE] = non_erased + (FLASH_ERASED_BYTE * (FLASH_SIZE - len(non_erased)))
+    flash_data = _to_bytes(ecu_client.upload(4, FLASH_BASE, 0))
+    assert flash_data == non_erased
+
+    # 2. Start programming session
     pgm_info = ecu_client.program_start()
     assert pgm_info.max_cto_pgm == 8
     assert mock_ecu._programming is True
 
-    # 4. Erase flash (64 KB)
+    # 3. Erase flash (64 KB) and verify it returns to erased state
     ecu_client.program_clear(FLASH_SIZE)
     assert mock_ecu._program_cleared is True
+    erased_data = _to_bytes(ecu_client.upload(4, FLASH_BASE, 0))
+    assert erased_data == FLASH_ERASED_BYTE * 4
 
-    # 5. Write firmware data at flash base
+    # 4. Write firmware data at flash base
     firmware_header = b"\x7F\x45\x4C\x46"  # ELF magic (all < 0x80)
     ecu_client.set_mta(FLASH_BASE, 0)
     ecu_client.program(firmware_header, block_length=len(firmware_header))
 
-    # 6. Write more firmware data at next offset
+    # 5. Write more firmware data at next offset
     firmware_body = b"\x01\x02\x03\x04\x05\x06\x07\x08"  # all < 0x80
     ecu_client.set_mta(FLASH_BASE + 4, 0)
     ecu_client.program(firmware_body, block_length=len(firmware_body))
 
-    # 7. Verify programmed data
+    # 6. Verify programmed data
     header_readback = _to_bytes(ecu_client.upload(4, FLASH_BASE, 0))
     assert header_readback == firmware_header
 
     body_readback = _to_bytes(ecu_client.upload(8, FLASH_BASE + 4, 0))
     assert body_readback == firmware_body
 
-    # 8. Verify untouched flash area is still erased
+    # 7. Verify untouched flash area is still erased
     beyond = _to_bytes(ecu_client.upload(4, FLASH_BASE + 12, 0))
     assert beyond == b"\x00\x00\x00\x00"
 
-    # 9. Reset ECU
+    # 8. Reset ECU
     ecu_client.program_reset()
     assert mock_ecu._programming is False
 
@@ -220,14 +223,19 @@ def test_read_all_measurement_signals(ecu_client):
         assert data == expected, f"Mismatch at 0x{addr:08X}"
 
 
-def test_calibration_write_without_unlock_succeeds(ecu_client, mock_ecu):
-    """The XCP driver doesn't enforce protection at the memory write level
-    (unlike UDS where the ECU rejects writes). The mock ECU allows writes
-    but protection state is tracked for the test to verify."""
+def test_calibration_write_requires_unlock(ecu_client, mock_ecu):
+    """Calibration writes to a protected resource must be preceded by unlock."""
     ecu_client.connect()
     assert mock_ecu._protection["calpag"] is True
 
-    # XCP memory write goes through even without unlock (ECU-specific behavior)
+    # Write without unlock should be rejected
+    with pytest.raises(DriverError, match="CAL/PAG resource is protected"):
+        ecu_client.download(0x0010_0000, b"\x00\x00\x00\x00", 0)
+
+    # After unlock, the write should succeed
+    prot = ecu_client.unlock()
+    assert prot["calpag"] is False
+
     ecu_client.download(0x0010_0000, b"\x00\x00\x00\x00", 0)
     data = _to_bytes(ecu_client.upload(4, 0x0010_0000, 0))
     assert data == b"\x00\x00\x00\x00"
@@ -281,6 +289,7 @@ def test_reconnect_preserves_memory(ecu_client, mock_ecu):
     """After disconnect + reconnect, calibration writes should persist
     (simulating non-volatile storage)."""
     ecu_client.connect()
+    ecu_client.unlock()
     new_val = struct.pack("<I", 42)
     ecu_client.download(0x0010_0000, new_val, 0)
     ecu_client.disconnect()

--- a/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/test_xcp_flow.py
+++ b/python/examples/xcp-ecu/jumpstarter_example_xcp_ecu/test_xcp_flow.py
@@ -1,0 +1,330 @@
+"""Representative end-to-end XCP ECU tests using jumpstarter.
+
+Demonstrates realistic XCP workflows: connection, measurement, calibration,
+DAQ configuration, and flash programming -- all running through the full
+jumpstarter driver/gRPC/client pipeline against a stateful mock ECU.
+"""
+
+import struct
+
+import pytest
+
+from .mock_ecu import (
+    CALIBRATION_MAP,
+    ECU_ID,
+    FLASH_BASE,
+    FLASH_SIZE,
+    MEASUREMENT_MAP,
+)
+from jumpstarter.client.core import DriverError
+
+
+def _to_bytes(data) -> bytes:
+    """Normalize data returned through the gRPC boundary to bytes."""
+    return bytes(data, "latin-1") if isinstance(data, str) else data
+
+
+# -- Full workflow tests -------------------------------------------------------
+
+
+def test_full_measurement_and_calibration_workflow(ecu_client, mock_ecu):
+    """Complete ECU workflow: connect, identify, read measurements, unlock,
+    calibrate, verify, checksum, disconnect."""
+
+    # 1. Connect and verify negotiated properties
+    info = ecu_client.connect()
+    assert info.max_cto == 8
+    assert info.max_dto == 256
+    assert info.supports_calpag is True
+    assert info.supports_daq is True
+    assert info.supports_pgm is True
+
+    # 2. Identify the ECU
+    ident = ecu_client.get_id(1)
+    assert ident.identifier == ECU_ID
+
+    # 3. Read initial calibration parameter (max RPM scale = 100)
+    rpm_scale_addr = 0x0010_0000
+    data = _to_bytes(ecu_client.upload(4, rpm_scale_addr, 0))
+    rpm_scale = struct.unpack("<I", data)[0]
+    assert rpm_scale == 100
+
+    # 4. Read initial measurement (coolant temp = 90)
+    coolant_addr = 0x0020_0000
+    data = _to_bytes(ecu_client.upload(4, coolant_addr, 0))
+    coolant_temp = struct.unpack("<I", data)[0]
+    assert coolant_temp == 90
+
+    # 5. Check protection status -- calpag should be protected
+    status = ecu_client.get_status()
+    assert status.resource_protection["calpag"] is True
+    assert status.resource_protection["pgm"] is True
+
+    # 6. Unlock resources
+    prot = ecu_client.unlock()
+    assert prot["calpag"] is False
+    assert prot["pgm"] is False
+
+    # 7. Calibrate: change max RPM scale from 100 to 120
+    new_rpm_scale = struct.pack("<I", 120)
+    ecu_client.download(rpm_scale_addr, new_rpm_scale, 0)
+
+    # 8. Read back and verify the calibration change
+    data = _to_bytes(ecu_client.upload(4, rpm_scale_addr, 0))
+    assert struct.unpack("<I", data)[0] == 120
+
+    # 9. Checksum verification over the calibration block
+    ecu_client.set_mta(rpm_scale_addr, 0)
+    csum = ecu_client.build_checksum(4)
+    assert csum.checksum_type == 1
+    assert csum.checksum_value == sum(new_rpm_scale)
+
+    # 10. Disconnect
+    ecu_client.disconnect()
+    assert mock_ecu._connected is False
+
+
+def test_full_flash_programming_workflow(ecu_client, mock_ecu):
+    """Complete flash programming lifecycle: connect, unlock, erase, write
+    firmware, verify, reset."""
+
+    ecu_client.connect()
+
+    # 1. Read flash region before programming (should be 0x00 = erased)
+    flash_data = _to_bytes(ecu_client.upload(4, FLASH_BASE, 0))
+    assert flash_data == b"\x00\x00\x00\x00"
+
+    # 2. Unlock PGM resource
+    ecu_client.unlock()
+
+    # 3. Start programming session
+    pgm_info = ecu_client.program_start()
+    assert pgm_info.max_cto_pgm == 8
+    assert mock_ecu._programming is True
+
+    # 4. Erase flash (64 KB)
+    ecu_client.program_clear(FLASH_SIZE)
+    assert mock_ecu._program_cleared is True
+
+    # 5. Write firmware data at flash base
+    firmware_header = b"\x7F\x45\x4C\x46"  # ELF magic (all < 0x80)
+    ecu_client.set_mta(FLASH_BASE, 0)
+    ecu_client.program(firmware_header, block_length=len(firmware_header))
+
+    # 6. Write more firmware data at next offset
+    firmware_body = b"\x01\x02\x03\x04\x05\x06\x07\x08"  # all < 0x80
+    ecu_client.set_mta(FLASH_BASE + 4, 0)
+    ecu_client.program(firmware_body, block_length=len(firmware_body))
+
+    # 7. Verify programmed data
+    header_readback = _to_bytes(ecu_client.upload(4, FLASH_BASE, 0))
+    assert header_readback == firmware_header
+
+    body_readback = _to_bytes(ecu_client.upload(8, FLASH_BASE + 4, 0))
+    assert body_readback == firmware_body
+
+    # 8. Verify untouched flash area is still erased
+    beyond = _to_bytes(ecu_client.upload(4, FLASH_BASE + 12, 0))
+    assert beyond == b"\x00\x00\x00\x00"
+
+    # 9. Reset ECU
+    ecu_client.program_reset()
+    assert mock_ecu._programming is False
+
+    ecu_client.disconnect()
+
+
+def test_full_daq_configuration_workflow(ecu_client, mock_ecu):
+    """Set up DAQ lists to measure engine RPM and coolant temperature,
+    start acquisition, then stop and clean up."""
+
+    ecu_client.connect()
+
+    # 1. Query DAQ capabilities
+    daq_info = ecu_client.get_daq_info()
+    assert daq_info.processor["maxDaq"] >= 4
+
+    # 2. Free any existing DAQ lists
+    ecu_client.free_daq()
+
+    # 3. Allocate 2 DAQ lists (one for engine, one for thermal)
+    ecu_client.alloc_daq(2)
+    assert len(mock_ecu._daq_lists) == 2
+
+    # 4. Configure DAQ list 0 (engine): 1 ODT with 2 entries
+    ecu_client.alloc_odt(0, 1)
+    assert mock_ecu._daq_lists[0].odt_count == 1
+    ecu_client.alloc_odt_entry(0, 0, 2)
+
+    # Entry 0: engine RPM (4 bytes at measurement address)
+    rpm_addr = 0x0020_000C
+    ecu_client.set_daq_ptr(0, 0, 0)
+    ecu_client.write_daq(0xFF, 4, 0, rpm_addr)
+    assert len(mock_ecu._daq_lists[0].entries) == 1
+    assert mock_ecu._daq_lists[0].entries[0] == (0xFF, 4, 0, rpm_addr)
+
+    # Entry 1: vehicle speed (4 bytes)
+    speed_addr = 0x0020_0004
+    ecu_client.set_daq_ptr(0, 0, 1)
+    ecu_client.write_daq(0xFF, 4, 0, speed_addr)
+
+    # 5. Configure DAQ list 1 (thermal): 1 ODT with 1 entry
+    ecu_client.alloc_odt(1, 1)
+    ecu_client.alloc_odt_entry(1, 0, 1)
+
+    coolant_addr = 0x0020_0000
+    ecu_client.set_daq_ptr(1, 0, 0)
+    ecu_client.write_daq(0xFF, 4, 0, coolant_addr)
+
+    # 6. Set DAQ list modes (event channel 1 for engine, 2 for thermal)
+    ecu_client.set_daq_list_mode(0x10, 0, 1, 1, 0)
+    ecu_client.set_daq_list_mode(0x10, 1, 2, 1, 0)
+    assert mock_ecu._daq_lists[0].event_channel == 1
+    assert mock_ecu._daq_lists[1].event_channel == 2
+
+    # 7. Start individual DAQ lists
+    ecu_client.start_stop_daq_list(1, 0)
+    assert mock_ecu._daq_lists[0].running is True
+    assert mock_ecu._daq_lists[1].running is False
+
+    ecu_client.start_stop_daq_list(1, 1)
+    assert mock_ecu._daq_lists[1].running is True
+
+    # 8. Stop all DAQ lists synchronously
+    ecu_client.start_stop_synch(0)
+    assert all(not dl.running for dl in mock_ecu._daq_lists)
+
+    # 9. Clean up
+    ecu_client.free_daq()
+    assert len(mock_ecu._daq_lists) == 0
+
+    ecu_client.disconnect()
+
+
+# -- Targeted scenario tests ---------------------------------------------------
+
+
+def test_read_all_calibration_parameters(ecu_client):
+    """All pre-populated calibration parameters should be readable."""
+    ecu_client.connect()
+    for addr, expected in CALIBRATION_MAP.items():
+        data = _to_bytes(ecu_client.upload(len(expected), addr, 0))
+        assert data == expected, f"Mismatch at 0x{addr:08X}"
+
+
+def test_read_all_measurement_signals(ecu_client):
+    """All pre-populated measurement signals should be readable."""
+    ecu_client.connect()
+    for addr, expected in MEASUREMENT_MAP.items():
+        data = _to_bytes(ecu_client.upload(len(expected), addr, 0))
+        assert data == expected, f"Mismatch at 0x{addr:08X}"
+
+
+def test_calibration_write_without_unlock_succeeds(ecu_client, mock_ecu):
+    """The XCP driver doesn't enforce protection at the memory write level
+    (unlike UDS where the ECU rejects writes). The mock ECU allows writes
+    but protection state is tracked for the test to verify."""
+    ecu_client.connect()
+    assert mock_ecu._protection["calpag"] is True
+
+    # XCP memory write goes through even without unlock (ECU-specific behavior)
+    ecu_client.download(0x0010_0000, b"\x00\x00\x00\x00", 0)
+    data = _to_bytes(ecu_client.upload(4, 0x0010_0000, 0))
+    assert data == b"\x00\x00\x00\x00"
+
+
+def test_multiple_calibration_changes(ecu_client):
+    """Modify several calibration parameters and verify each independently."""
+    ecu_client.connect()
+    ecu_client.unlock()
+
+    changes = {
+        0x0010_0000: struct.pack("<I", 120),   # max RPM scale
+        0x0010_0004: struct.pack("<I", 75),    # idle RPM target
+        0x0010_0008: struct.pack("<I", 15),    # fuel trim %
+    }
+
+    for addr, new_value in changes.items():
+        ecu_client.download(addr, new_value, 0)
+
+    for addr, expected in changes.items():
+        data = _to_bytes(ecu_client.upload(len(expected), addr, 0))
+        assert data == expected, f"Mismatch at 0x{addr:08X}"
+
+
+def test_program_clear_before_start_fails(ecu_client):
+    """programClear without programStart should fail (sequence error)."""
+    ecu_client.connect()
+    ecu_client.unlock()
+
+    with pytest.raises(DriverError, match="programStart must be called"):
+        ecu_client.program_clear(FLASH_SIZE)
+
+
+def test_program_without_clear_fails(ecu_client):
+    """program without programClear should fail (sequence error)."""
+    ecu_client.connect()
+    ecu_client.unlock()
+    ecu_client.program_start()
+
+    with pytest.raises(DriverError, match="programClear must be called"):
+        ecu_client.program(b"\x00" * 8)
+
+
+def test_operations_before_connect_fail(ecu_client, mock_ecu):
+    """Operations called before connect() should raise an error."""
+    with pytest.raises(DriverError, match="Not connected"):
+        ecu_client.get_id()
+
+
+def test_reconnect_preserves_memory(ecu_client, mock_ecu):
+    """After disconnect + reconnect, calibration writes should persist
+    (simulating non-volatile storage)."""
+    ecu_client.connect()
+    new_val = struct.pack("<I", 42)
+    ecu_client.download(0x0010_0000, new_val, 0)
+    ecu_client.disconnect()
+
+    ecu_client.connect()
+    data = _to_bytes(ecu_client.upload(4, 0x0010_0000, 0))
+    assert struct.unpack("<I", data)[0] == 42
+
+
+def test_checksum_over_measurement_region(ecu_client):
+    """Checksum over a measurement region should reflect stored values."""
+    ecu_client.connect()
+    coolant_addr = 0x0020_0000
+    ecu_client.set_mta(coolant_addr, 0)
+    csum = ecu_client.build_checksum(4)
+    expected = sum(MEASUREMENT_MAP[coolant_addr])
+    assert csum.checksum_value == expected
+
+
+def test_session_status_after_unlock(ecu_client):
+    """After unlock, all protection bits should be cleared."""
+    ecu_client.connect()
+    prot = ecu_client.unlock()
+    for resource, locked in prot.items():
+        assert locked is False, f"{resource} should be unlocked"
+
+
+def test_flash_readback_after_partial_program(ecu_client):
+    """Program only the first 8 bytes of flash, verify rest is untouched."""
+    ecu_client.connect()
+    ecu_client.unlock()
+    ecu_client.program_start()
+    ecu_client.program_clear(FLASH_SIZE)
+
+    firmware = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+    ecu_client.set_mta(FLASH_BASE, 0)
+    ecu_client.program(firmware, block_length=len(firmware))
+
+    # Programmed region
+    readback = _to_bytes(ecu_client.upload(8, FLASH_BASE, 0))
+    assert readback == firmware
+
+    # Adjacent erased region
+    erased = _to_bytes(ecu_client.upload(4, FLASH_BASE + 8, 0))
+    assert erased == b"\x00\x00\x00\x00"
+
+    ecu_client.program_reset()

--- a/python/examples/xcp-ecu/pyproject.toml
+++ b/python/examples/xcp-ecu/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "jumpstarter-example-xcp-ecu"
+version = "0.1.0"
+description = "Representative XCP ECU measurement, calibration, and flash programming tests using jumpstarter with a stateful mock ECU"
+authors = [
+  { name = "Kirk Brauer", email = "kbrauer@hatci.com" },
+  { name = "Nick Cao", email = "ncao@redhat.com" },
+  { name = "Miguel Angel Ajo Pelayo", email = "majopela@redhat.com" },
+  { name = "Vinicius Zein", email = "vzein@redhat.com" },
+]
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+dependencies = [
+  "pytest>=8.3.2",
+  "jumpstarter",
+  "jumpstarter-driver-xcp",
+]
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"

--- a/python/packages/jumpstarter-driver-xcp/.gitignore
+++ b/python/packages/jumpstarter-driver-xcp/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-xcp/README.md
+++ b/python/packages/jumpstarter-driver-xcp/README.md
@@ -1,0 +1,147 @@
+# XCP Driver
+
+`jumpstarter-driver-xcp` provides XCP (Universal Measurement and Calibration Protocol) support
+for Jumpstarter, enabling remote measurement, calibration, DAQ (data acquisition), and
+programming of XCP-enabled ECUs.
+
+It wraps the [pyXCP](https://github.com/christoph2/pyxcp) library and supports Ethernet (TCP/UDP),
+CAN, USB, and Serial (SxI) transports.
+
+## Installation
+
+```shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-xcp
+```
+
+## Configuration
+
+### Ethernet (TCP)
+
+```yaml
+export:
+  xcp:
+    type: jumpstarter_driver_xcp.driver.Xcp
+    config:
+      transport: ETH
+      host: "192.168.1.100"
+      port: 5555
+      protocol: TCP
+```
+
+### Ethernet (UDP)
+
+```yaml
+export:
+  xcp:
+    type: jumpstarter_driver_xcp.driver.Xcp
+    config:
+      transport: ETH
+      host: "192.168.1.100"
+      port: 5555
+      protocol: UDP
+```
+
+### CAN
+
+```yaml
+export:
+  xcp:
+    type: jumpstarter_driver_xcp.driver.Xcp
+    config:
+      transport: CAN
+      can_interface: vector
+      channel: 0
+      bitrate: 500000
+      can_id_master: 0x7E0
+      can_id_slave: 0x7E1
+```
+
+### Using a pyXCP Config File
+
+For advanced configuration (seed & key, DAQ policies, etc.), provide a
+[pyXCP configuration file](https://pyxcp.readthedocs.io/en/latest/configuration.html):
+
+```yaml
+export:
+  xcp:
+    type: jumpstarter_driver_xcp.driver.Xcp
+    config:
+      transport: ETH
+      config_file: /path/to/xcp_config.py
+```
+
+## Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `transport` | `str` | `ETH` | Transport layer: `ETH`, `CAN`, `USB`, `SXI` |
+| `host` | `str` | `localhost` | IP address or hostname (Ethernet only) |
+| `port` | `int` | `5555` | Port number (Ethernet only) |
+| `protocol` | `str` | `TCP` | `TCP` or `UDP` (Ethernet only) |
+| `can_interface` | `str` | `None` | python-can interface name (CAN only) |
+| `channel` | `str\|int` | `None` | CAN channel (CAN only) |
+| `bitrate` | `int` | `None` | CAN bitrate in bits/s (CAN only) |
+| `can_id_master` | `int` | `None` | CAN ID for master -> slave (CAN only) |
+| `can_id_slave` | `int` | `None` | CAN ID for slave -> master (CAN only) |
+| `config_file` | `str` | `None` | Path to a pyXCP config file (overrides individual params) |
+
+## API Reference
+
+### Session Management
+
+- `connect(mode=0)` - Connect to the XCP slave, returns negotiated properties
+- `disconnect()` - Disconnect from the XCP slave
+- `get_id(id_type=1)` - Get the slave identifier
+- `get_status()` - Get session status and resource protection
+
+### Security
+
+- `unlock(resources=None)` - Perform seed & key unlock for protected resources
+
+### Memory Access (Measurement / Calibration)
+
+- `upload(length, address, ext=0)` - Read memory from the slave
+- `download(address, data, ext=0)` - Write data to the slave memory
+- `set_mta(address, ext=0)` - Set the Memory Transfer Address
+- `build_checksum(block_size)` - Compute checksum over a memory block
+
+### DAQ (Data Acquisition)
+
+- `get_daq_info()` - Get DAQ processor, resolution, and event channel info
+- `free_daq()` - Free all DAQ lists
+- `alloc_daq(daq_count)` - Allocate DAQ lists
+- `alloc_odt(daq_list_number, odt_count)` - Allocate ODTs
+- `alloc_odt_entry(daq_list_number, odt_number, odt_entries_count)` - Allocate ODT entries
+- `set_daq_ptr(daq_list, odt, entry)` - Set DAQ list pointer
+- `write_daq(bit_offset, size, ext, address)` - Configure what to measure
+- `set_daq_list_mode(mode, daq_list, event, prescaler, priority)` - Set DAQ list mode
+- `start_stop_daq_list(mode, daq_list)` - Start/stop a single DAQ list
+- `start_stop_synch(mode)` - Start/stop all DAQ lists synchronously
+
+### Programming (Flashing)
+
+- `program_start()` - Begin programming sequence
+- `program_clear(clear_range, mode=0)` - Erase memory range
+- `program(data, block_length=0)` - Download program data
+- `program_reset()` - Reset slave after programming
+
+## Example Usage
+
+```python
+from jumpstarter.common.utils import env
+
+with env() as client:
+    xcp = client.xcp
+
+    info = xcp.connect()
+    print(f"Max CTO: {info.max_cto}, Max DTO: {info.max_dto}")
+
+    xcp.unlock()
+
+    data = xcp.upload(4, 0x1000)
+    print(f"Memory at 0x1000: {data.hex()}")
+
+    xcp.download(0x2000, b"\x42\x00\x00\x00")
+
+    xcp.disconnect()
+```

--- a/python/packages/jumpstarter-driver-xcp/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-xcp/examples/exporter.yaml
@@ -1,0 +1,10 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+endpoint:
+  xcp:
+    type: jumpstarter_driver_xcp.driver.Xcp
+    config:
+      transport: ETH
+      host: "192.168.1.100"
+      port: 5555
+      protocol: TCP

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/client.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/client.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .common import (
+    XcpChecksum,
+    XcpConnectionInfo,
+    XcpDaqInfo,
+    XcpIdentifier,
+    XcpProgramInfo,
+    XcpStatusResponse,
+)
+from jumpstarter.client import DriverClient
+
+
+@dataclass(kw_only=True)
+class XcpClient(DriverClient):
+    """Client interface for XCP (Universal Measurement and Calibration Protocol).
+
+    Provides methods for measurement, calibration, DAQ, and programming
+    of XCP-enabled devices (ECUs) via the Jumpstarter remoting layer.
+    """
+
+    # --- Session Management ---
+
+    def connect(self, mode: int = 0) -> XcpConnectionInfo:
+        """Connect to the XCP slave and return negotiated properties."""
+        return XcpConnectionInfo.model_validate(self.call("connect", mode))
+
+    def disconnect(self) -> None:
+        """Disconnect from the XCP slave."""
+        self.call("disconnect")
+
+    def get_id(self, id_type: int = 1) -> XcpIdentifier:
+        """Get the slave identifier string."""
+        return XcpIdentifier.model_validate(self.call("get_id", id_type))
+
+    def get_status(self) -> XcpStatusResponse:
+        """Get the current session status and resource protection."""
+        return XcpStatusResponse.model_validate(self.call("get_status"))
+
+    # --- Security ---
+
+    def unlock(self, resources: list[str] | None = None) -> dict[str, bool]:
+        """Perform conditional unlock (seed & key) for protected resources."""
+        return self.call("unlock", resources)
+
+    # --- Memory Access (Measurement / Calibration) ---
+
+    def upload(self, length: int, address: int, ext: int = 0) -> bytes:
+        """Read memory from the XCP slave."""
+        return self.call("upload", length, address, ext)
+
+    def download(self, address: int, data: bytes, ext: int = 0) -> None:
+        """Write data to the XCP slave memory."""
+        self.call("download", address, data, ext)
+
+    def set_mta(self, address: int, ext: int = 0) -> None:
+        """Set the Memory Transfer Address pointer."""
+        self.call("set_mta", address, ext)
+
+    def build_checksum(self, block_size: int) -> XcpChecksum:
+        """Compute a checksum over a memory block (starting at current MTA)."""
+        return XcpChecksum.model_validate(self.call("build_checksum", block_size))
+
+    # --- DAQ (Data Acquisition) ---
+
+    def get_daq_info(self) -> XcpDaqInfo:
+        """Get DAQ processor, resolution, and event channel information."""
+        return XcpDaqInfo.model_validate(self.call("get_daq_info"))
+
+    def free_daq(self) -> None:
+        """Free all DAQ lists."""
+        self.call("free_daq")
+
+    def alloc_daq(self, daq_count: int) -> None:
+        """Allocate DAQ lists."""
+        self.call("alloc_daq", daq_count)
+
+    def alloc_odt(self, daq_list_number: int, odt_count: int) -> None:
+        """Allocate ODTs for a DAQ list."""
+        self.call("alloc_odt", daq_list_number, odt_count)
+
+    def alloc_odt_entry(
+        self, daq_list_number: int, odt_number: int, odt_entries_count: int
+    ) -> None:
+        """Allocate ODT entries for a specific ODT."""
+        self.call("alloc_odt_entry", daq_list_number, odt_number, odt_entries_count)
+
+    def set_daq_ptr(self, daq_list: int, odt: int, entry: int) -> None:
+        """Set the DAQ list pointer."""
+        self.call("set_daq_ptr", daq_list, odt, entry)
+
+    def write_daq(
+        self, bit_offset: int, size: int, ext: int, address: int
+    ) -> None:
+        """Write a DAQ entry (configure what to measure)."""
+        self.call("write_daq", bit_offset, size, ext, address)
+
+    def set_daq_list_mode(
+        self, mode: int, daq_list: int, event: int, prescaler: int, priority: int
+    ) -> None:
+        """Set the mode for a DAQ list."""
+        self.call("set_daq_list_mode", mode, daq_list, event, prescaler, priority)
+
+    def start_stop_daq_list(self, mode: int, daq_list: int) -> None:
+        """Start or stop a single DAQ list."""
+        self.call("start_stop_daq_list", mode, daq_list)
+
+    def start_stop_synch(self, mode: int) -> None:
+        """Start or stop all DAQ lists synchronously."""
+        self.call("start_stop_synch", mode)
+
+    # --- Programming (Flashing) ---
+
+    def program_start(self) -> XcpProgramInfo:
+        """Begin a programming sequence."""
+        return XcpProgramInfo.model_validate(self.call("program_start"))
+
+    def program_clear(self, clear_range: int, mode: int = 0) -> None:
+        """Clear (erase) a memory range for programming."""
+        self.call("program_clear", clear_range, mode)
+
+    def program(self, data: bytes, block_length: int = 0) -> None:
+        """Download program data to the slave."""
+        self.call("program", data, block_length)
+
+    def program_reset(self) -> None:
+        """Reset the slave after programming."""
+        self.call("program_reset")

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/common.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/common.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class XcpTransport(str, Enum):
+    """XCP transport layer type."""
+
+    ETH = "ETH"
+    CAN = "CAN"
+    USB = "USB"
+    SXI = "SXI"
+
+
+class XcpEthProtocol(str, Enum):
+    """Ethernet protocol for XCP over Ethernet transport."""
+
+    TCP = "TCP"
+    UDP = "UDP"
+
+
+class XcpConnectionInfo(BaseModel):
+    """Information returned after a successful XCP CONNECT."""
+
+    max_cto: int
+    max_dto: int
+    byte_order: str
+    supports_pgm: bool = False
+    supports_stim: bool = False
+    supports_daq: bool = False
+    supports_calpag: bool = False
+    protocol_layer_version: int = 0
+    transport_layer_version: int = 0
+    address_granularity: str = ""
+    slave_block_mode: bool = False
+
+
+class XcpStatusResponse(BaseModel):
+    """Response from GET_STATUS command."""
+
+    session_status: dict[str, Any] = {}
+    resource_protection: dict[str, bool] = {}
+
+
+class XcpDaqInfo(BaseModel):
+    """DAQ configuration information."""
+
+    processor: dict[str, Any] = {}
+    resolution: dict[str, Any] = {}
+    channels: list[dict[str, Any]] = []
+
+
+class XcpProgramInfo(BaseModel):
+    """Information returned by PROGRAM_START."""
+
+    comm_mode_pgm: int = 0
+    max_cto_pgm: int = 0
+    max_bs_pgm: int = 0
+    min_st_pgm: int = 0
+    queue_size_pgm: int = 0
+
+
+class XcpChecksum(BaseModel):
+    """Result of BUILD_CHECKSUM command."""
+
+    checksum_type: int
+    checksum_value: int
+
+
+class XcpIdentifier(BaseModel):
+    """Slave identifier result."""
+
+    id_type: int
+    identifier: str

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/conftest.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/conftest.py
@@ -1,0 +1,280 @@
+"""Simulated XCP-on-Ethernet TCP server for integration testing.
+
+Implements a minimal subset of the XCP protocol (ASAM MCD-1):
+- CONNECT / DISCONNECT
+- GET_STATUS
+- GET_ID
+- SHORT_UPLOAD / DOWNLOAD / SET_MTA
+- BUILD_CHECKSUM
+- FREE_DAQ / ALLOC_DAQ
+- PROGRAM_START / PROGRAM_CLEAR / PROGRAM / PROGRAM_RESET
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+
+import pytest
+
+# XCP command codes (request PIDs)
+CMD_CONNECT = 0xFF
+CMD_DISCONNECT = 0xFE
+CMD_GET_STATUS = 0xFD
+CMD_SYNCH = 0xFC
+CMD_GET_ID = 0xFA
+CMD_SET_MTA = 0xF6
+CMD_UPLOAD = 0xF5
+CMD_SHORT_UPLOAD = 0xF4
+CMD_BUILD_CHECKSUM = 0xF3
+CMD_DOWNLOAD = 0xF0
+CMD_GET_DAQ_PROCESSOR_INFO = 0xDA
+CMD_GET_DAQ_RESOLUTION_INFO = 0xD9
+CMD_FREE_DAQ = 0xD6
+CMD_ALLOC_DAQ = 0xD5
+CMD_PROGRAM_START = 0xD2
+CMD_PROGRAM_CLEAR = 0xD1
+CMD_PROGRAM = 0xD0
+CMD_PROGRAM_RESET = 0xCF
+
+# XCP response codes
+RES_OK = 0xFF
+RES_ERR = 0xFE
+
+# XCP error codes
+ERR_CMD_UNKNOWN = 0x20
+ERR_OUT_OF_RANGE = 0x22
+ERR_ACCESS_DENIED = 0x24
+
+# Simulated slave properties
+MAX_CTO = 8
+MAX_DTO = 8
+SLAVE_ID = b"XCP_SIM_v1.0"
+
+
+def _xcp_header(length: int, ctr: int = 0) -> bytes:
+    """Build XCP-on-Ethernet transport header: LEN(H) + CTR(H)."""
+    return struct.pack("<HH", length, ctr)
+
+
+def _positive(pid: int, *tail_bytes: int) -> bytes:
+    payload = bytes([RES_OK, pid] + list(tail_bytes))
+    return _xcp_header(len(payload)) + payload
+
+
+class MockXcpServer:
+    """Minimal XCP-on-Ethernet TCP server for integration testing."""
+
+    def __init__(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("127.0.0.1", 0))
+        self._server.listen(2)
+        self._server.settimeout(1.0)
+        self.port = self._server.getsockname()[1]
+        self._running = True
+        self._clients: list[socket.socket] = []
+        self._ctr = 0
+        self._memory: dict[int, bytes] = {}
+        self._mta_address = 0
+        self._mta_ext = 0
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._thread.start()
+
+    def _accept_loop(self):
+        while self._running:
+            try:
+                conn, _ = self._server.accept()
+                conn.settimeout(1.0)
+                self._clients.append(conn)
+                handler = threading.Thread(
+                    target=self._handle_client, args=(conn,), daemon=True
+                )
+                handler.start()
+            except OSError:
+                pass
+
+    def _handle_client(self, conn: socket.socket):
+        try:
+            while self._running:
+                try:
+                    hdr = self._recv_exact(conn, 4)
+                    if hdr is None:
+                        break
+                    length, _ctr = struct.unpack("<HH", hdr)
+                    payload = self._recv_exact(conn, length)
+                    if payload is None:
+                        break
+                    response = self._dispatch(payload)
+                    if response is not None:
+                        conn.sendall(response)
+                except OSError:
+                    break
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _recv_exact(conn: socket.socket, n: int) -> bytes | None:
+        data = b""
+        while len(data) < n:
+            chunk = conn.recv(n - len(data))
+            if not chunk:
+                return None
+            data += chunk
+        return data
+
+    def _make_response(self, payload: bytes) -> bytes:
+        self._ctr += 1
+        return _xcp_header(len(payload), self._ctr) + payload
+
+    def _make_error(self, err_code: int) -> bytes:
+        return self._make_response(bytes([RES_ERR, err_code]))
+
+    def _dispatch(self, payload: bytes) -> bytes | None:
+        if not payload:
+            return self._make_error(ERR_CMD_UNKNOWN)
+
+        cmd = payload[0]
+        handlers = {
+            CMD_CONNECT: self._handle_connect,
+            CMD_DISCONNECT: self._handle_disconnect,
+            CMD_GET_STATUS: self._handle_get_status,
+            CMD_GET_ID: self._handle_get_id,
+            CMD_SET_MTA: self._handle_set_mta,
+            CMD_SHORT_UPLOAD: self._handle_short_upload,
+            CMD_DOWNLOAD: self._handle_download,
+            CMD_BUILD_CHECKSUM: self._handle_build_checksum,
+            CMD_FREE_DAQ: self._handle_free_daq,
+            CMD_ALLOC_DAQ: self._handle_alloc_daq,
+            CMD_GET_DAQ_PROCESSOR_INFO: self._handle_daq_processor_info,
+            CMD_GET_DAQ_RESOLUTION_INFO: self._handle_daq_resolution_info,
+            CMD_PROGRAM_START: self._handle_program_start,
+            CMD_PROGRAM_CLEAR: self._handle_program_clear,
+            CMD_PROGRAM: self._handle_program,
+            CMD_PROGRAM_RESET: self._handle_program_reset,
+        }
+
+        handler = handlers.get(cmd)
+        if handler is None:
+            return self._make_error(ERR_CMD_UNKNOWN)
+        return handler(payload)
+
+    def _handle_connect(self, _payload: bytes) -> bytes:
+        # resource(B) commModeBasic(B) maxCto(B) maxDto(H) protVer(B) transVer(B)
+        resource = 0x01 | 0x04  # CAL/PAG + DAQ
+        comm_mode = 0x00  # little-endian, no block mode
+        resp = struct.pack(
+            "<BBBBBHBB",
+            RES_OK,
+            resource,
+            comm_mode,
+            0x00,  # reserved
+            MAX_CTO,
+            MAX_DTO,
+            0x01,  # protocol layer version
+            0x01,  # transport layer version
+        )
+        return self._make_response(resp)
+
+    def _handle_disconnect(self, _payload: bytes) -> bytes:
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_get_status(self, _payload: bytes) -> bytes:
+        # status(B) protectionStatus(B) configId(H)
+        resp = bytes([RES_OK, 0x00, 0x00, 0x00, 0x00, 0x00])
+        return self._make_response(resp)
+
+    def _handle_get_id(self, payload: bytes) -> bytes:
+        # Returns length then the ID string must be fetched with UPLOAD
+        id_bytes = SLAVE_ID
+        resp = struct.pack("<BBBBl", RES_OK, 0x00, 0x00, 0x00, len(id_bytes))
+        return self._make_response(resp)
+
+    def _handle_set_mta(self, payload: bytes) -> bytes:
+        if len(payload) >= 8:
+            self._mta_ext = payload[3]
+            self._mta_address = struct.unpack_from("<I", payload, 4)[0]
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_short_upload(self, payload: bytes) -> bytes:
+        if len(payload) < 8:
+            return self._make_error(ERR_OUT_OF_RANGE)
+        length = payload[1]
+        address = struct.unpack_from("<I", payload, 4)[0]
+        data = self._memory.get(address, b"\x00" * length)[:length]
+        data = data.ljust(length, b"\x00")
+        resp = bytes([RES_OK]) + data
+        return self._make_response(resp)
+
+    def _handle_download(self, payload: bytes) -> bytes:
+        if len(payload) < 2:
+            return self._make_error(ERR_OUT_OF_RANGE)
+        length = payload[1]
+        data = payload[2 : 2 + length]
+        self._memory[self._mta_address] = data
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_build_checksum(self, payload: bytes) -> bytes:
+        # Return a fixed checksum for testing
+        resp = struct.pack("<BBBxI", RES_OK, 0x01, 0x00, 0x0000DEAD)
+        return self._make_response(resp)
+
+    def _handle_free_daq(self, _payload: bytes) -> bytes:
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_alloc_daq(self, _payload: bytes) -> bytes:
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_daq_processor_info(self, _payload: bytes) -> bytes:
+        # daqProperties(B) maxDaq(H) maxEventChannel(H) minDaq(B) daqKeyByte(B)
+        resp = struct.pack("<BBHBHBB", RES_OK, 0x00, 4, 0, 2, 0, 0x00)
+        return self._make_response(resp)
+
+    def _handle_daq_resolution_info(self, _payload: bytes) -> bytes:
+        resp = struct.pack(
+            "<BBBBBBB",
+            RES_OK,
+            1,  # granularityOdtEntrySizeDaq
+            8,  # maxOdtEntrySizeDaq
+            1,  # granularityOdtEntrySizeStim
+            8,  # maxOdtEntrySizeStim
+            0x22,  # timestampMode
+            0x01,  # timestampTicks (low)
+        )
+        # pad to fill remaining timestamp ticks
+        resp += struct.pack("<H", 1)
+        return self._make_response(resp)
+
+    def _handle_program_start(self, _payload: bytes) -> bytes:
+        resp = struct.pack("<BBBBBBB", RES_OK, 0x00, MAX_CTO, 0, 0, 0, 0)
+        return self._make_response(resp)
+
+    def _handle_program_clear(self, _payload: bytes) -> bytes:
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_program(self, _payload: bytes) -> bytes:
+        return self._make_response(bytes([RES_OK]))
+
+    def _handle_program_reset(self, _payload: bytes) -> bytes:
+        return self._make_response(bytes([RES_OK]))
+
+    def stop(self):
+        self._running = False
+        self._server.close()
+        for c in self._clients:
+            try:
+                c.close()
+            except OSError:
+                pass
+        self._thread.join(timeout=3)
+
+
+@pytest.fixture
+def mock_xcp_server():
+    """Start a MockXcpServer on a dynamic port and yield the port number."""
+    server = MockXcpServer()
+    try:
+        yield server.port
+    finally:
+        server.stop()

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/conftest.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/conftest.py
@@ -278,3 +278,220 @@ def mock_xcp_server():
         yield server.port
     finally:
         server.stop()
+
+
+# =========================================================================
+# Stateful XCP mock master for comprehensive integration-style testing
+# =========================================================================
+
+
+class _SlaveProperties(dict):
+    """Mimics pyxcp's SlaveProperties (dict with attribute access)."""
+
+    def __getattr__(self, name: str):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __setattr__(self, name: str, value) -> None:
+        self[name] = value
+
+
+class XcpNotConnected(RuntimeError):
+    pass
+
+
+class XcpSequenceError(RuntimeError):
+    pass
+
+
+class StatefulXcpMaster:
+    """A drop-in replacement for pyxcp's Master that enforces XCP state rules.
+
+    Tracks connection state, simulated memory, MTA pointer,
+    DAQ list allocation, and programming sequence ordering.
+    """
+
+    SLAVE_ID = "XCP_STATEFUL_SIM_v2.0"
+    MAX_CTO = 8
+    MAX_DTO = 256
+
+    def __init__(self) -> None:
+        self._connected = False
+        self._memory: dict[int, bytes] = {}
+        self._mta_address = 0
+        self._mta_ext = 0
+        self._daq_lists = 0
+        self._daq_ptr: tuple[int, int, int] | None = None
+        self._programming = False
+        self._program_cleared = False
+        self._protection = {
+            "dbg": True,
+            "pgm": True,
+            "stim": False,
+            "daq": False,
+            "calpag": True,
+        }
+        self._unlocked = False
+
+        self.slaveProperties = _SlaveProperties(
+            maxCto=self.MAX_CTO,
+            maxDto=self.MAX_DTO,
+            byteOrder="INTEL",
+            supportsPgm=True,
+            supportsStim=False,
+            supportsDaq=True,
+            supportsCalpag=True,
+            protocolLayerVersion=1,
+            transportLayerVersion=1,
+            addressGranularity="BYTE",
+            slaveBlockMode=False,
+        )
+
+    def _require_connected(self):
+        if not self._connected:
+            raise XcpNotConnected("Not connected – call connect() first")
+
+    # -- session --------------------------------------------------------
+
+    def connect(self, mode: int = 0):
+        if self._connected:
+            return
+        self._connected = True
+
+    def close(self):
+        self._connected = False
+        self._programming = False
+        self._program_cleared = False
+
+    def identifier(self, id_value: int) -> str:
+        self._require_connected()
+        return self.SLAVE_ID
+
+    def getStatus(self):
+        self._require_connected()
+        status = _SlaveProperties(store_cal_req=False)
+        return status
+
+    def getCurrentProtectionStatus(self) -> dict[str, bool]:
+        return dict(self._protection)
+
+    # -- security -------------------------------------------------------
+
+    def cond_unlock(self, resources=None):
+        self._require_connected()
+        self._unlocked = True
+        for key in self._protection:
+            self._protection[key] = False
+
+    # -- memory access --------------------------------------------------
+
+    def setMta(self, address: int, ext: int = 0):
+        self._require_connected()
+        self._mta_address = address
+        self._mta_ext = ext
+
+    def shortUpload(self, length: int, address: int, ext: int = 0) -> bytes:
+        self._require_connected()
+        stored = self._memory.get(address, b"")
+        if len(stored) < length:
+            stored = stored + b"\x00" * (length - len(stored))
+        return stored[:length]
+
+    def download(self, data: bytes):
+        self._require_connected()
+        self._memory[self._mta_address] = data
+
+    # -- checksum -------------------------------------------------------
+
+    def buildChecksum(self, block_size: int):
+        self._require_connected()
+        raw = self._memory.get(self._mta_address, b"\x00" * block_size)[:block_size]
+        raw = raw.ljust(block_size, b"\x00")
+        csum = sum(raw) & 0xFFFFFFFF
+        return _SlaveProperties(checksumType=0x01, checksum=csum)
+
+    # -- DAQ ------------------------------------------------------------
+
+    def getDaqInfo(self):
+        self._require_connected()
+        return {
+            "processor": {"minDaq": 0, "maxDaq": max(self._daq_lists, 4)},
+            "resolution": {"timestampTicks": 1},
+            "channels": [],
+        }
+
+    def freeDaq(self):
+        self._require_connected()
+        self._daq_lists = 0
+        self._daq_ptr = None
+
+    def allocDaq(self, daq_count: int):
+        self._require_connected()
+        self._daq_lists = daq_count
+
+    def allocOdt(self, daq_list_number: int, odt_count: int):
+        self._require_connected()
+        if daq_list_number >= self._daq_lists:
+            raise RuntimeError(f"DAQ list {daq_list_number} not allocated")
+
+    def allocOdtEntry(self, daq_list_number: int, odt_number: int, odt_entries_count: int):
+        self._require_connected()
+
+    def setDaqPtr(self, daq_list: int, odt: int, entry: int):
+        self._require_connected()
+        self._daq_ptr = (daq_list, odt, entry)
+
+    def writeDaq(self, bit_offset: int, size: int, ext: int, address: int):
+        self._require_connected()
+        if self._daq_ptr is None:
+            raise XcpSequenceError("setDaqPtr must be called before writeDaq")
+
+    def setDaqListMode(self, mode: int, daq_list: int, event: int, prescaler: int, priority: int):
+        self._require_connected()
+
+    def startStopDaqList(self, mode: int, daq_list: int):
+        self._require_connected()
+
+    def startStopSynch(self, mode: int):
+        self._require_connected()
+
+    # -- programming ----------------------------------------------------
+
+    def programStart(self):
+        self._require_connected()
+        self._programming = True
+        self._program_cleared = False
+        return _SlaveProperties(
+            commModePgm=0, maxCtoPgm=self.MAX_CTO,
+            maxBsPgm=0, minStPgm=0, queueSizePgm=0,
+        )
+
+    def programClear(self, mode: int, clear_range: int):
+        self._require_connected()
+        if not self._programming:
+            raise XcpSequenceError("programStart must be called before programClear")
+        self._program_cleared = True
+        for addr in list(self._memory):
+            if addr < clear_range:
+                del self._memory[addr]
+
+    def program(self, data: bytes, block_length: int, last: bool = False):
+        self._require_connected()
+        if not self._programming:
+            raise XcpSequenceError("programStart must be called before program")
+        if not self._program_cleared:
+            raise XcpSequenceError("programClear must be called before program")
+        self._memory[self._mta_address] = data
+
+    def programReset(self, wait_for_optional_response: bool = True):
+        self._require_connected()
+        self._programming = False
+        self._program_cleared = False
+
+
+@pytest.fixture
+def stateful_master():
+    """Provide a fresh StatefulXcpMaster instance."""
+    return StatefulXcpMaster()

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/conftest.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/conftest.py
@@ -417,7 +417,8 @@ class StatefulXcpMaster:
     def getDaqInfo(self):
         self._require_connected()
         return {
-            "processor": {"minDaq": 0, "maxDaq": max(self._daq_lists, 4)},
+            # Hardware minimum of 4 DAQ lists, or actual allocation if larger
+            "processor": {"minDaq": 0, "maxDaq": max(4, self._daq_lists)},
             "resolution": {"timestampTicks": 1},
             "channels": [],
         }

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from dataclasses import field
+
+from pydantic import ConfigDict, validate_call
+from pydantic.dataclasses import dataclass
+
+from .common import (
+    XcpChecksum,
+    XcpConnectionInfo,
+    XcpDaqInfo,
+    XcpEthProtocol,
+    XcpIdentifier,
+    XcpProgramInfo,
+    XcpStatusResponse,
+    XcpTransport,
+)
+from jumpstarter.driver import Driver, export
+
+
+def _build_config_content(
+    transport: XcpTransport,
+    host: str | None,
+    port: int,
+    protocol: XcpEthProtocol,
+    can_interface: str | None,
+    channel: str | int | None,
+    bitrate: int | None,
+    can_id_master: int | None,
+    can_id_slave: int | None,
+) -> str:
+    lines = ["c = get_config()"]
+    lines.append(f'c.Transport.layer = "{transport.value}"')
+
+    if transport == XcpTransport.ETH:
+        if host:
+            lines.append(f'c.Transport.Eth.host = "{host}"')
+        lines.append(f"c.Transport.Eth.port = {port}")
+        lines.append(f'c.Transport.Eth.protocol = "{protocol.value}"')
+    elif transport == XcpTransport.CAN:
+        if can_interface:
+            lines.append(f'c.Transport.Can.interface = "{can_interface}"')
+        if channel is not None:
+            lines.append(f"c.Transport.Can.channel = {channel}")
+        if bitrate is not None:
+            lines.append(f"c.Transport.Can.bitrate = {bitrate}")
+        if can_id_master is not None:
+            lines.append(f"c.Transport.Can.can_id_master = {can_id_master}")
+        if can_id_slave is not None:
+            lines.append(f"c.Transport.Can.can_id_slave = {can_id_slave}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _create_xcp_master(
+    transport: XcpTransport,
+    config_file: str | None,
+    host: str | None,
+    port: int,
+    protocol: XcpEthProtocol,
+    can_interface: str | None,
+    channel: str | int | None,
+    bitrate: int | None,
+    can_id_master: int | None,
+    can_id_slave: int | None,
+):
+    """Create a pyxcp Master instance from driver parameters.
+
+    Uses pyxcp's ArgumentParser with a generated or user-provided config file.
+    sys.argv is temporarily overridden to pass transport arguments.
+    """
+    from pyxcp.cmdline import ArgumentParser as XcpArgumentParser
+
+    tmp_path = None
+    try:
+        if config_file is None:
+            content = _build_config_content(
+                transport, host, port, protocol,
+                can_interface, channel, bitrate, can_id_master, can_id_slave,
+            )
+            fd, tmp_path = tempfile.mkstemp(suffix=".py", prefix="xcp_cfg_")
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            cfg_path = tmp_path
+        else:
+            cfg_path = config_file
+
+        saved_argv = sys.argv
+        sys.argv = [
+            "jumpstarter-xcp",
+            "-t", transport.value.lower(),
+            "--config", cfg_path,
+        ]
+        try:
+            ap = XcpArgumentParser(description="Jumpstarter XCP Driver")
+            master = ap.run()
+        finally:
+            sys.argv = saved_argv
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    return master
+
+
+@dataclass(kw_only=True, config=ConfigDict(arbitrary_types_allowed=True))
+class Xcp(Driver):
+    """XCP (Universal Measurement and Calibration Protocol) driver.
+
+    Wraps the pyXCP library to provide remote access to XCP-enabled
+    devices (ECUs) for measurement, calibration, DAQ, and programming.
+    """
+
+    transport: XcpTransport = XcpTransport.ETH
+    host: str | None = "localhost"
+    port: int = 5555
+    protocol: XcpEthProtocol = XcpEthProtocol.TCP
+    can_interface: str | None = None
+    channel: str | int | None = None
+    bitrate: int | None = None
+    can_id_master: int | None = None
+    can_id_slave: int | None = None
+    config_file: str | None = None
+
+    _master: object = field(init=False, repr=False, default=None)
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_xcp.client.XcpClient"
+
+    def _ensure_master(self):
+        if self._master is None:
+            self._master = _create_xcp_master(
+                transport=self.transport,
+                config_file=self.config_file,
+                host=self.host,
+                port=self.port,
+                protocol=self.protocol,
+                can_interface=self.can_interface,
+                channel=self.channel,
+                bitrate=self.bitrate,
+                can_id_master=self.can_id_master,
+                can_id_slave=self.can_id_slave,
+            )
+
+    # --- Session Management ---
+
+    @export
+    @validate_call(validate_return=True)
+    def connect(self, mode: int = 0) -> XcpConnectionInfo:
+        """Connect to the XCP slave and return negotiated properties."""
+        self._ensure_master()
+        self._master.connect(mode)
+        sp = self._master.slaveProperties
+        return XcpConnectionInfo(
+            max_cto=sp.get("maxCto", 0),
+            max_dto=sp.get("maxDto", 0),
+            byte_order=str(sp.get("byteOrder", "")),
+            supports_pgm=sp.get("supportsPgm", False),
+            supports_stim=sp.get("supportsStim", False),
+            supports_daq=sp.get("supportsDaq", False),
+            supports_calpag=sp.get("supportsCalpag", False),
+            protocol_layer_version=sp.get("protocolLayerVersion", 0),
+            transport_layer_version=sp.get("transportLayerVersion", 0),
+            address_granularity=str(sp.get("addressGranularity", "")),
+            slave_block_mode=sp.get("slaveBlockMode", False),
+        )
+
+    @export
+    @validate_call(validate_return=True)
+    def disconnect(self) -> None:
+        """Disconnect from the XCP slave."""
+        if self._master is not None:
+            self._master.close()
+            self._master = None
+
+    @export
+    @validate_call(validate_return=True)
+    def get_id(self, id_type: int = 1) -> XcpIdentifier:
+        """Get the slave identifier string."""
+        self._ensure_master()
+        result = self._master.identifier(id_type)
+        return XcpIdentifier(id_type=id_type, identifier=str(result))
+
+    @export
+    @validate_call(validate_return=True)
+    def get_status(self) -> XcpStatusResponse:
+        """Get the current session status and resource protection."""
+        self._ensure_master()
+        status = self._master.getStatus()
+        protection = self._master.getCurrentProtectionStatus()
+        return XcpStatusResponse(
+            session_status={
+                k: v for k, v in status.items()
+                if isinstance(v, (bool, int, str))
+            } if hasattr(status, "items") else {},
+            resource_protection=protection if isinstance(protection, dict) else {},
+        )
+
+    # --- Security ---
+
+    @export
+    @validate_call(validate_return=True)
+    def unlock(self, resources: list[str] | None = None) -> dict[str, bool]:
+        """Perform conditional unlock (seed & key) for protected resources.
+
+        Uses the seed-n-key function/DLL configured in the pyxcp config.
+        Returns the current protection status after the unlock attempt.
+        """
+        self._ensure_master()
+        self._master.cond_unlock(resources)
+        return self._master.getCurrentProtectionStatus()
+
+    # --- Memory Access (Measurement / Calibration) ---
+
+    @export
+    @validate_call(validate_return=True)
+    def upload(self, length: int, address: int, ext: int = 0) -> bytes:
+        """Read memory from the XCP slave (short upload)."""
+        self._ensure_master()
+        data = self._master.shortUpload(length, address, ext)
+        return bytes(data)
+
+    @export
+    @validate_call(validate_return=True)
+    def download(self, address: int, data: bytes, ext: int = 0) -> None:
+        """Write data to the XCP slave memory."""
+        self._ensure_master()
+        self._master.setMta(address, ext)
+        self._master.download(data)
+
+    @export
+    @validate_call(validate_return=True)
+    def set_mta(self, address: int, ext: int = 0) -> None:
+        """Set the Memory Transfer Address pointer."""
+        self._ensure_master()
+        self._master.setMta(address, ext)
+
+    @export
+    @validate_call(validate_return=True)
+    def build_checksum(self, block_size: int) -> XcpChecksum:
+        """Compute a checksum over a memory block (starting at current MTA)."""
+        self._ensure_master()
+        result = self._master.buildChecksum(block_size)
+        return XcpChecksum(
+            checksum_type=result.checksumType if hasattr(result, "checksumType") else 0,
+            checksum_value=result.checksum if hasattr(result, "checksum") else 0,
+        )
+
+    # --- DAQ (Data Acquisition) ---
+
+    @export
+    @validate_call(validate_return=True)
+    def get_daq_info(self) -> XcpDaqInfo:
+        """Get DAQ processor, resolution, and event channel information."""
+        self._ensure_master()
+        info = self._master.getDaqInfo()
+        return XcpDaqInfo(
+            processor=info.get("processor", {}),
+            resolution=info.get("resolution", {}),
+            channels=info.get("channels", []),
+        )
+
+    @export
+    @validate_call(validate_return=True)
+    def free_daq(self) -> None:
+        """Free all DAQ lists."""
+        self._ensure_master()
+        self._master.freeDaq()
+
+    @export
+    @validate_call(validate_return=True)
+    def alloc_daq(self, daq_count: int) -> None:
+        """Allocate DAQ lists."""
+        self._ensure_master()
+        self._master.allocDaq(daq_count)
+
+    @export
+    @validate_call(validate_return=True)
+    def alloc_odt(self, daq_list_number: int, odt_count: int) -> None:
+        """Allocate ODTs for a DAQ list."""
+        self._ensure_master()
+        self._master.allocOdt(daq_list_number, odt_count)
+
+    @export
+    @validate_call(validate_return=True)
+    def alloc_odt_entry(
+        self, daq_list_number: int, odt_number: int, odt_entries_count: int
+    ) -> None:
+        """Allocate ODT entries for a specific ODT."""
+        self._ensure_master()
+        self._master.allocOdtEntry(daq_list_number, odt_number, odt_entries_count)
+
+    @export
+    @validate_call(validate_return=True)
+    def set_daq_ptr(self, daq_list: int, odt: int, entry: int) -> None:
+        """Set the DAQ list pointer."""
+        self._ensure_master()
+        self._master.setDaqPtr(daq_list, odt, entry)
+
+    @export
+    @validate_call(validate_return=True)
+    def write_daq(
+        self, bit_offset: int, size: int, ext: int, address: int
+    ) -> None:
+        """Write a DAQ entry (configure what to measure)."""
+        self._ensure_master()
+        self._master.writeDaq(bit_offset, size, ext, address)
+
+    @export
+    @validate_call(validate_return=True)
+    def set_daq_list_mode(
+        self, mode: int, daq_list: int, event: int, prescaler: int, priority: int
+    ) -> None:
+        """Set the mode for a DAQ list."""
+        self._ensure_master()
+        self._master.setDaqListMode(mode, daq_list, event, prescaler, priority)
+
+    @export
+    @validate_call(validate_return=True)
+    def start_stop_daq_list(self, mode: int, daq_list: int) -> None:
+        """Start or stop a single DAQ list."""
+        self._ensure_master()
+        self._master.startStopDaqList(mode, daq_list)
+
+    @export
+    @validate_call(validate_return=True)
+    def start_stop_synch(self, mode: int) -> None:
+        """Start or stop all DAQ lists synchronously."""
+        self._ensure_master()
+        self._master.startStopSynch(mode)
+
+    # --- Programming (Flashing) ---
+
+    @export
+    @validate_call(validate_return=True)
+    def program_start(self) -> XcpProgramInfo:
+        """Begin a programming sequence."""
+        self._ensure_master()
+        result = self._master.programStart()
+        return XcpProgramInfo(
+            comm_mode_pgm=getattr(result, "commModePgm", 0),
+            max_cto_pgm=getattr(result, "maxCtoPgm", 0),
+            max_bs_pgm=getattr(result, "maxBsPgm", 0),
+            min_st_pgm=getattr(result, "minStPgm", 0),
+            queue_size_pgm=getattr(result, "queueSizePgm", 0),
+        )
+
+    @export
+    @validate_call(validate_return=True)
+    def program_clear(self, clear_range: int, mode: int = 0) -> None:
+        """Clear (erase) a memory range for programming."""
+        self._ensure_master()
+        self._master.programClear(mode, clear_range)
+
+    @export
+    @validate_call(validate_return=True)
+    def program(self, data: bytes, block_length: int = 0) -> None:
+        """Download program data to the slave."""
+        self._ensure_master()
+        self._master.program(data, block_length or len(data))
+
+    @export
+    @validate_call(validate_return=True)
+    def program_reset(self) -> None:
+        """Reset the slave after programming."""
+        self._ensure_master()
+        self._master.programReset()

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver.py
@@ -71,6 +71,12 @@ def _create_xcp_master(
 
     Uses pyxcp's ArgumentParser with a generated or user-provided config file.
     sys.argv is temporarily overridden to pass transport arguments.
+
+    WARNING: This function is NOT thread-safe. pyxcp's ArgumentParser mutates
+    process-global state (sys.argv, internal singletons via .run()). Callers
+    must serialize access or ensure only one driver is created at a time.
+    For programmatic, thread-safe creation consider using
+    ``pyxcp.config.create_application_from_config()`` instead.
     """
     from pyxcp.cmdline import ArgumentParser as XcpArgumentParser
 

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
@@ -408,24 +408,6 @@ def test_custom_config_forwarded(mock_create):
         client.connect()
 
     mock_create.assert_called_once()
-    call_kwargs = mock_create.call_args
-    args = call_kwargs.kwargs if call_kwargs.kwargs else {}
-    if not args:
-        args = {
-            "transport": call_kwargs[1].get("transport", call_kwargs[0][0] if call_kwargs[0] else None),
-        }
-        # Extract from positional/keyword args
-        keys = [
-            "transport", "config_file", "host", "port", "protocol",
-            "can_interface", "channel", "bitrate", "can_id_master", "can_id_slave",
-        ]
-        for i, key in enumerate(keys):
-            if i < len(call_kwargs[0]):
-                args[key] = call_kwargs[0][i]
-            elif key in (call_kwargs[1] if len(call_kwargs) > 1 and call_kwargs[1] else {}):
-                args[key] = call_kwargs[1][key]
-
-    # The call should use the CAN transport with our specific params
     actual_kwargs = mock_create.call_args.kwargs
     assert actual_kwargs["can_interface"] == "vector"
     assert actual_kwargs["channel"] == 0

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
@@ -435,10 +435,278 @@ def test_custom_config_forwarded(mock_create):
 
 
 # =============================================================================
-# Integration tests with simulated XCP server
-# (These use the mock_xcp_server fixture from conftest.py but require
-# pyxcp to actually connect. They are currently skipped because pyxcp's
-# Master + ArgumentParser flow needs a full traitlets config setup that
-# is complex to wire in a test. The mock-based tests above provide
-# equivalent coverage through the gRPC boundary.)
+# Stateful integration tests
+#
+# These use a StatefulXcpMaster (conftest.py) that behaves like a real
+# XCP ECU: it tracks connection state, memory, MTA pointer, DAQ
+# allocation, and programming sequence.  Each test exercises a realistic
+# multi-step workflow through the full gRPC boundary.
 # =============================================================================
+
+
+def _stateful_client_ctx(stateful_master):
+    """Context manager helper: serve() an Xcp driver backed by the stateful mock."""
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=stateful_master,
+    ):
+        with serve(instance) as c:
+            yield c
+
+
+@pytest.fixture
+def stateful_client(stateful_master):
+    yield from _stateful_client_ctx(stateful_master)
+
+
+# -- session & identification --------------------------------------------------
+
+
+def test_stateful_connect_disconnect(stateful_client, stateful_master):
+    info = stateful_client.connect()
+    assert info.max_cto == 8
+    assert info.max_dto == 256
+    assert info.byte_order == "INTEL"
+    assert stateful_master._connected is True
+
+    stateful_client.disconnect()
+    assert stateful_master._connected is False
+
+
+def test_stateful_get_id_after_connect(stateful_client):
+    stateful_client.connect()
+    result = stateful_client.get_id(1)
+    assert result.identifier == "XCP_STATEFUL_SIM_v2.0"
+
+
+def test_stateful_get_status_shows_protection(stateful_client):
+    stateful_client.connect()
+    status = stateful_client.get_status()
+    assert status.resource_protection["pgm"] is True
+    assert status.resource_protection["calpag"] is True
+    assert status.resource_protection["daq"] is False
+
+
+# -- unlock flow ---------------------------------------------------------------
+
+
+def test_stateful_unlock_clears_protection(stateful_client):
+    stateful_client.connect()
+    result = stateful_client.unlock()
+    assert result["pgm"] is False
+    assert result["calpag"] is False
+    assert result["dbg"] is False
+
+
+# -- memory read / write round-trip -------------------------------------------
+
+
+def test_stateful_download_then_upload(stateful_client):
+    """Write data to an address and read it back — verifies memory state."""
+    stateful_client.connect()
+    stateful_client.download(0x1000, b"\x0C\x0A", 0)
+
+    data = stateful_client.upload(2, 0x1000, 0)
+    raw = bytes(data, "latin-1") if isinstance(data, str) else data
+    assert raw == b"\x0C\x0A"
+
+
+def test_stateful_upload_unwritten_address_returns_zeros(stateful_client):
+    stateful_client.connect()
+    data = stateful_client.upload(4, 0x9999, 0)
+    raw = bytes(data, "latin-1") if isinstance(data, str) else data
+    assert raw == b"\x00\x00\x00\x00"
+
+
+def test_stateful_overwrite_memory(stateful_client):
+    """Download twice to the same address — second write wins."""
+    stateful_client.connect()
+    stateful_client.download(0x2000, b"\x11\x22", 0)
+    stateful_client.download(0x2000, b"\x33\x44", 0)
+
+    data = stateful_client.upload(2, 0x2000, 0)
+    raw = bytes(data, "latin-1") if isinstance(data, str) else data
+    assert raw == b"\x33\x44"
+
+
+def test_stateful_multiple_addresses(stateful_client):
+    """Write to different addresses and verify each independently."""
+    stateful_client.connect()
+    stateful_client.download(0x1000, b"\x01", 0)
+    stateful_client.download(0x2000, b"\x02", 0)
+    stateful_client.download(0x3000, b"\x03", 0)
+
+    for addr, expected in [(0x1000, b"\x01"), (0x2000, b"\x02"), (0x3000, b"\x03")]:
+        data = stateful_client.upload(1, addr, 0)
+        raw = bytes(data, "latin-1") if isinstance(data, str) else data
+        assert raw == expected, f"Mismatch at 0x{addr:X}"
+
+
+# -- checksum ------------------------------------------------------------------
+
+
+def test_stateful_checksum_over_written_data(stateful_client):
+    stateful_client.connect()
+    stateful_client.download(0x4000, b"\x01\x02\x03\x04", 0)
+
+    stateful_client.set_mta(0x4000, 0)
+    result = stateful_client.build_checksum(4)
+    assert result.checksum_type == 1
+    assert result.checksum_value == 0x01 + 0x02 + 0x03 + 0x04
+
+
+# -- DAQ allocation workflow ---------------------------------------------------
+
+
+def test_stateful_daq_alloc_flow(stateful_client, stateful_master):
+    stateful_client.connect()
+
+    info = stateful_client.get_daq_info()
+    assert info.processor["maxDaq"] >= 4
+
+    stateful_client.free_daq()
+    assert stateful_master._daq_lists == 0
+
+    stateful_client.alloc_daq(3)
+    assert stateful_master._daq_lists == 3
+
+    stateful_client.alloc_odt(0, 2)
+    stateful_client.alloc_odt_entry(0, 0, 4)
+
+    stateful_client.set_daq_ptr(0, 0, 0)
+    assert stateful_master._daq_ptr == (0, 0, 0)
+
+    stateful_client.write_daq(0xFF, 4, 0, 0x1000)
+    stateful_client.set_daq_list_mode(0x10, 0, 1, 1, 0)
+    stateful_client.start_stop_daq_list(1, 0)
+    stateful_client.start_stop_synch(1)
+
+    stateful_client.start_stop_synch(0)
+    stateful_client.free_daq()
+    assert stateful_master._daq_lists == 0
+
+
+# -- programming sequence -----------------------------------------------------
+
+
+def test_stateful_full_programming_flow(stateful_client, stateful_master):
+    """Exercise the complete flash-programming lifecycle."""
+    stateful_client.connect()
+
+    # Pre-load memory that will be cleared
+    stateful_client.download(0x0000, b"\x7F" * 16, 0)
+
+    info = stateful_client.program_start()
+    assert info.max_cto_pgm == 8
+    assert stateful_master._programming is True
+
+    stateful_client.program_clear(0x10000)
+    assert stateful_master._program_cleared is True
+    # Memory below clear_range should be wiped
+    data = stateful_client.upload(4, 0x0000, 0)
+    raw = bytes(data, "latin-1") if isinstance(data, str) else data
+    assert raw == b"\x00\x00\x00\x00"
+
+    # Program new data
+    stateful_client.set_mta(0x0000, 0)
+    stateful_client.program(b"\x0D\x0A", block_length=2)
+
+    # Verify programmed data is in memory
+    data = stateful_client.upload(2, 0x0000, 0)
+    raw = bytes(data, "latin-1") if isinstance(data, str) else data
+    assert raw == b"\x0D\x0A"
+
+    stateful_client.program_reset()
+    assert stateful_master._programming is False
+
+    stateful_client.disconnect()
+    assert stateful_master._connected is False
+
+
+def test_stateful_program_clear_before_start_raises(stateful_master):
+    """programClear without programStart should fail."""
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=stateful_master,
+    ):
+        with serve(instance) as c:
+            c.connect()
+            with pytest.raises(DriverError, match="programStart must be called"):
+                c.program_clear(0x10000)
+
+
+def test_stateful_program_before_clear_raises(stateful_master):
+    """program without programClear should fail."""
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=stateful_master,
+    ):
+        with serve(instance) as c:
+            c.connect()
+            c.program_start()
+            with pytest.raises(DriverError, match="programClear must be called"):
+                c.program(b"\x00" * 8)
+
+
+# -- end-to-end calibration workflow ------------------------------------------
+
+
+def test_stateful_calibration_workflow(stateful_client):
+    """Simulate a typical calibration session: connect, unlock, read,
+    modify, write-back, verify, disconnect."""
+    stateful_client.connect()
+    stateful_client.unlock()
+
+    # Initial state: zeros
+    orig = stateful_client.upload(4, 0x5000, 0)
+    raw_orig = bytes(orig, "latin-1") if isinstance(orig, str) else orig
+    assert raw_orig == b"\x00\x00\x00\x00"
+
+    # Calibrate: write a new parameter value
+    stateful_client.download(0x5000, b"\x42\x00\x00\x00", 0)
+
+    # Read back and verify
+    modified = stateful_client.upload(4, 0x5000, 0)
+    raw_mod = bytes(modified, "latin-1") if isinstance(modified, str) else modified
+    assert raw_mod == b"\x42\x00\x00\x00"
+
+    # Checksum verification
+    stateful_client.set_mta(0x5000, 0)
+    csum = stateful_client.build_checksum(4)
+    assert csum.checksum_value == 0x42
+
+    stateful_client.disconnect()
+
+
+# -- connect-required enforcement ---------------------------------------------
+
+
+def test_stateful_operations_before_connect_raise(stateful_master):
+    """Methods called before connect() should fail."""
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=stateful_master,
+    ):
+        with serve(instance) as c:
+            with pytest.raises(DriverError, match="Not connected"):
+                c.get_id()
+
+
+def test_stateful_reconnect_after_disconnect(stateful_client, stateful_master):
+    """After disconnect, a new connect should succeed and reset state."""
+    stateful_client.connect()
+    stateful_client.download(0x7000, b"\x7F", 0)
+    stateful_client.disconnect()
+    assert stateful_master._connected is False
+
+    stateful_client.connect()
+    assert stateful_master._connected is True
+
+    # Memory persists across reconnect (simulates non-volatile storage)
+    data = stateful_client.upload(1, 0x7000, 0)
+    raw = bytes(data, "latin-1") if isinstance(data, str) else data
+    assert raw == b"\x7F"

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
@@ -1,0 +1,444 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from .driver import Xcp
+from jumpstarter.client.core import DriverError
+from jumpstarter.common.utils import serve
+
+
+def _make_mock_master():
+    """Create a mock pyxcp Master with realistic return values."""
+    master = MagicMock()
+
+    master.slaveProperties = {
+        "maxCto": 8,
+        "maxDto": 8,
+        "byteOrder": "INTEL",
+        "supportsPgm": True,
+        "supportsStim": False,
+        "supportsDaq": True,
+        "supportsCalpag": True,
+        "protocolLayerVersion": 1,
+        "transportLayerVersion": 1,
+        "addressGranularity": "BYTE",
+        "slaveBlockMode": False,
+    }
+
+    master.connect.return_value = MagicMock()
+    master.identifier.return_value = "XCP_TEST_SLAVE_v1.0"
+    master.shortUpload.return_value = b"\x01\x02\x03\x04"
+    master.buildChecksum.return_value = MagicMock(checksumType=1, checksum=0xDEAD)
+    master.getDaqInfo.return_value = {
+        "processor": {"minDaq": 0, "maxDaq": 4},
+        "resolution": {"timestampTicks": 1},
+        "channels": [],
+    }
+    master.programStart.return_value = MagicMock(
+        commModePgm=0, maxCtoPgm=8, maxBsPgm=0, minStPgm=0, queueSizePgm=0,
+    )
+
+    status_mock = MagicMock()
+    status_mock.items.return_value = [("store_cal_req", False)]
+    master.getStatus.return_value = status_mock
+    master.getCurrentProtectionStatus.return_value = {
+        "dbg": False, "pgm": False, "stim": False, "daq": False, "calpag": False,
+    }
+
+    return master
+
+
+@pytest.fixture
+def mock_master():
+    return _make_mock_master()
+
+
+@pytest.fixture
+def client(mock_master):
+    instance = Xcp(
+        transport="ETH",
+        host="127.0.0.1",
+        port=5555,
+        protocol="TCP",
+    )
+
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            yield client
+
+
+# =============================================================================
+# Happy-path tests
+# =============================================================================
+
+
+def test_connect(client, mock_master):
+    info = client.connect()
+    assert info.max_cto == 8
+    assert info.max_dto == 8
+    assert info.byte_order == "INTEL"
+    assert info.supports_daq is True
+    assert info.supports_calpag is True
+    assert info.supports_pgm is True
+    assert info.supports_stim is False
+    mock_master.connect.assert_called_once_with(0)
+
+
+def test_connect_with_mode(client, mock_master):
+    client.connect(mode=1)
+    mock_master.connect.assert_called_once_with(1)
+
+
+def test_disconnect(client, mock_master):
+    client.connect()
+    client.disconnect()
+    mock_master.close.assert_called_once()
+
+
+def test_get_id(client, mock_master):
+    client.connect()
+    result = client.get_id(1)
+    assert result.identifier == "XCP_TEST_SLAVE_v1.0"
+    assert result.id_type == 1
+    mock_master.identifier.assert_called_once_with(1)
+
+
+def test_get_id_custom_type(client, mock_master):
+    client.connect()
+    client.get_id(0)
+    mock_master.identifier.assert_called_once_with(0)
+
+
+def test_get_status(client, mock_master):
+    client.connect()
+    status = client.get_status()
+    assert isinstance(status.resource_protection, dict)
+    assert status.resource_protection["pgm"] is False
+    assert status.resource_protection["daq"] is False
+    mock_master.getStatus.assert_called_once()
+    mock_master.getCurrentProtectionStatus.assert_called()
+
+
+def test_upload(client, mock_master):
+    client.connect()
+    data = client.upload(4, 0x1000, 0)
+    assert bytes(data, "latin-1") if isinstance(data, str) else data == b"\x01\x02\x03\x04"
+    mock_master.shortUpload.assert_called_once_with(4, 0x1000, 0)
+
+
+def test_download(client, mock_master):
+    client.connect()
+    client.download(0x2000, b"\x01\x02", 0)
+    mock_master.setMta.assert_called_once_with(0x2000, 0)
+    mock_master.download.assert_called_once_with(b"\x01\x02")
+
+
+def test_set_mta(client, mock_master):
+    client.connect()
+    client.set_mta(0x3000, 1)
+    mock_master.setMta.assert_called_once_with(0x3000, 1)
+
+
+def test_build_checksum(client, mock_master):
+    client.connect()
+    client.set_mta(0x1000, 0)
+    result = client.build_checksum(256)
+    assert result.checksum_type == 1
+    assert result.checksum_value == 0xDEAD
+    mock_master.buildChecksum.assert_called_once_with(256)
+
+
+def test_get_daq_info(client, mock_master):
+    client.connect()
+    info = client.get_daq_info()
+    assert info.processor["minDaq"] == 0
+    assert info.processor["maxDaq"] == 4
+    assert info.resolution["timestampTicks"] == 1
+    assert info.channels == []
+    mock_master.getDaqInfo.assert_called_once()
+
+
+def test_free_daq(client, mock_master):
+    client.connect()
+    client.free_daq()
+    mock_master.freeDaq.assert_called_once()
+
+
+def test_alloc_daq(client, mock_master):
+    client.connect()
+    client.alloc_daq(2)
+    mock_master.allocDaq.assert_called_once_with(2)
+
+
+def test_alloc_odt(client, mock_master):
+    client.connect()
+    client.alloc_odt(0, 3)
+    mock_master.allocOdt.assert_called_once_with(0, 3)
+
+
+def test_alloc_odt_entry(client, mock_master):
+    client.connect()
+    client.alloc_odt_entry(0, 1, 4)
+    mock_master.allocOdtEntry.assert_called_once_with(0, 1, 4)
+
+
+def test_set_daq_ptr(client, mock_master):
+    client.connect()
+    client.set_daq_ptr(0, 0, 0)
+    mock_master.setDaqPtr.assert_called_once_with(0, 0, 0)
+
+
+def test_write_daq(client, mock_master):
+    client.connect()
+    client.write_daq(0xFF, 4, 0, 0x1000)
+    mock_master.writeDaq.assert_called_once_with(0xFF, 4, 0, 0x1000)
+
+
+def test_set_daq_list_mode(client, mock_master):
+    client.connect()
+    client.set_daq_list_mode(0x10, 0, 1, 1, 0)
+    mock_master.setDaqListMode.assert_called_once_with(0x10, 0, 1, 1, 0)
+
+
+def test_start_stop_daq_list(client, mock_master):
+    client.connect()
+    client.start_stop_daq_list(1, 0)
+    mock_master.startStopDaqList.assert_called_once_with(1, 0)
+
+
+def test_start_stop_synch(client, mock_master):
+    client.connect()
+    client.start_stop_synch(1)
+    mock_master.startStopSynch.assert_called_once_with(1)
+
+
+def test_program_start(client, mock_master):
+    client.connect()
+    info = client.program_start()
+    assert info.max_cto_pgm == 8
+    assert info.comm_mode_pgm == 0
+    mock_master.programStart.assert_called_once()
+
+
+def test_program_clear(client, mock_master):
+    client.connect()
+    client.program_clear(0x10000, mode=0)
+    mock_master.programClear.assert_called_once_with(0, 0x10000)
+
+
+def test_program(client, mock_master):
+    client.connect()
+    data = b"\x00" * 64
+    client.program(data, block_length=64)
+    mock_master.program.assert_called_once_with(data, 64)
+
+
+def test_program_reset(client, mock_master):
+    client.connect()
+    client.program_reset()
+    mock_master.programReset.assert_called_once()
+
+
+def test_program_full_flow(client, mock_master):
+    """Test a complete programming sequence end-to-end."""
+    client.connect()
+    client.program_start()
+    client.program_clear(0x10000)
+    client.program(b"\x00" * 64)
+    client.program_reset()
+    mock_master.programStart.assert_called_once()
+    mock_master.programClear.assert_called_once()
+    mock_master.program.assert_called_once()
+    mock_master.programReset.assert_called_once()
+
+
+def test_unlock(client, mock_master):
+    client.connect()
+    result = client.unlock()
+    assert isinstance(result, dict)
+    assert "pgm" in result
+    assert result["pgm"] is False
+    mock_master.cond_unlock.assert_called_once_with(None)
+
+
+def test_unlock_with_resources(client, mock_master):
+    client.connect()
+    client.unlock(resources=["pgm", "daq"])
+    mock_master.cond_unlock.assert_called_once_with(["pgm", "daq"])
+
+
+# =============================================================================
+# Error-path tests
+# =============================================================================
+
+
+def test_connect_timeout(mock_master):
+    mock_master.connect.side_effect = TimeoutError("No response from ECU")
+
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            with pytest.raises(DriverError, match="No response from ECU"):
+                client.connect()
+
+
+def test_upload_error(mock_master):
+    mock_master.shortUpload.side_effect = RuntimeError("XCP ERR_ACCESS_DENIED")
+
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="ERR_ACCESS_DENIED"):
+                client.upload(4, 0x1000, 0)
+
+
+def test_download_error(mock_master):
+    mock_master.download.side_effect = RuntimeError("XCP ERR_OUT_OF_RANGE")
+
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="ERR_OUT_OF_RANGE"):
+                client.download(0x2000, b"\x01\x02", 0)
+
+
+def test_program_clear_error(mock_master):
+    mock_master.programClear.side_effect = RuntimeError("Erase failed")
+
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="Erase failed"):
+                client.program_clear(0x10000)
+
+
+def test_unlock_error(mock_master):
+    mock_master.cond_unlock.side_effect = RuntimeError("Seed & key failed")
+
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="Seed & key failed"):
+                client.unlock()
+
+
+def test_get_daq_info_error(mock_master):
+    mock_master.getDaqInfo.side_effect = RuntimeError("DAQ not supported")
+
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    with patch(
+        "jumpstarter_driver_xcp.driver._create_xcp_master",
+        return_value=mock_master,
+    ):
+        with serve(instance) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="DAQ not supported"):
+                client.get_daq_info()
+
+
+# =============================================================================
+# Config validation tests
+# =============================================================================
+
+
+def test_invalid_transport_type():
+    with pytest.raises(ValidationError):
+        Xcp(transport="INVALID", host="127.0.0.1", port=5555)
+
+
+def test_invalid_protocol_type():
+    with pytest.raises(ValidationError):
+        Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="INVALID")
+
+
+def test_invalid_port_type():
+    with pytest.raises(ValidationError):
+        Xcp(transport="ETH", host="127.0.0.1", port="not_a_port")
+
+
+def test_default_config_values():
+    instance = Xcp()
+    assert instance.transport.value == "ETH"
+    assert instance.host == "localhost"
+    assert instance.port == 5555
+    assert instance.protocol.value == "TCP"
+    assert instance.can_interface is None
+    assert instance.channel is None
+    assert instance.bitrate is None
+    assert instance.config_file is None
+
+
+@patch("jumpstarter_driver_xcp.driver._create_xcp_master")
+def test_custom_config_forwarded(mock_create):
+    """Verify non-default config values are used to create the master."""
+    mock_create.return_value = _make_mock_master()
+
+    instance = Xcp(
+        transport="CAN",
+        can_interface="vector",
+        channel=0,
+        bitrate=500000,
+        can_id_master=0x7E0,
+        can_id_slave=0x7E1,
+    )
+    with serve(instance) as client:
+        client.connect()
+
+    mock_create.assert_called_once()
+    call_kwargs = mock_create.call_args
+    args = call_kwargs.kwargs if call_kwargs.kwargs else {}
+    if not args:
+        args = {
+            "transport": call_kwargs[1].get("transport", call_kwargs[0][0] if call_kwargs[0] else None),
+        }
+        # Extract from positional/keyword args
+        keys = [
+            "transport", "config_file", "host", "port", "protocol",
+            "can_interface", "channel", "bitrate", "can_id_master", "can_id_slave",
+        ]
+        for i, key in enumerate(keys):
+            if i < len(call_kwargs[0]):
+                args[key] = call_kwargs[0][i]
+            elif key in (call_kwargs[1] if len(call_kwargs) > 1 and call_kwargs[1] else {}):
+                args[key] = call_kwargs[1][key]
+
+    # The call should use the CAN transport with our specific params
+    actual_kwargs = mock_create.call_args.kwargs
+    assert actual_kwargs["can_interface"] == "vector"
+    assert actual_kwargs["channel"] == 0
+    assert actual_kwargs["bitrate"] == 500000
+    assert actual_kwargs["can_id_master"] == 0x7E0
+    assert actual_kwargs["can_id_slave"] == 0x7E1
+
+
+# =============================================================================
+# Integration tests with simulated XCP server
+# (These use the mock_xcp_server fixture from conftest.py but require
+# pyxcp to actually connect. They are currently skipped because pyxcp's
+# Master + ArgumentParser flow needs a full traitlets config setup that
+# is complex to wire in a test. The mock-based tests above provide
+# equivalent coverage through the gRPC boundary.)
+# =============================================================================

--- a/python/packages/jumpstarter-driver-xcp/pyproject.toml
+++ b/python/packages/jumpstarter-driver-xcp/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "jumpstarter-driver-xcp"
+dynamic = ["version", "urls"]
+description = "XCP (Universal Measurement and Calibration Protocol) driver for Jumpstarter"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "Vinicius Zein", email = "vtzein@gmail.com" },
+]
+requires-python = ">=3.11"
+dependencies = [
+    "jumpstarter",
+    "pyxcp>=0.27.0",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+Xcp = "jumpstarter_driver_xcp.driver:Xcp"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../' }
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=html --cov-report=xml"
+log_cli = true
+log_cli_level = "INFO"
+testpaths = ["jumpstarter_driver_xcp"]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,6 +40,7 @@ jumpstarter-driver-iscsi = { workspace = true }
 jumpstarter-driver-ustreamer = { workspace = true }
 jumpstarter-driver-yepkit = { workspace = true }
 jumpstarter-driver-vnc = { workspace = true }
+jumpstarter-driver-xcp = { workspace = true }
 jumpstarter-imagehash = { workspace = true }
 jumpstarter-kubernetes = { workspace = true }
 jumpstarter-protocol = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -45,6 +45,7 @@ members = [
     "jumpstarter-driver-uds-doip",
     "jumpstarter-driver-ustreamer",
     "jumpstarter-driver-vnc",
+    "jumpstarter-driver-xcp",
     "jumpstarter-driver-yepkit",
     "jumpstarter-example-automotive",
     "jumpstarter-example-soc-pytest",
@@ -300,6 +301,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/76/14349136c395f94fbd2af663301c2d661da9109fdf74692fe5095808cb9d/backports_zstd-1.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbcbb091fede530d096e32f3409056c59dc7b5e6cc9bf39131c7961eaaf8f475", size = 393965, upload-time = "2025-11-23T12:51:15.646Z" },
     { url = "https://files.pythonhosted.org/packages/c1/5b/fa580166cdf945be0b3ca1dbf8b23bc1370087707fa825b764d7e98b9a3c/backports_zstd-1.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5ac888007be1724efaa565f69ba64ce0c0c0e135d7f22830565399ff76465f1", size = 413929, upload-time = "2025-11-23T12:51:16.75Z" },
     { url = "https://files.pythonhosted.org/packages/aa/f3/650db1631d75c3f6ad46b09dfee2a761b2678b1e2e0004d90258020801c3/backports_zstd-1.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:08f66e228821a87ba7c74170b6b173cf249eeface98c0951c0da7db680b887d5", size = 299785, upload-time = "2025-11-23T12:51:17.969Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
@@ -582,6 +598,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -648,6 +673,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "construct"
+version = "2.10.70"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/77/8c84b98eca70d245a2a956452f21d57930d22ab88cbeed9290ca630cf03f/construct-2.10.70.tar.gz", hash = "sha256:4d2472f9684731e58cc9c56c463be63baa1447d674e0d66aeb5627b22f512c29", size = 86337, upload-time = "2023-11-29T08:44:49.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/fb/08b3f4bf05da99aba8ffea52a558758def16e8516bc75ca94ff73587e7d3/construct-2.10.70-py3-none-any.whl", hash = "sha256:c80be81ef595a1a821ec69dc16099550ed22197615f4320b57cc9ce2a672cb30", size = 63020, upload-time = "2023-11-29T08:44:46.876Z" },
 ]
 
 [[package]]
@@ -2651,6 +2685,32 @@ dev = [
 ]
 
 [[package]]
+name = "jumpstarter-driver-xcp"
+source = { editable = "packages/jumpstarter-driver-xcp" }
+dependencies = [
+    { name = "jumpstarter" },
+    { name = "pyxcp" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "pyxcp", specifier = ">=0.27.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+]
+
+[[package]]
 name = "jumpstarter-driver-yepkit"
 source = { editable = "packages/jumpstarter-driver-yepkit" }
 dependencies = [
@@ -2886,6 +2946,65 @@ wheels = [
 ]
 
 [[package]]
+name = "line-profiler"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/b6/6d18ad201417a9c5168995541d0fd7981b5652b2b34f6e46a3a93c0f1beb/line_profiler-5.0.2.tar.gz", hash = "sha256:8d8a990c84c64bcde45af22af502d17bc0ae107be405ce41bba92af5c39c0000", size = 407075, upload-time = "2026-02-23T23:31:20.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/cd/a92661cb24987d0a4cf86f7ec9f6a0f74ea981c520b6458275d41b11ec0a/line_profiler-5.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:602370a9bb8d020ea28ddac3bb7fd4331c91d495e6e81d5f75752cbb2f2bb802", size = 650547, upload-time = "2026-02-23T23:30:00.593Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/77/5489458f8cc01ea00cdf25bc6fa74e748a30e7b758275cc98b485b59de91/line_profiler-5.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:26956eef9668f641c9c6f9adb6b1b236252a73405e238452768812af14f9a145", size = 507989, upload-time = "2026-02-23T23:30:01.848Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4f/14aace66e067fb5a774580bc71b348c323c91a4e2ac223a98822de67ecda/line_profiler-5.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:64376a726009b7842706a3fef2a6dba051f0bf5a98cbbcafa4c23d6c83bac53c", size = 497137, upload-time = "2026-02-23T23:30:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/ea92cc96538a192fdf74249f28ad9e9c0526743b12817f920985e7fdbbe2/line_profiler-5.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68432878d7598916f02be3fbb83e3a4727443cfd96af9cbea05cc1ae9749ed82", size = 1526617, upload-time = "2026-02-23T23:30:05.211Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/8d/c73544fba5683a50d7579f21614942d9223e2dd618986be56d5beff561e5/line_profiler-5.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7956e79526dc4898ca63dd8e3f435ff674b35d7e06457bfff883efae3ecb8359", size = 1540576, upload-time = "2026-02-23T23:30:07.234Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/33/a3255c143148e5886179b689b0413bb0b7edbd6af1531db577f8bf8b69fd/line_profiler-5.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:29370b9d239c0e68ea017bbf2b582beed6122a439ef97a8e38228708b52ba595", size = 2480641, upload-time = "2026-02-23T23:30:08.638Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/d398438f9af55c4bd799c15c6a9fc5d349c36ef461edce8ed3569768c964/line_profiler-5.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f47682cb1cef2a3b3865e59fdaf2f486196476fa508ddcdd838e3484626c2a68", size = 2565285, upload-time = "2026-02-23T23:30:10.015Z" },
+    { url = "https://files.pythonhosted.org/packages/74/08/663f3dd52ebebcb98cddca9ca4f4b51fcd43ce2c8c6b676de28e2ad6f384/line_profiler-5.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:b74416342261d0434e2ae0ff074ec0ecf0ea4e66ec2db5a95dd8b0ec7f2b1a8b", size = 480440, upload-time = "2026-02-23T23:30:11.588Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c4/12ac6f1c139780301d23b9f64ccb160366063124e91134fcccfb24d8b9b7/line_profiler-5.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f0d51ddb054d38a37607b335475c8be9fae4152b01873d1fc1d6b6a317b66398", size = 464965, upload-time = "2026-02-23T23:30:13.262Z" },
+    { url = "https://files.pythonhosted.org/packages/99/92/fb766e6355118d2a681c18525d4c005c146ec44b064ccfd70f4529d8d260/line_profiler-5.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:256c1d5e84a93254dbe656d0486322190cc68f6b517544edef17a9f00167e680", size = 646920, upload-time = "2026-02-23T23:30:14.692Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9d/3583c1cdc740206de9e4734bdcf377d649b89ea876bc36001d95b3dea67d/line_profiler-5.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:892f0cd9967b101ce7528be2d388616037c73cb27830effd7493fa021165c622", size = 505695, upload-time = "2026-02-23T23:30:16.375Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/412476a1d09beac783d11d3bbf85fe6c1e3d50058e3c28967fee59c46649/line_profiler-5.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d2d02735843c14337dae3e80d95a732b4657ef759def75162ef97a1aa7466aac", size = 495859, upload-time = "2026-02-23T23:30:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/37/75/65028bad08264fd8f9c3f0fd405c539ff552c2d1cf2a00965157ad148973/line_profiler-5.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d2e166a86dc9c78c349ee18b592b98ebfb9dae615f63fc77cce5f5f751a6ad0", size = 1464882, upload-time = "2026-02-23T23:30:19.273Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6c/2d0286f67e6bb2b00ae23f9af6df18bfc6bb1ac5d803a8f46bd3eb22a8f1/line_profiler-5.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a870b68af1539d718d030f4c4726d35cff4b14ab605147e65222933c5c0e10e", size = 1484331, upload-time = "2026-02-23T23:30:20.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a4/b01359733214a1a85c5f86f3953b07deb61b267efa0328e8d436a1ad80ea/line_profiler-5.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:fe8cd787caa2a02ca7e138832fa4cab1f198377eaf6e5e8263e8b7506157c454", size = 2411802, upload-time = "2026-02-23T23:30:21.995Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f4/1fa91206a6c50091cf614fdd5c9d349eb3a57d23f5eb8be8fffe7e0525b9/line_profiler-5.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:70ff915ade9e3ec38ff043ff093b590bbb3055e6fc8b311e0fe14cd78fb2a7f7", size = 2495790, upload-time = "2026-02-23T23:30:23.448Z" },
+    { url = "https://files.pythonhosted.org/packages/87/18/d389c72dce6c8318c088a7c29ee8961a913c8a1c6469888b517e8f47ddaf/line_profiler-5.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:026779b9dfca0f367174f5d34bcccffce2755db40a4389f0d8a531a2e3ca7cfc", size = 478790, upload-time = "2026-02-23T23:30:24.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/54/d171600a4190c07215090a88846ef0093b5bf34a81f8059115592dbb1354/line_profiler-5.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:fe22b927f05a61a0149976bf0d22d8e56fa742ec89f3d72358db71a1f440c77b", size = 462269, upload-time = "2026-02-23T23:30:26.237Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/64/856b920e026fbd239df875ec05e63583f7bd7f250805215ab6e132da11d1/line_profiler-5.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:016effba91d34d15229d41984e921a27f66a7b634f1d7adf6c57c743f3d6a0eb", size = 642642, upload-time = "2026-02-23T23:30:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/08/0a56fab0a36818af6ffc8073700db2f402db5a62477b69d938c19871d631/line_profiler-5.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:506e800dd408a8aafadf39ff4e4a1375ae7794910d00098f191520a2f390cb99", size = 503787, upload-time = "2026-02-23T23:30:29.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9a/0ab45cf92b2c13261b475c440e18bb18d9497cc2ad5dfaf38c231c72b02b/line_profiler-5.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e67f77bcb349a663cb22819f65621bcd2a39889524dd890d1d88f8736841b7b", size = 493631, upload-time = "2026-02-23T23:30:30.502Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/15/a5b603f0c7c795aa656a95e2a70d139dc499b5d153b6a3129bbba6b6f913/line_profiler-5.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6b9d08e85fd48d254ae253e76dc72598e94200ef7002eb1ae0bab4cc9c5e41a", size = 1464022, upload-time = "2026-02-23T23:30:31.793Z" },
+    { url = "https://files.pythonhosted.org/packages/27/6f/0f399c72eecaf8f8c00e84238b5786afc34d0a4ef5ad10c63c712715ba86/line_profiler-5.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31290e06ac25cd87fee46ebe979541d4ec7c8d6f15c5cbe5874a932b1cee95bb", size = 1483425, upload-time = "2026-02-23T23:30:33.15Z" },
+    { url = "https://files.pythonhosted.org/packages/65/18/f4c642a29719a84d17ea8b58cd6e60943573a28228c30c568565ed5512aa/line_profiler-5.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1d7fbcc2dbd8534fc6f7d2b440076749b2235cdc525eb177fefafeaf7550373f", size = 2410276, upload-time = "2026-02-23T23:30:34.943Z" },
+    { url = "https://files.pythonhosted.org/packages/90/33/701203686e7d27a545e3bbc8e81fffc7d091c42ed33564be4e72376ef45b/line_profiler-5.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:55f04671f48afcd90858c18fbdb2509463c77d717ed5424664f096e902206b6b", size = 2495283, upload-time = "2026-02-23T23:30:36.616Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e1/59fe065f67ed1fb8f974a9e3434685af1fc1f6a154489f7ab0992eab1c73/line_profiler-5.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:d2262d4bbbcf72bd430fc5763073792a0f1cb20e64de0f7ecf6e8ae16627d876", size = 479287, upload-time = "2026-02-23T23:30:38.152Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/89f6ae52fa77960404ee88fc078ee680e504bf1ab8724ac01430cee0f5a5/line_profiler-5.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:abf755b020d91b639cbc563015eca381ca64e6bd27ee55ef9004a3a17b6d4dcf", size = 461960, upload-time = "2026-02-23T23:30:39.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ae/43caf21edd10a7f5e138bdffcad01ade9a704462a923054402bbadbe5364/line_profiler-5.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a1cc30f3f7877fec826d0f40f400ee6c99239dc6a2f587b8d90d06a42d29c8a5", size = 648335, upload-time = "2026-02-23T23:30:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/34/90/8a1fb985dc582d140fc92608dec3037a484c5f8ab99ae05c24031aa68000/line_profiler-5.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f90923e1cc4ff8eda1d18e525089fca7bfd6dfe8817ec530a913a2c7444ba0fd", size = 508823, upload-time = "2026-02-23T23:30:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/01/855c55e195ac0aadb8ca4e4c65311f945ed02a2491b436bc33cee318d841/line_profiler-5.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cc3d0ecccb14f014d05b32f687d22adcb98bf59fdcc721e7a4330f0372a56f92", size = 499868, upload-time = "2026-02-23T23:30:44.188Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/48/fe73d6192a37637534366306a7871ef0f7ff5973bd87da082e4bf5ec0764/line_profiler-5.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5341f36e532e7ed28e323f5502a29b397b66a6708c6427a77f965148a2e5ddec", size = 1460660, upload-time = "2026-02-23T23:30:45.601Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1c/e1236e0f3c7ec1e19e74d61ac15143a7826b5767296de87bcf3aa26548a1/line_profiler-5.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cce501f9d996b317b599c0ae99e3eb1bd447874ef8fef1da330b27f3a23eb50", size = 1475222, upload-time = "2026-02-23T23:30:47.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ad/02302fd2a82949277036bc557ecebddb9bc6282b76a4da7660258fe82111/line_profiler-5.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b237d82fb792c3db7c80a8675d3c48993d4421b14d96ae602f7fe9ccf1f85903", size = 2413428, upload-time = "2026-02-23T23:30:48.828Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b3efe646c8b9fdc6fe26720860276c8a2bb745ffe30f5bcbc9726b975673/line_profiler-5.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:74febeca89128a37a32e6500c99665943c0d11e6043f46ce95596d7d1e1732a7", size = 2494741, upload-time = "2026-02-23T23:30:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ad/ddadd39eb92900f063f27e8f6d748c03dc2638873f07ebf3cee75f29711f/line_profiler-5.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:d6ce98faff60d9552a30e233648a848682b5d664a7e09e9669163a8f01e28147", size = 485700, upload-time = "2026-02-23T23:30:52.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/45/a529f355eea8fb790fbdee0273d6c0049dba3232a36e82c30d849b00e996/line_profiler-5.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:8be7cc5f4ed9ad87352129d1a494cf5ba7f0fced0472201d83ac9fbfa20f798b", size = 469781, upload-time = "2026-02-23T23:30:53.747Z" },
+]
+
+[[package]]
+name = "line-profiler-pycharm"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "line-profiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/b0/d7437c668ce49d45b8e28548d863ffccf4c067c66f147444594c1e531a92/line_profiler_pycharm-1.2.0.tar.gz", hash = "sha256:16cacf234952420fc324f17704c0cc2145d5afd2ec0593e359796927bcc0debb", size = 4386, upload-time = "2024-09-23T18:50:41.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/5e/b0331bf5e3f9f193b776fc0b22348143fc36f59bb931f0679a473ee667eb/line_profiler_pycharm-1.2.0-py3-none-any.whl", hash = "sha256:2d4c47c6894ab81f48fbb132ac4830490813b13c297016ae0d97bc7ef12041ad", size = 4762, upload-time = "2024-09-23T18:50:39.553Z" },
+]
+
+[[package]]
 name = "lsprotocol"
 version = "2023.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2896,6 +3015,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434, upload-time = "2024-01-09T17:21:12.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826, upload-time = "2024-01-09T17:21:14.491Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]
@@ -3888,6 +4019,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
 name = "pyudev"
 version = "0.24.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3959,6 +4099,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/09/9c1b978ffc4ae53999e89c19c77ba882d9fce476729f23ef55211ea1c034/pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab", size = 8794384, upload-time = "2025-03-17T00:56:04.383Z" },
     { url = "https://files.pythonhosted.org/packages/45/3c/b4640f740ffebadd5d34df35fecba0e1cfef8fde9f3e594df91c28ad9b50/pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e", size = 9503039, upload-time = "2025-03-17T00:56:06.207Z" },
     { url = "https://files.pythonhosted.org/packages/b4/f4/f785020090fb050e7fb6d34b780f2231f302609dc964672f72bfaeb59a28/pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33", size = 8458152, upload-time = "2025-03-17T00:56:07.819Z" },
+]
+
+[[package]]
+name = "pyxcp"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bandit" },
+    { name = "chardet" },
+    { name = "construct" },
+    { name = "line-profiler-pycharm" },
+    { name = "mako" },
+    { name = "pydantic" },
+    { name = "pyserial" },
+    { name = "python-can" },
+    { name = "pytz" },
+    { name = "pyusb" },
+    { name = "rich" },
+    { name = "toml" },
+    { name = "tomlkit" },
+    { name = "traitlets" },
+    { name = "uptime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/24/5d98e62560ab5fd895cdefe131c96eaa9bbcdee1c03ea7d240d17e6a24d1/pyxcp-0.28.1.tar.gz", hash = "sha256:a0109476c4427d0d6e87b7f50b2a5c44f31d14d817bb2b97ed0db4dad0750741", size = 299281, upload-time = "2026-03-01T06:50:48.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/2f/0052ba201bfbc957bf7ba85b63c0b150d19144057830877bc832fc180aca/pyxcp-0.28.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99c76538db44f4d8dcd0288164f26d6157988125f383ea5b29dd0b3a12290405", size = 1794599, upload-time = "2026-03-01T06:50:15.043Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d8/0f756c35ae8180089fe836379e27d70ffea1ea3eb105b3faa56b9b70a3d3/pyxcp-0.28.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6cf8529d6370658deaf619b5af9cb7d00606e010c9a4707ce6fd0e93cbe8673e", size = 2100970, upload-time = "2026-03-01T06:50:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ce/0007cb48bfc198d37aa08533b029712aaa29084df8026a539e7c3a45ce31/pyxcp-0.28.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa6641c0eb1d9c48378dee3566bfe65e7bc685ccadb27325cd88aa511472852e", size = 2290045, upload-time = "2026-03-01T06:50:18.552Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/88/efc85b9af66aa691af131bbfbd98b916ef80c3f170822b1621e8daf0c1ae/pyxcp-0.28.1-cp311-cp311-win_amd64.whl", hash = "sha256:6a27e908917cebf27c9a2d35a21d1dfa4ac6922856bda225079d4bc62e8085bc", size = 1570483, upload-time = "2026-03-01T06:50:20.192Z" },
+    { url = "https://files.pythonhosted.org/packages/93/4d/5d21e380b9c123af8e2a06eb9fb7e4de7a53f4bf684666f70c88c63c73a3/pyxcp-0.28.1-cp311-cp311-win_arm64.whl", hash = "sha256:06281f0335762d4888eaf0427856228b668bb829cd6e62588ad968e650db17b3", size = 1566013, upload-time = "2026-03-01T06:50:21.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/38/aebb30debf40b762c65fd77cda9061976b47b91d1642cb1802574566f8d5/pyxcp-0.28.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06cd5788955b95a8abfa44c52e20b0c9af5cbcd4f7f6eecba0bbdec9b1d88bdc", size = 2520918, upload-time = "2026-03-01T06:50:23.471Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c9/e2e920d7e9f922bb49b92a549dafe477b246683dad718a71addbd92bd3a6/pyxcp-0.28.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8414f3f4cb27f86748eb8fe6b0dcd6eeaf959d75c65bf3ba3f690fec0c0e7d77", size = 2977582, upload-time = "2026-03-01T06:50:25.162Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/63/5ebc80de26068a581746ccc79a5f2cdea9717c91c8bfebb9b70bfa1fd1a2/pyxcp-0.28.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a727664989c594e3113002fb6e95c55b1a228089ccd072570cd44c976686ae5", size = 3262767, upload-time = "2026-03-01T06:50:26.824Z" },
+    { url = "https://files.pythonhosted.org/packages/88/68/8c446ea90d534ff08b08b290e9da1d9b8ce21258f0085ea165b9045b4fde/pyxcp-0.28.1-cp312-cp312-win_amd64.whl", hash = "sha256:859636570978f95628af11db48d23968e11ace859b637903fc2d70ba0676d457", size = 2183577, upload-time = "2026-03-01T06:50:28.943Z" },
+    { url = "https://files.pythonhosted.org/packages/98/10/6c4c59ba6ad51fa9f33d619db91c6319e105a5f94fc3f2859b39e7b2dde1/pyxcp-0.28.1-cp312-cp312-win_arm64.whl", hash = "sha256:0b7c1bd6d818c5ff9c480fa8f5979d176f85862648b3c40dab0f359527bde02b", size = 2163147, upload-time = "2026-03-01T06:50:30.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/5f/030531db98ff05c1d7a1c00cd6c0c19af6f0418e9176f2ed1162f32c7427/pyxcp-0.28.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e1088931517c5f51112e47d780a61ee613149423a066a435d82fe94fe81d7249", size = 3247180, upload-time = "2026-03-01T06:50:31.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6c/7e0532245c56ea3db4307b06056882740499079741df2d17143089250350/pyxcp-0.28.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ba7605bfbc3b51c27cfd5469e1ec2067ba1caba95094b68b7a8b4161530b2dd", size = 3854267, upload-time = "2026-03-01T06:50:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f3/1f1053eca225be359f9f6d9e199114b321d60700b61c9cfea90bf6da7b3e/pyxcp-0.28.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6a59b7858c8aa897fc555957571fdfe28ff8820efbb53fb2c847107eb36fb23", size = 4235621, upload-time = "2026-03-01T06:50:35.066Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6e/09b7e8b66a29508b105699eaeaa6991a4976cf78675dfaf651a7ba23772a/pyxcp-0.28.1-cp313-cp313-win_amd64.whl", hash = "sha256:47a1d7686f2f5e7898cc5f9a4227945a07f849e64d232d299ca1ea94e73daaed", size = 2796672, upload-time = "2026-03-01T06:50:36.908Z" },
+    { url = "https://files.pythonhosted.org/packages/db/bb/d07483ec266377db0b573b49050ba0d88bbd22b9c86f2686035519f76e7c/pyxcp-0.28.1-cp313-cp313-win_arm64.whl", hash = "sha256:2e862a134acd2f4fbe6ea697e14a10c468b477aaccc502adc6ef7da39b1b90bb", size = 2760297, upload-time = "2026-03-01T06:50:38.273Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8f/11514be79db3ac063f24dbf5021e0a412d7d93296fa7673bb4d733c99644/pyxcp-0.28.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c5f11549a782140831ccac3348cb4a36f4c99aaf77fc44a3b5a4797eb28fbfe", size = 3975125, upload-time = "2026-03-01T06:50:39.801Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a3/500e57e0ec01e125fa0afd3d0b997d7d2cd6c5e914bdf2cc14709eb6a973/pyxcp-0.28.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e4212c1f08cc44e50c5f6e2c14f01835a776efbd2c4953db4fe7916c956ea17", size = 4733487, upload-time = "2026-03-01T06:50:41.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4c/f7cbcf3871f0da6b6e8693bd199331623ba148a96f52f6b2c69cc250c22a/pyxcp-0.28.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:810a208d66ed8554e19cca9cba6e2c20bd9b2912e658edaa14d90475333716b1", size = 5208830, upload-time = "2026-03-01T06:50:43.186Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/b99ef260f5c064282691bbd6784aeebf5d7ae602f1392d092f4343d8dd32/pyxcp-0.28.1-cp314-cp314-win_amd64.whl", hash = "sha256:45abfda1b5462aa5ac1aee0f61bb76c819ec648330a2a59a6f82b4e20988da1d", size = 3505288, upload-time = "2026-03-01T06:50:45.085Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9c/222f4961742c6b5e157478bc417612cd9266264196a736375df07e90a990/pyxcp-0.28.1-cp314-cp314-win_arm64.whl", hash = "sha256:2decf194a3b24c0503d205f7ef3210af392007e8352502111a4f1d21acc322a2", size = 3449043, upload-time = "2026-03-01T06:50:46.753Z" },
 ]
 
 [[package]]
@@ -4530,12 +4715,30 @@ wheels = [
 ]
 
 [[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -4584,6 +4787,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -4722,6 +4943,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/2b/b5/50bdde3a075808038
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/b7/3ce55ec6ad06ded79d93ba09f217a8f7d4b277abc79158bb1d1f7eb66666/udsoncan-1.25.2-py3-none-any.whl", hash = "sha256:96b34b643558ab0dfbb56947c15d6d8c5106aa8c8739553dad7c896170deb684", size = 119927, upload-time = "2026-02-13T02:11:26.907Z" },
 ]
+
+[[package]]
+name = "uptime"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/53/6c420ddf6949097d6f9406358951c9322505849bea9cb79efe3acc0bb55d/uptime-3.0.1.tar.gz", hash = "sha256:7c300254775b807ce46e3dcbcda30aa3b9a204b9c57a7ac1e79ee6dbe3942973", size = 6630, upload-time = "2013-10-07T14:19:58.456Z" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
- Add jumpstarter-driver-xcp package with full XCP protocol support (measurement, calibration, DAQ, and flash programming) over Ethernet and CAN transports, powered by pyXCP.
- Add python/examples/xcp-ecu/ with a stateful mock ECU and end-to-end scenario tests, following the same pattern as the automotive UDS example.
- 54 driver tests + 14 example tests covering happy paths, error handling, config validation, and multi-step stateful workflows through the gRPC boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full XCP support: driver and client covering sessions, security, memory access, DAQ, and flashing.

* **Examples**
  * Added a runnable XCP ECU example with a stateful mock ECU and test fixtures.

* **Documentation**
  * Added driver README, API reference entries, and an exporter example config; added example README for the ECU.

* **Tests**
  * Added extensive unit and integration tests plus test harnesses covering end-to-end XCP workflows.

* **Chores**
  * Packaging/config updates and .gitignore entries for coverage artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->