### PR TITLE
Improve j commands exception handling

### DIFF
--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
@@ -224,7 +224,9 @@ def handle_exceptions_with_reauthentication(login_func):
                 _handle_exception_group_with_reauth(eg, login_func)
             except (ConnectionError, JumpstarterException, click.ClickException) as e:
                 _handle_single_exception_with_reauth(e, login_func)
-            except Exception:
+            except Exception as e:
+                if common_exc := _map_common_exception(e):
+                    raise common_exc from None
                 raise
 
         return wrapped

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import socket
 import ssl
 import types
@@ -61,6 +62,17 @@ def _map_common_exception(exc: BaseException) -> click.ClickException | None:
     if isinstance(exc, PermissionError):
         return ClickExceptionRed(f"Permission denied while accessing a required resource. Details: {message}")
 
+    if isinstance(exc, json.JSONDecodeError):
+        return ClickExceptionRed(
+            f"Received invalid JSON data from a remote endpoint. Verify the service/proxy response. Details: {message}"
+        )
+
+    if isinstance(exc, click.Abort):
+        return ClickExceptionRed("Aborted by user.")
+
+    if isinstance(exc, OSError):
+        return ClickExceptionRed(f"Local system error while performing the operation. Details: {message}")
+
     # gRPC status handling for common user-facing errors before they become opaque traces.
     code = None
     details = ""
@@ -99,6 +111,18 @@ def _map_common_exception(exc: BaseException) -> click.ClickException | None:
             "Service is temporarily unavailable or unreachable. Verify endpoint/network and retry."
             f"{detail_suffix}"
         )
+    if code in ("UNAUTHENTICATED", "PERMISSION_DENIED"):
+        detail_suffix = f" Details: {details}" if details else ""
+        return ClickExceptionRed(
+            "Authentication or authorization failed. Run 'jmp login' and verify access permissions."
+            f"{detail_suffix}"
+        )
+    if code == "INVALID_ARGUMENT":
+        detail_suffix = f" Details: {details}" if details else ""
+        return ClickExceptionRed(
+            "Invalid request arguments were sent to the service. Verify command options and configuration."
+            f"{detail_suffix}"
+        )
 
     return None
 
@@ -123,6 +147,8 @@ def async_handle_exceptions(func):
             raise eg
         except JumpstarterException as e:
             raise ClickExceptionRed(str(e)) from None
+        except KeyboardInterrupt:
+            raise ClickExceptionRed("Cancelled by user.") from None
         except click.ClickException:
             raise  # if it was already a click exception from the cli commands, just re-raise it
         except Exception as e:
@@ -142,6 +168,8 @@ def handle_exceptions(func):
             return func(*args, **kwargs)
         except JumpstarterException as e:
             raise ClickExceptionRed(str(e)) from None
+        except KeyboardInterrupt:
+            raise ClickExceptionRed("Cancelled by user.") from None
         except click.ClickException:
             raise  # if it was already a click exception from the cli commands, just re-raise it
         except Exception as e:

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
@@ -18,11 +18,11 @@ class ClickExceptionRed(click.ClickException):
         return click.style(self.message, fg="red")
 
 
-def _map_common_exception(exc: BaseException) -> click.ClickException | None:
-    """Map common transport/runtime exceptions to user-friendly Click errors."""
-    message = str(exc)
-    message_lower = message.lower()
+def _append_details(base_message: str, details: str) -> str:
+    return f"{base_message} Details: {details}" if details else base_message
 
+
+def _map_runtime_exception(exc: BaseException, message: str, message_lower: str) -> click.ClickException | None:
     timeout_types = (TimeoutError, asyncio.TimeoutError, socket.timeout, FutureTimeoutError)
     if isinstance(exc, timeout_types):
         timeout_hint = (
@@ -30,9 +30,7 @@ def _map_common_exception(exc: BaseException) -> click.ClickException | None:
             "If this happened while flashing, verify the board is reachable/in flashing mode "
             "and increase retries or timeout."
         )
-        if message:
-            timeout_hint = f"{timeout_hint} Details: {message}"
-        return ClickExceptionRed(timeout_hint)
+        return ClickExceptionRed(_append_details(timeout_hint, message))
 
     is_cert_verification_error = isinstance(exc, ssl.SSLCertVerificationError) or (
         isinstance(exc, ssl.SSLError) and "certificate verify failed" in message_lower
@@ -42,18 +40,18 @@ def _map_common_exception(exc: BaseException) -> click.ClickException | None:
             "TLS certificate validation failed. Verify the endpoint certificate chain or configure "
             "the correct CA certificate. Use insecure TLS only for testing."
         )
-        if message:
-            cert_hint = f"{cert_hint} Details: {message}"
-        return ClickExceptionRed(cert_hint)
+        return ClickExceptionRed(_append_details(cert_hint, message))
 
     if isinstance(exc, socket.gaierror):
         return ClickExceptionRed(
-            f"Could not resolve host name. Check the endpoint DNS name and network settings. Details: {message}"
+            "Could not resolve host name. Check the endpoint DNS name and network settings. "
+            f"Details: {message}"
         )
 
     if isinstance(exc, ConnectionRefusedError):
         return ClickExceptionRed(
-            f"Connection was refused by the remote endpoint. Verify endpoint/port and that the service is running. Details: {message}"
+            "Connection was refused by the remote endpoint. Verify endpoint/port and that the service "
+            f"is running. Details: {message}"
         )
 
     if isinstance(exc, FileNotFoundError):
@@ -64,7 +62,8 @@ def _map_common_exception(exc: BaseException) -> click.ClickException | None:
 
     if isinstance(exc, json.JSONDecodeError):
         return ClickExceptionRed(
-            f"Received invalid JSON data from a remote endpoint. Verify the service/proxy response. Details: {message}"
+            "Received invalid JSON data from a remote endpoint. Verify the service/proxy response. "
+            f"Details: {message}"
         )
 
     if isinstance(exc, click.Abort):
@@ -72,58 +71,94 @@ def _map_common_exception(exc: BaseException) -> click.ClickException | None:
 
     if isinstance(exc, OSError):
         return ClickExceptionRed(f"Local system error while performing the operation. Details: {message}")
+    return None
 
-    # gRPC status handling for common user-facing errors before they become opaque traces.
+
+def _extract_grpc_code_and_details(exc: BaseException) -> tuple[str | None, str]:
     code = None
     details = ""
-    if hasattr(exc, "code") and callable(getattr(exc, "code")):
-        try:
-            grpc_code = exc.code()
-            code = getattr(grpc_code, "name", str(grpc_code))
-        except Exception:
-            code = None
-    if hasattr(exc, "details") and callable(getattr(exc, "details")):
-        try:
-            details = str(exc.details() or "")
-        except Exception:
-            details = ""
+    try:
+        code_member = exc.code
+        if callable(code_member):
+            grpc_code = code_member()
+            code = grpc_code.name if hasattr(grpc_code, "name") else str(grpc_code)
+    except Exception:
+        code = None
+
+    try:
+        details_member = exc.details
+        if callable(details_member):
+            details = str(details_member() or "")
+    except Exception:
+        details = ""
+    return code, details
+
+
+def _map_grpc_exception(exc: BaseException) -> click.ClickException | None:
+    # gRPC status handling for common user-facing errors before they become opaque traces.
+    code, details = _extract_grpc_code_and_details(exc)
     details_lower = details.lower()
 
     if code == "DEADLINE_EXCEEDED":
-        detail_suffix = f" Details: {details}" if details else ""
         return ClickExceptionRed(
-            "Operation timed out while waiting for a response from the service."
-            f"{detail_suffix}"
+            _append_details(
+                "Operation timed out while waiting for a response from the service.",
+                details,
+            )
         )
     if code == "UNAVAILABLE" and (
         "certificate verify failed" in details_lower
         or "certificate" in details_lower
         or "tls" in details_lower
     ):
-        detail_suffix = f" Details: {details}" if details else ""
         return ClickExceptionRed(
-            "TLS connection failed while connecting to the service. Verify certificates/CA settings."
-            f"{detail_suffix}"
+            _append_details(
+                "TLS connection failed while connecting to the service. Verify certificates/CA settings.",
+                details,
+            )
         )
     if code == "UNAVAILABLE":
-        detail_suffix = f" Details: {details}" if details else ""
         return ClickExceptionRed(
-            "Service is temporarily unavailable or unreachable. Verify endpoint/network and retry."
-            f"{detail_suffix}"
+            _append_details(
+                "Service is temporarily unavailable or unreachable. Verify endpoint/network and retry.",
+                details,
+            )
         )
     if code in ("UNAUTHENTICATED", "PERMISSION_DENIED"):
-        detail_suffix = f" Details: {details}" if details else ""
         return ClickExceptionRed(
-            "Authentication or authorization failed. Run 'jmp login' and verify access permissions."
-            f"{detail_suffix}"
+            _append_details(
+                "Authentication or authorization failed. Run 'jmp login' and verify access permissions.",
+                details,
+            )
         )
     if code == "INVALID_ARGUMENT":
-        detail_suffix = f" Details: {details}" if details else ""
         return ClickExceptionRed(
-            "Invalid request arguments were sent to the service. Verify command options and configuration."
-            f"{detail_suffix}"
+            _append_details(
+                "Invalid request arguments were sent to the service. Verify command options and configuration.",
+                details,
+            )
         )
+    return None
 
+
+def _map_common_exception(exc: BaseException) -> click.ClickException | None:
+    """Map common transport/runtime exceptions to user-friendly Click errors."""
+    message = str(exc)
+    message_lower = message.lower()
+    if mapped := _map_runtime_exception(exc, message, message_lower):
+        return mapped
+    return _map_grpc_exception(exc)
+
+
+def _map_cli_exception(exc: BaseException) -> click.ClickException | None:
+    if common_exc := _map_common_exception(exc):
+        return common_exc
+    if isinstance(exc, JumpstarterException):
+        return ClickExceptionRed(str(exc))
+    if isinstance(exc, KeyboardInterrupt):
+        return ClickExceptionRed("Cancelled by user.")
+    if isinstance(exc, click.ClickException):
+        return exc
     return None
 
 
@@ -137,23 +172,17 @@ def async_handle_exceptions(func):
         except BaseExceptionGroup as eg:
             # Handle exceptions wrapped in ExceptionGroup (e.g., from task groups)
             for exc in leaf_exceptions(eg, fix_tracebacks=False):
-                if common_exc := _map_common_exception(exc):
-                    raise common_exc from None
-                elif isinstance(exc, JumpstarterException):
-                    raise ClickExceptionRed(str(exc)) from None
-                elif isinstance(exc, click.ClickException):
-                    raise exc from None
+                if cli_exc := _map_cli_exception(exc):
+                    raise cli_exc from None
             # If no handled exceptions, re-raise the original group
             raise eg
-        except JumpstarterException as e:
-            raise ClickExceptionRed(str(e)) from None
-        except KeyboardInterrupt:
-            raise ClickExceptionRed("Cancelled by user.") from None
-        except click.ClickException:
-            raise  # if it was already a click exception from the cli commands, just re-raise it
         except Exception as e:
-            if common_exc := _map_common_exception(e):
-                raise common_exc from None
+            if cli_exc := _map_cli_exception(e):
+                raise cli_exc from None
+            raise
+        except KeyboardInterrupt as e:
+            if cli_exc := _map_cli_exception(e):
+                raise cli_exc from None
             raise
 
     return wrapped
@@ -166,15 +195,13 @@ def handle_exceptions(func):
     def wrapped(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except JumpstarterException as e:
-            raise ClickExceptionRed(str(e)) from None
-        except KeyboardInterrupt:
-            raise ClickExceptionRed("Cancelled by user.") from None
-        except click.ClickException:
-            raise  # if it was already a click exception from the cli commands, just re-raise it
         except Exception as e:
-            if common_exc := _map_common_exception(e):
-                raise common_exc from None
+            if cli_exc := _map_cli_exception(e):
+                raise cli_exc from None
+            raise
+        except KeyboardInterrupt as e:
+            if cli_exc := _map_cli_exception(e):
+                raise cli_exc from None
             raise
 
     return wrapped
@@ -195,12 +222,8 @@ def _handle_single_exception_with_reauth(exc, login_func):
     """Handle a single exception (may raise)."""
     if isinstance(exc, ConnectionError):
         _handle_connection_error_with_reauth(exc, login_func)
-    elif common_exc := _map_common_exception(exc):
-        raise common_exc from None
-    elif isinstance(exc, JumpstarterException):
-        raise ClickExceptionRed(str(exc)) from None
-    elif isinstance(exc, click.ClickException):
-        raise exc from None
+    elif cli_exc := _map_cli_exception(exc):
+        raise cli_exc from None
     # Not handled: fall through
 
 
@@ -225,8 +248,8 @@ def handle_exceptions_with_reauthentication(login_func):
             except (ConnectionError, JumpstarterException, click.ClickException) as e:
                 _handle_single_exception_with_reauth(e, login_func)
             except Exception as e:
-                if common_exc := _map_common_exception(e):
-                    raise common_exc from None
+                if cli_exc := _map_cli_exception(e):
+                    raise cli_exc from None
                 raise
 
         return wrapped

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
@@ -1,4 +1,8 @@
+import asyncio
+import socket
+import ssl
 import types
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from functools import wraps
 from types import TracebackType
 from typing import NoReturn
@@ -13,6 +17,92 @@ class ClickExceptionRed(click.ClickException):
         return click.style(self.message, fg="red")
 
 
+def _map_common_exception(exc: BaseException) -> click.ClickException | None:
+    """Map common transport/runtime exceptions to user-friendly Click errors."""
+    message = str(exc)
+    message_lower = message.lower()
+
+    timeout_types = (TimeoutError, asyncio.TimeoutError, socket.timeout, FutureTimeoutError)
+    if isinstance(exc, timeout_types):
+        timeout_hint = (
+            "Operation timed out. Check connectivity and retry. "
+            "If this happened while flashing, verify the board is reachable/in flashing mode "
+            "and increase retries or timeout."
+        )
+        if message:
+            timeout_hint = f"{timeout_hint} Details: {message}"
+        return ClickExceptionRed(timeout_hint)
+
+    is_cert_verification_error = isinstance(exc, ssl.SSLCertVerificationError) or (
+        isinstance(exc, ssl.SSLError) and "certificate verify failed" in message_lower
+    )
+    if is_cert_verification_error:
+        cert_hint = (
+            "TLS certificate validation failed. Verify the endpoint certificate chain or configure "
+            "the correct CA certificate. Use insecure TLS only for testing."
+        )
+        if message:
+            cert_hint = f"{cert_hint} Details: {message}"
+        return ClickExceptionRed(cert_hint)
+
+    if isinstance(exc, socket.gaierror):
+        return ClickExceptionRed(
+            f"Could not resolve host name. Check the endpoint DNS name and network settings. Details: {message}"
+        )
+
+    if isinstance(exc, ConnectionRefusedError):
+        return ClickExceptionRed(
+            f"Connection was refused by the remote endpoint. Verify endpoint/port and that the service is running. Details: {message}"
+        )
+
+    if isinstance(exc, FileNotFoundError):
+        return ClickExceptionRed(f"File not found. Verify the path and retry. Details: {message}")
+
+    if isinstance(exc, PermissionError):
+        return ClickExceptionRed(f"Permission denied while accessing a required resource. Details: {message}")
+
+    # gRPC status handling for common user-facing errors before they become opaque traces.
+    code = None
+    details = ""
+    if hasattr(exc, "code") and callable(getattr(exc, "code")):
+        try:
+            grpc_code = exc.code()
+            code = getattr(grpc_code, "name", str(grpc_code))
+        except Exception:
+            code = None
+    if hasattr(exc, "details") and callable(getattr(exc, "details")):
+        try:
+            details = str(exc.details() or "")
+        except Exception:
+            details = ""
+    details_lower = details.lower()
+
+    if code == "DEADLINE_EXCEEDED":
+        detail_suffix = f" Details: {details}" if details else ""
+        return ClickExceptionRed(
+            "Operation timed out while waiting for a response from the service."
+            f"{detail_suffix}"
+        )
+    if code == "UNAVAILABLE" and (
+        "certificate verify failed" in details_lower
+        or "certificate" in details_lower
+        or "tls" in details_lower
+    ):
+        detail_suffix = f" Details: {details}" if details else ""
+        return ClickExceptionRed(
+            "TLS connection failed while connecting to the service. Verify certificates/CA settings."
+            f"{detail_suffix}"
+        )
+    if code == "UNAVAILABLE":
+        detail_suffix = f" Details: {details}" if details else ""
+        return ClickExceptionRed(
+            "Service is temporarily unavailable or unreachable. Verify endpoint/network and retry."
+            f"{detail_suffix}"
+        )
+
+    return None
+
+
 def async_handle_exceptions(func):
     """Decorator to handle exceptions in async functions, including those wrapped in BaseExceptionGroup."""
 
@@ -23,7 +113,9 @@ def async_handle_exceptions(func):
         except BaseExceptionGroup as eg:
             # Handle exceptions wrapped in ExceptionGroup (e.g., from task groups)
             for exc in leaf_exceptions(eg, fix_tracebacks=False):
-                if isinstance(exc, JumpstarterException):
+                if common_exc := _map_common_exception(exc):
+                    raise common_exc from None
+                elif isinstance(exc, JumpstarterException):
                     raise ClickExceptionRed(str(exc)) from None
                 elif isinstance(exc, click.ClickException):
                     raise exc from None
@@ -33,7 +125,9 @@ def async_handle_exceptions(func):
             raise ClickExceptionRed(str(e)) from None
         except click.ClickException:
             raise  # if it was already a click exception from the cli commands, just re-raise it
-        except Exception:
+        except Exception as e:
+            if common_exc := _map_common_exception(e):
+                raise common_exc from None
             raise
 
     return wrapped
@@ -50,7 +144,9 @@ def handle_exceptions(func):
             raise ClickExceptionRed(str(e)) from None
         except click.ClickException:
             raise  # if it was already a click exception from the cli commands, just re-raise it
-        except Exception:
+        except Exception as e:
+            if common_exc := _map_common_exception(e):
+                raise common_exc from None
             raise
 
     return wrapped
@@ -71,6 +167,8 @@ def _handle_single_exception_with_reauth(exc, login_func):
     """Handle a single exception (may raise)."""
     if isinstance(exc, ConnectionError):
         _handle_connection_error_with_reauth(exc, login_func)
+    elif common_exc := _map_common_exception(exc):
+        raise common_exc from None
     elif isinstance(exc, JumpstarterException):
         raise ClickExceptionRed(str(exc)) from None
     elif isinstance(exc, click.ClickException):

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
@@ -1,4 +1,5 @@
 import ssl
+from json import JSONDecodeError
 
 import click
 import pytest
@@ -70,3 +71,62 @@ def test_handle_exceptions_maps_connection_refused() -> None:
 
     with pytest.raises(click.ClickException, match="Connection was refused"):
         connection_refused_fn()
+
+
+def test_handle_exceptions_maps_json_decode_error() -> None:
+    @handle_exceptions
+    def bad_json_fn():
+        raise JSONDecodeError("Expecting value", "x", 0)
+
+    with pytest.raises(click.ClickException, match="Received invalid JSON data"):
+        bad_json_fn()
+
+
+def test_handle_exceptions_maps_keyboard_interrupt() -> None:
+    @handle_exceptions
+    def interrupt_fn():
+        raise KeyboardInterrupt()
+
+    with pytest.raises(click.ClickException, match="Cancelled by user"):
+        interrupt_fn()
+
+
+def test_handle_exceptions_maps_click_abort() -> None:
+    @handle_exceptions
+    def abort_fn():
+        raise click.Abort()
+
+    with pytest.raises(click.ClickException, match="Aborted by user"):
+        abort_fn()
+
+
+def test_handle_exceptions_maps_grpc_unauthenticated() -> None:
+    class MockGrpcError(Exception):
+        def code(self):
+            return type("Code", (), {"name": "UNAUTHENTICATED"})()
+
+        def details(self):
+            return "token expired"
+
+    @handle_exceptions
+    def grpc_auth_fn():
+        raise MockGrpcError()
+
+    with pytest.raises(click.ClickException, match="Authentication or authorization failed"):
+        grpc_auth_fn()
+
+
+def test_handle_exceptions_maps_grpc_invalid_argument() -> None:
+    class MockGrpcError(Exception):
+        def code(self):
+            return type("Code", (), {"name": "INVALID_ARGUMENT"})()
+
+        def details(self):
+            return "invalid selector"
+
+    @handle_exceptions
+    def grpc_invalid_arg_fn():
+        raise MockGrpcError()
+
+    with pytest.raises(click.ClickException, match="Invalid request arguments"):
+        grpc_invalid_arg_fn()

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
@@ -11,6 +11,11 @@ from jumpstarter_cli_common.exceptions import (
 )
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 def test_handle_exceptions_maps_timeout_error() -> None:
     @handle_exceptions
     def timeout_fn():

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
@@ -1,0 +1,72 @@
+import ssl
+
+import click
+import pytest
+
+from jumpstarter_cli_common.exceptions import (
+    async_handle_exceptions,
+    handle_exceptions,
+    handle_exceptions_with_reauthentication,
+)
+
+
+def test_handle_exceptions_maps_timeout_error() -> None:
+    @handle_exceptions
+    def timeout_fn():
+        raise TimeoutError("flash operation exceeded timeout")
+
+    with pytest.raises(click.ClickException, match="Operation timed out"):
+        timeout_fn()
+
+
+def test_handle_exceptions_maps_tls_certificate_error() -> None:
+    @handle_exceptions
+    def cert_fn():
+        raise ssl.SSLCertVerificationError("certificate verify failed")
+
+    with pytest.raises(click.ClickException, match="TLS certificate validation failed"):
+        cert_fn()
+
+
+@pytest.mark.anyio
+async def test_async_handle_exceptions_maps_timeout_error() -> None:
+    @async_handle_exceptions
+    async def timeout_async_fn():
+        raise TimeoutError("deadline exceeded while waiting for flasher")
+
+    with pytest.raises(click.ClickException, match="Operation timed out"):
+        await timeout_async_fn()
+
+
+def test_handle_exceptions_with_reauth_still_maps_common_exceptions() -> None:
+    calls = []
+
+    def login_func(_config):
+        calls.append(True)
+
+    @handle_exceptions_with_reauthentication(login_func)
+    def timeout_fn():
+        raise TimeoutError("operation timed out")
+
+    with pytest.raises(click.ClickException, match="Operation timed out"):
+        timeout_fn()
+
+    assert calls == []
+
+
+def test_handle_exceptions_maps_file_not_found() -> None:
+    @handle_exceptions
+    def missing_file_fn():
+        raise FileNotFoundError("/tmp/missing.img")
+
+    with pytest.raises(click.ClickException, match="File not found"):
+        missing_file_fn()
+
+
+def test_handle_exceptions_maps_connection_refused() -> None:
+    @handle_exceptions
+    def connection_refused_fn():
+        raise ConnectionRefusedError("connection refused")
+
+    with pytest.raises(click.ClickException, match="Connection was refused"):
+        connection_refused_fn()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -1,5 +1,6 @@
 import ssl
 from typing import Any
+from urllib.parse import urlparse
 
 import aiohttp
 import click
@@ -21,6 +22,29 @@ from jumpstarter.config.user import UserConfigV1Alpha1
 
 # Default timeout for HTTP requests to prevent CLI from hanging indefinitely
 _HTTP_TIMEOUT_SECONDS = 30
+
+
+def _validate_login_endpoint_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise click.ClickException(
+            f"Invalid login endpoint '{url}': unsupported URL scheme '{parsed.scheme}'. Use http or https."
+        )
+    if not parsed.netloc:
+        raise click.ClickException(f"Invalid login endpoint '{url}': missing host.")
+
+
+def _validate_auth_config_payload(payload: Any, source_url: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"Invalid auth config response from {source_url}: expected a JSON object."
+        )
+    grpc_endpoint = payload.get("grpcEndpoint")
+    if not isinstance(grpc_endpoint, str) or not grpc_endpoint.strip():
+        raise click.ClickException(
+            f"Invalid auth config response from {source_url}: missing required field 'grpcEndpoint'."
+        )
+    return payload
 
 
 async def fetch_auth_config(
@@ -48,6 +72,8 @@ async def fetch_auth_config(
         scheme = "http" if use_http else "https"
         login_endpoint = f"{scheme}://{login_endpoint}"
 
+    _validate_login_endpoint_url(login_endpoint)
+
     url = f"{login_endpoint.rstrip('/')}/v1/auth/config"
 
     # Configure SSL context: False disables verification, True enables it
@@ -56,11 +82,26 @@ async def fetch_auth_config(
     # Use a timeout to prevent the CLI from hanging indefinitely
     timeout = aiohttp.ClientTimeout(total=_HTTP_TIMEOUT_SECONDS)
 
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.get(url, ssl=ssl_context) as response:
-            if response.status != 200:
-                raise click.ClickException(f"Failed to fetch auth config from {url}: HTTP {response.status}")
-            return await response.json()
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, ssl=ssl_context) as response:
+                if response.status != 200:
+                    raise click.ClickException(f"Failed to fetch auth config from {url}: HTTP {response.status}")
+                payload = await response.json()
+                return _validate_auth_config_payload(payload, url)
+    except aiohttp.ClientConnectorCertificateError as e:
+        raise click.ClickException(
+            f"TLS certificate verification failed while connecting to {login_endpoint}. "
+            "Verify the endpoint certificate, or use --insecure-login-tls only for testing."
+        ) from e
+    except aiohttp.ClientConnectorSSLError as e:
+        raise click.ClickException(
+            f"TLS handshake failed while connecting to {login_endpoint}: {e}"
+        ) from e
+    except TimeoutError as e:
+        raise click.ClickException(
+            f"Timed out while connecting to {login_endpoint}. Check network connectivity and retry."
+        ) from e
 
 
 def parse_login_argument(login_arg: str) -> tuple[str | None, str]:
@@ -72,9 +113,17 @@ def parse_login_argument(login_arg: str) -> tuple[str | None, str]:
     Returns:
         Tuple of (username, endpoint) where username may be None
     """
+    login_arg = login_arg.strip()
+    if login_arg == "":
+        raise click.ClickException("Login target cannot be empty.")
+
     if "@" in login_arg:
         # Split on the last @ to handle email-like usernames
         parts = login_arg.rsplit("@", 1)
+        if parts[0] == "":
+            raise click.ClickException("Client name before '@' cannot be empty.")
+        if parts[1] == "":
+            raise click.ClickException("Login endpoint after '@' cannot be empty.")
         return parts[0], parts[1]
     return None, login_arg
 
@@ -150,6 +199,8 @@ async def login(  # noqa: C901
     """
 
     confirm_insecure_tls(insecure_tls_config, nointeractive)
+    if insecure_login_http and insecure_login_tls:
+        raise click.UsageError("--insecure-login-http and --insecure-login-tls cannot be used together.")
 
     # Handle simplified login format: [client-name@]login.endpoint.com
     ca_bundle = None

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -1,7 +1,7 @@
+import json
 import ssl
 from typing import Any
 from urllib.parse import urlparse
-import json
 
 import aiohttp
 import click
@@ -25,11 +25,16 @@ from jumpstarter.config.user import UserConfigV1Alpha1
 _HTTP_TIMEOUT_SECONDS = 30
 
 
-def _validate_login_endpoint_url(url: str) -> None:
+def _validate_login_endpoint_url(url: str, *, allow_http: bool = False) -> None:
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
         raise click.ClickException(
             f"Invalid login endpoint '{url}': unsupported URL scheme '{parsed.scheme}'. Use http or https."
+        )
+    if parsed.scheme == "http" and not allow_http:
+        raise click.ClickException(
+            f"Refusing insecure login endpoint '{url}'. "
+            "Use --insecure-login-http to explicitly allow plain HTTP."
         )
     if not parsed.netloc:
         raise click.ClickException(f"Invalid login endpoint '{url}': missing host.")
@@ -73,7 +78,7 @@ async def fetch_auth_config(
         scheme = "http" if use_http else "https"
         login_endpoint = f"{scheme}://{login_endpoint}"
 
-    _validate_login_endpoint_url(login_endpoint)
+    _validate_login_endpoint_url(login_endpoint, allow_http=use_http)
 
     url = f"{login_endpoint.rstrip('/')}/v1/auth/config"
 
@@ -125,11 +130,13 @@ def parse_login_argument(login_arg: str) -> tuple[str | None, str]:
     if "@" in login_arg:
         # Split on the last @ to handle email-like usernames
         parts = login_arg.rsplit("@", 1)
-        if parts[0] == "":
+        client_name = parts[0].strip()
+        endpoint = parts[1].strip()
+        if client_name == "":
             raise click.ClickException("Client name before '@' cannot be empty.")
-        if parts[1] == "":
+        if endpoint == "":
             raise click.ClickException("Login endpoint after '@' cannot be empty.")
-        return parts[0], parts[1]
+        return client_name, endpoint
     return None, login_arg
 
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -1,6 +1,7 @@
 import ssl
 from typing import Any
 from urllib.parse import urlparse
+import json
 
 import aiohttp
 import click
@@ -97,6 +98,10 @@ async def fetch_auth_config(
     except aiohttp.ClientConnectorSSLError as e:
         raise click.ClickException(
             f"TLS handshake failed while connecting to {login_endpoint}: {e}"
+        ) from e
+    except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+        raise click.ClickException(
+            f"Invalid JSON response received from {url}. Verify the login endpoint or proxy configuration."
         ) from e
     except TimeoutError as e:
         raise click.ClickException(

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login_test.py
@@ -1,0 +1,91 @@
+import click
+import pytest
+from click.testing import CliRunner
+
+from jumpstarter_cli.jmp import jmp
+from jumpstarter_cli.login import (
+    _validate_auth_config_payload,
+    _validate_login_endpoint_url,
+    parse_login_argument,
+)
+
+
+def test_parse_login_argument_supports_client_and_endpoint() -> None:
+    username, endpoint = parse_login_argument("my-client@login.example.com")
+    assert username == "my-client"
+    assert endpoint == "login.example.com"
+
+
+def test_parse_login_argument_rejects_empty_target() -> None:
+    with pytest.raises(click.ClickException, match="Login target cannot be empty"):
+        parse_login_argument("   ")
+
+
+def test_parse_login_argument_rejects_empty_client_name() -> None:
+    with pytest.raises(click.ClickException, match="Client name before '@' cannot be empty"):
+        parse_login_argument("@login.example.com")
+
+
+def test_validate_login_endpoint_url_rejects_missing_host() -> None:
+    with pytest.raises(click.ClickException, match="missing host"):
+        _validate_login_endpoint_url("https:///v1/auth/config")
+
+
+def test_validate_login_endpoint_url_rejects_unsupported_scheme() -> None:
+    with pytest.raises(click.ClickException, match="unsupported URL scheme"):
+        _validate_login_endpoint_url("ftp://login.example.com")
+
+
+def test_validate_auth_config_payload_requires_grpc_endpoint() -> None:
+    with pytest.raises(click.ClickException, match="missing required field 'grpcEndpoint'"):
+        _validate_auth_config_payload({"namespace": "default"}, "https://login.example.com/v1/auth/config")
+
+
+def test_login_cli_shows_timeout_message(monkeypatch) -> None:
+    async def fake_fetch_auth_config(*args, **kwargs):
+        raise click.ClickException("Timed out while connecting to login.example.com.")
+
+    monkeypatch.setattr("jumpstarter_cli.login.fetch_auth_config", fake_fetch_auth_config)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        jmp,
+        ["login", "login.example.com", "--client-config", "/tmp/nonexistent-client.yaml"],
+    )
+
+    assert result.exit_code != 0
+    assert "Timed out while connecting to login.example.com." in result.output
+
+
+def test_login_cli_shows_certificate_message(monkeypatch) -> None:
+    async def fake_fetch_auth_config(*args, **kwargs):
+        raise click.ClickException("TLS certificate verification failed while connecting to login.example.com.")
+
+    monkeypatch.setattr("jumpstarter_cli.login.fetch_auth_config", fake_fetch_auth_config)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        jmp,
+        ["login", "login.example.com", "--client-config", "/tmp/nonexistent-client.yaml"],
+    )
+
+    assert result.exit_code != 0
+    assert "TLS certificate verification failed" in result.output
+
+
+def test_login_cli_rejects_conflicting_insecure_flags() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        jmp,
+        [
+            "login",
+            "login.example.com",
+            "--client-config",
+            "/tmp/nonexistent-client.yaml",
+            "--insecure-login-http",
+            "--insecure-login-tls",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--insecure-login-http and --insecure-login-tls cannot be used together" in result.output

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login_test.py
@@ -26,6 +26,17 @@ def test_parse_login_argument_rejects_empty_client_name() -> None:
         parse_login_argument("@login.example.com")
 
 
+def test_parse_login_argument_rejects_whitespace_only_endpoint() -> None:
+    with pytest.raises(click.ClickException, match="Login endpoint after '@' cannot be empty"):
+        parse_login_argument("my-client@   ")
+
+
+def test_parse_login_argument_trims_client_and_endpoint() -> None:
+    username, endpoint = parse_login_argument("  my-client  @  login.example.com  ")
+    assert username == "my-client"
+    assert endpoint == "login.example.com"
+
+
 def test_validate_login_endpoint_url_rejects_missing_host() -> None:
     with pytest.raises(click.ClickException, match="missing host"):
         _validate_login_endpoint_url("https:///v1/auth/config")
@@ -34,6 +45,15 @@ def test_validate_login_endpoint_url_rejects_missing_host() -> None:
 def test_validate_login_endpoint_url_rejects_unsupported_scheme() -> None:
     with pytest.raises(click.ClickException, match="unsupported URL scheme"):
         _validate_login_endpoint_url("ftp://login.example.com")
+
+
+def test_validate_login_endpoint_url_rejects_http_without_explicit_opt_in() -> None:
+    with pytest.raises(click.ClickException, match="Use --insecure-login-http"):
+        _validate_login_endpoint_url("http://login.example.com")
+
+
+def test_validate_login_endpoint_url_allows_http_with_explicit_opt_in() -> None:
+    _validate_login_endpoint_url("http://login.example.com", allow_http=True)
 
 
 def test_validate_auth_config_payload_requires_grpc_endpoint() -> None:

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -132,6 +132,8 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         power_off: bool = True,
     ):
         """Flash image to DUT"""
+        self._validate_flash_preflight(path, retries, cacert_file, insecure_tls, fls_binary_url, os_image_checksum)
+
         if bearer_token:
             bearer_token = self._validate_bearer_token(bearer_token)
 
@@ -258,6 +260,36 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         # total time in minutes:seconds
         minutes, seconds = divmod(total_time, 60)
         self.logger.info(f"Flashing completed in {int(minutes)}m {int(seconds):02d}s")
+
+    def _validate_flash_preflight(
+        self,
+        path: PathBuf,
+        retries: int,
+        cacert_file: str | None,
+        insecure_tls: bool,
+        fls_binary_url: str | None,
+        os_image_checksum: str | None,
+    ) -> None:
+        image_path = str(path).strip()
+        if image_path == "":
+            raise click.ClickException("Image path cannot be empty.")
+
+        if retries < 0:
+            raise click.ClickException("Retries must be a non-negative integer.")
+
+        if insecure_tls and cacert_file:
+            raise click.ClickException("Use either --insecure-tls or --cacert, not both.")
+
+        if os_image_checksum and not re.fullmatch(r"[A-Fa-f0-9]{64}", os_image_checksum.strip()):
+            raise click.ClickException("OS image checksum must be a valid SHA256 hex value (64 characters).")
+
+        if image_path.startswith(("http://", "https://")):
+            self._validate_http_url(image_path, "image URL")
+        elif image_path.startswith("oci://"):
+            self._validate_oci_reference(image_path)
+
+        if fls_binary_url:
+            self._validate_http_url(fls_binary_url, "FLS binary URL")
 
     def _categorize_exception(self, exception: Exception) -> FlashRetryableError | FlashNonRetryableError:
         """Categorize an exception as retryable or non-retryable.
@@ -1244,6 +1276,18 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
                 raise ArgumentError(f"Duplicate header '{key}'")
             seen.add(kl)
         return header_map
+
+    def _validate_http_url(self, url: str, name: str) -> None:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise click.ClickException(f"Invalid {name}: '{url}'. Expected an absolute http(s) URL.")
+
+    def _validate_oci_reference(self, ref: str) -> None:
+        parsed = urlparse(ref)
+        if not parsed.netloc or parsed.path in ("", "/"):
+            raise click.ClickException(
+                f"Invalid OCI image reference: '{ref}'. Expected format like oci://registry/repository:tag."
+            )
 
     def _parse_headers(self, headers: list[str]) -> dict[str, str]:
         header_map: dict[str, str] = {}

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -132,8 +132,6 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         power_off: bool = True,
     ):
         """Flash image to DUT"""
-        self._validate_flash_preflight(path, retries, cacert_file, insecure_tls, fls_binary_url, os_image_checksum)
-
         if bearer_token:
             bearer_token = self._validate_bearer_token(bearer_token)
 
@@ -260,36 +258,6 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         # total time in minutes:seconds
         minutes, seconds = divmod(total_time, 60)
         self.logger.info(f"Flashing completed in {int(minutes)}m {int(seconds):02d}s")
-
-    def _validate_flash_preflight(
-        self,
-        path: PathBuf,
-        retries: int,
-        cacert_file: str | None,
-        insecure_tls: bool,
-        fls_binary_url: str | None,
-        os_image_checksum: str | None,
-    ) -> None:
-        image_path = str(path).strip()
-        if image_path == "":
-            raise click.ClickException("Image path cannot be empty.")
-
-        if retries < 0:
-            raise click.ClickException("Retries must be a non-negative integer.")
-
-        if insecure_tls and cacert_file:
-            raise click.ClickException("Use either --insecure-tls or --cacert, not both.")
-
-        if os_image_checksum and not re.fullmatch(r"[A-Fa-f0-9]{64}", os_image_checksum.strip()):
-            raise click.ClickException("OS image checksum must be a valid SHA256 hex value (64 characters).")
-
-        if image_path.startswith(("http://", "https://")):
-            self._validate_http_url(image_path, "image URL")
-        elif image_path.startswith("oci://"):
-            self._validate_oci_reference(image_path)
-
-        if fls_binary_url:
-            self._validate_http_url(fls_binary_url, "FLS binary URL")
 
     def _categorize_exception(self, exception: Exception) -> FlashRetryableError | FlashNonRetryableError:
         """Categorize an exception as retryable or non-retryable.
@@ -1276,18 +1244,6 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
                 raise ArgumentError(f"Duplicate header '{key}'")
             seen.add(kl)
         return header_map
-
-    def _validate_http_url(self, url: str, name: str) -> None:
-        parsed = urlparse(url)
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            raise click.ClickException(f"Invalid {name}: '{url}'. Expected an absolute http(s) URL.")
-
-    def _validate_oci_reference(self, ref: str) -> None:
-        parsed = urlparse(ref)
-        if not parsed.netloc or parsed.path in ("", "/"):
-            raise click.ClickException(
-                f"Invalid OCI image reference: '{ref}'. Expected format like oci://registry/repository:tag."
-            )
 
     def _parse_headers(self, headers: list[str]) -> dict[str, str]:
         header_map: dict[str, str] = {}

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client_test.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client_test.py
@@ -4,7 +4,6 @@ from pathlib import PosixPath
 
 import click
 import pytest
-from click.testing import CliRunner
 
 from .client import BaseFlasherClient, FlashNonRetryableError, FlashRetryableError
 from jumpstarter.common.exceptions import ArgumentError
@@ -17,6 +16,8 @@ class MockFlasherClient(BaseFlasherClient):
         self._manifest = None
         self._console_debug = False
         self._redaction_values = set()
+        self.children = {}
+        self.methods_description = {}
         self.logger = type(
             "MockLogger",
             (),
@@ -446,61 +447,3 @@ def test_resolve_flash_parameters():
         client._resolve_flash_parameters(None, ("rootfs_no_colon",), None)
 
 
-def test_validate_flash_preflight_rejects_negative_retries():
-    client = MockFlasherClient()
-
-    with pytest.raises(click.ClickException, match="Retries must be a non-negative integer"):
-        client._validate_flash_preflight("image.img", -1, None, False, None, None)
-
-
-def test_validate_flash_preflight_rejects_conflicting_tls_options():
-    client = MockFlasherClient()
-
-    with pytest.raises(click.ClickException, match="Use either --insecure-tls or --cacert"):
-        client._validate_flash_preflight("image.img", 0, "/tmp/ca.crt", True, None, None)
-
-
-def test_validate_flash_preflight_rejects_invalid_checksum():
-    client = MockFlasherClient()
-
-    with pytest.raises(click.ClickException, match="OS image checksum must be a valid SHA256"):
-        client._validate_flash_preflight("image.img", 0, None, False, None, "1234")
-
-
-def test_validate_flash_preflight_rejects_invalid_http_url():
-    client = MockFlasherClient()
-
-    with pytest.raises(click.ClickException, match="Invalid image URL"):
-        client._validate_flash_preflight("https:///bad", 0, None, False, None, None)
-
-
-def test_validate_flash_preflight_rejects_invalid_oci_reference():
-    client = MockFlasherClient()
-
-    with pytest.raises(click.ClickException, match="Invalid OCI image reference"):
-        client._validate_flash_preflight("oci://", 0, None, False, None, None)
-
-
-def test_flash_cli_shows_preflight_error_for_negative_retries():
-    client = MockFlasherClient()
-    runner = CliRunner()
-
-    result = runner.invoke(client.cli(), ["flash", "image.img", "--retries", "-1"])
-
-    assert result.exit_code != 0
-    assert "Retries must be a non-negative integer" in result.output
-
-
-def test_flash_cli_shows_preflight_error_for_conflicting_tls_options(tmp_path):
-    client = MockFlasherClient()
-    runner = CliRunner()
-    cacert = tmp_path / "ca.crt"
-    cacert.write_text("dummy")
-
-    result = runner.invoke(
-        client.cli(),
-        ["flash", "image.img", "--insecure-tls", "--cacert", str(cacert)],
-    )
-
-    assert result.exit_code != 0
-    assert "Use either --insecure-tls or --cacert, not both" in result.output

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client_test.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client_test.py
@@ -4,6 +4,7 @@ from pathlib import PosixPath
 
 import click
 import pytest
+from click.testing import CliRunner
 
 from .client import BaseFlasherClient, FlashNonRetryableError, FlashRetryableError
 from jumpstarter.common.exceptions import ArgumentError
@@ -443,3 +444,63 @@ def test_resolve_flash_parameters():
         client._resolve_flash_parameters(None, None, None)
     with pytest.raises(click.UsageError):
         client._resolve_flash_parameters(None, ("rootfs_no_colon",), None)
+
+
+def test_validate_flash_preflight_rejects_negative_retries():
+    client = MockFlasherClient()
+
+    with pytest.raises(click.ClickException, match="Retries must be a non-negative integer"):
+        client._validate_flash_preflight("image.img", -1, None, False, None, None)
+
+
+def test_validate_flash_preflight_rejects_conflicting_tls_options():
+    client = MockFlasherClient()
+
+    with pytest.raises(click.ClickException, match="Use either --insecure-tls or --cacert"):
+        client._validate_flash_preflight("image.img", 0, "/tmp/ca.crt", True, None, None)
+
+
+def test_validate_flash_preflight_rejects_invalid_checksum():
+    client = MockFlasherClient()
+
+    with pytest.raises(click.ClickException, match="OS image checksum must be a valid SHA256"):
+        client._validate_flash_preflight("image.img", 0, None, False, None, "1234")
+
+
+def test_validate_flash_preflight_rejects_invalid_http_url():
+    client = MockFlasherClient()
+
+    with pytest.raises(click.ClickException, match="Invalid image URL"):
+        client._validate_flash_preflight("https:///bad", 0, None, False, None, None)
+
+
+def test_validate_flash_preflight_rejects_invalid_oci_reference():
+    client = MockFlasherClient()
+
+    with pytest.raises(click.ClickException, match="Invalid OCI image reference"):
+        client._validate_flash_preflight("oci://", 0, None, False, None, None)
+
+
+def test_flash_cli_shows_preflight_error_for_negative_retries():
+    client = MockFlasherClient()
+    runner = CliRunner()
+
+    result = runner.invoke(client.cli(), ["flash", "image.img", "--retries", "-1"])
+
+    assert result.exit_code != 0
+    assert "Retries must be a non-negative integer" in result.output
+
+
+def test_flash_cli_shows_preflight_error_for_conflicting_tls_options(tmp_path):
+    client = MockFlasherClient()
+    runner = CliRunner()
+    cacert = tmp_path / "ca.crt"
+    cacert.write_text("dummy")
+
+    result = runner.invoke(
+        client.cli(),
+        ["flash", "image.img", "--insecure-tls", "--cacert", str(cacert)],
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --insecure-tls or --cacert, not both" in result.output


### PR DESCRIPTION
Updated exception handling for J commands to show cleaner, actionable errors for common failures: timeouts, TLS/certificate issues, DNS/connection problems, file and permission errors, bad JSON, and user cancellations. It also now maps key gRPC errors (DEADLINE_EXCEEDED, UNAVAILABLE, UNAUTHENTICATED/PERMISSION_DENIED, INVALID_ARGUMENT) to friendlier messages.

Also made sure the re-auth wrapper uses the same fallback mapping and improved jmp login fetch handling so invalid JSON/content-type responses are reported clearly.

Related to: https://github.com/jumpstarter-dev/jumpstarter/issues/57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error messaging: timeouts, TLS cert issues, DNS, file/JSON errors, gRPC auth/argument problems and interrupts now map to clear, actionable CLI messages.
  * Stricter login validation: tighter checks on login endpoints, auth-config payloads, argument parsing, and conflicting insecure-flag handling.

* **Refactor**
  * Centralized exception translation for consistent error handling across sync/async flows.

* **Tests**
  * Added comprehensive tests for exception mappings, reauthentication flows, gRPC cases, and login validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->