### PR TITLE
docs: include release-0.8 in docs build

### DIFF
--- a/python/docs/multiversion.sh
+++ b/python/docs/multiversion.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-declare -a BRANCHES=("main" "release-0.6" "release-0.7")
+declare -a BRANCHES=("main" "release-0.6" "release-0.7" "release-0.8")
 
 # https://stackoverflow.com/a/246128
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
Make sure that the docs build release-0.8 version as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration to process the 0.8 release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->