### PR TITLE
cli: add lease transfer option

### DIFF
--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -350,16 +350,19 @@ EOF
   # Create a lease owned by test-client-oidc
   run jmp create lease --selector example.com/board=oidc --duration 1d -o yaml
   assert_success
-
-  # Get the lease name from the output
   LEASE_NAME=$(echo "$output" | go run github.com/mikefarah/yq/v4@latest '.name')
+
+  # Wait for the lease to become active
+  kubectl -n "${JS_NAMESPACE}" wait --timeout 60s --for=condition=Ready \
+    leases.jumpstarter.dev/"$LEASE_NAME"
 
   # Transfer the lease to test-client-legacy
   run jmp update lease "$LEASE_NAME" --to-client test-client-legacy -o yaml
   assert_success
   assert_output --partial "test-client-legacy"
 
-  jmp delete leases --all
+  # Delete as the new owner
+  jmp delete leases --client test-client-legacy --all
 }
 
 @test "can lease and connect to exporters" {

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -342,6 +342,26 @@ EOF
   jmp delete leases    --all
 }
 
+@test "can transfer lease to another client" {
+  wait_for_exporter
+
+  jmp config client use test-client-oidc
+
+  # Create a lease owned by test-client-oidc
+  run jmp create lease --selector example.com/board=oidc --duration 1d -o yaml
+  assert_success
+
+  # Get the lease name from the output
+  LEASE_NAME=$(echo "$output" | go run github.com/mikefarah/yq/v4@latest '.name')
+
+  # Transfer the lease to test-client-legacy
+  run jmp update lease "$LEASE_NAME" --to-client test-client-legacy -o yaml
+  assert_success
+  assert_output --partial "test-client-legacy"
+
+  jmp delete leases --all
+}
+
 @test "can lease and connect to exporters" {
   wait_for_exporter
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -275,6 +275,10 @@ async def _shell_with_signal_handling(  # noqa: C901
                         # Lease expired naturally (e.g. during beforeLease hook)
                         # — exit gracefully instead of showing a scary error
                         pass
+                    elif lease_used.lease_transferred:
+                        raise ExporterOfflineError(
+                            "Lease has been transferred to another client. Session is no longer valid."
+                        ) from None
                     else:
                         raise ExporterOfflineError("Connection to exporter lost") from None
                 else:

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/update.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/update.py
@@ -43,15 +43,15 @@ def update_lease(
     Update a lease
 
     Update the duration, begin time, and/or owner of an existing lease.
-    At least one of --duration, --begin-time, or --to_client must be specified.
+    At least one of --duration, --begin-time, or --to-client must be specified.
 
-    To transfer a lease to another client in the same namespace, use the --to_client option.
+    To transfer a lease to another client in the same namespace, use the --to-client option.
 
     Updating the begin time of an already active lease is not allowed.
     """
 
     if duration is None and begin_time is None and to_client is None:
-        raise click.UsageError("At least one of --duration, --begin-time, or --client must be specified")
+        raise click.UsageError("At least one of --duration, --begin-time, or --to-client must be specified")
 
     client_path = f"namespaces/{config.metadata.namespace}/clients/{to_client}" if to_client else None
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/update.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/update.py
@@ -23,20 +23,38 @@ def update():
 @click.argument("name")
 @opt_duration_partial(required=False)
 @opt_begin_time
+@click.option(
+    "--to-client",
+    type=str,
+    default=None,
+    help="Transfer lease to a different client in the same namespace",
+)
 @opt_output_all
 @handle_exceptions_with_reauthentication(relogin_client)
-def update_lease(config, name: str, duration: timedelta | None, begin_time: datetime | None, output: OutputType):
+def update_lease(
+    config,
+    name: str,
+    duration: timedelta | None,
+    begin_time: datetime | None,
+    to_client: str | None,
+    output: OutputType,
+):
     """
     Update a lease
 
-    Update the duration and/or begin time of an existing lease.
-    At least one of --duration or --begin-time must be specified.
+    Update the duration, begin time, and/or owner of an existing lease.
+    At least one of --duration, --begin-time, or --to_client must be specified.
+
+    To transfer a lease to another client in the same namespace, use the --to_client option.
+
     Updating the begin time of an already active lease is not allowed.
     """
 
-    if duration is None and begin_time is None:
-        raise click.UsageError("At least one of --duration or --begin-time must be specified")
+    if duration is None and begin_time is None and to_client is None:
+        raise click.UsageError("At least one of --duration, --begin-time, or --client must be specified")
 
-    lease = config.update_lease(name, duration=duration, begin_time=begin_time)
+    client_path = f"namespaces/{config.metadata.namespace}/clients/{to_client}" if to_client else None
+
+    lease = config.update_lease(name, duration=duration, begin_time=begin_time, client=client_path)
 
     model_print(lease, output)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/update_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/update_test.py
@@ -1,0 +1,94 @@
+import inspect
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+import click
+import pytest
+
+from jumpstarter_cli.update import update_lease
+
+
+def test_update_lease_with_to_client():
+    config = Mock()
+    config.metadata.namespace = "test-ns"
+    lease = Mock()
+    config.update_lease.return_value = lease
+
+    with patch("jumpstarter_cli.update.model_print") as model_print:
+        inspect.unwrap(update_lease.callback)(
+            config=config,
+            name="my-lease",
+            duration=None,
+            begin_time=None,
+            to_client="other-client",
+            output="yaml",
+        )
+
+    config.update_lease.assert_called_once_with(
+        "my-lease",
+        duration=None,
+        begin_time=None,
+        client="namespaces/test-ns/clients/other-client",
+    )
+    model_print.assert_called_once_with(lease, "yaml")
+
+
+def test_update_lease_with_duration_and_to_client():
+    config = Mock()
+    config.metadata.namespace = "test-ns"
+    lease = Mock()
+    config.update_lease.return_value = lease
+
+    with patch("jumpstarter_cli.update.model_print") as model_print:
+        inspect.unwrap(update_lease.callback)(
+            config=config,
+            name="my-lease",
+            duration=timedelta(hours=2),
+            begin_time=None,
+            to_client="other-client",
+            output="yaml",
+        )
+
+    config.update_lease.assert_called_once_with(
+        "my-lease",
+        duration=timedelta(hours=2),
+        begin_time=None,
+        client="namespaces/test-ns/clients/other-client",
+    )
+    model_print.assert_called_once_with(lease, "yaml")
+
+
+def test_update_lease_without_to_client():
+    config = Mock()
+    lease = Mock()
+    config.update_lease.return_value = lease
+
+    with patch("jumpstarter_cli.update.model_print") as model_print:
+        inspect.unwrap(update_lease.callback)(
+            config=config,
+            name="my-lease",
+            duration=timedelta(hours=1),
+            begin_time=None,
+            to_client=None,
+            output="yaml",
+        )
+
+    config.update_lease.assert_called_once_with(
+        "my-lease",
+        duration=timedelta(hours=1),
+        begin_time=None,
+        client=None,
+    )
+    model_print.assert_called_once_with(lease, "yaml")
+
+
+def test_update_lease_requires_at_least_one_option():
+    with pytest.raises(click.UsageError, match="At least one of"):
+        inspect.unwrap(update_lease.callback)(
+            config=Mock(),
+            name="my-lease",
+            duration=None,
+            begin_time=None,
+            to_client=None,
+            output="yaml",
+        )

--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -449,6 +449,7 @@ class ClientService:
         name: str,
         duration: timedelta | None = None,
         begin_time: datetime | None = None,
+        client: str | None = None,
     ):
         lease_pb = client_pb2.Lease(
             name="namespaces/{}/leases/{}".format(self.namespace, name),
@@ -468,8 +469,12 @@ class ClientService:
             lease_pb.begin_time.CopyFrom(timestamp_pb)
             update_fields.append("begin_time")
 
+        if client is not None:
+            lease_pb.client = client
+            update_fields.append("client")
+
         if not update_fields:
-            raise ValueError("At least one of duration or begin_time must be provided")
+            raise ValueError("At least one of duration, begin_time, or client must be provided")
 
         update_mask = field_mask_pb2.FieldMask()
         update_mask.FromJsonString(",".join(update_fields))

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -63,6 +63,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         default=None, init=False
     )  # Called when lease is ending
     lease_ended: bool = field(default=False, init=False)  # Set when lease expires naturally
+    lease_transferred: bool = field(default=False, init=False)  # Set when lease is transferred to another client
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -293,7 +294,15 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
                     attempt += 1
                     continue
                 # Exporter went offline or lease ended - log and exit gracefully
-                logger.warning("Connection to exporter lost: %s", e.details())
+                if "permission denied" in str(e.details()).lower():
+                    self.lease_transferred = True
+                    logger.warning(
+                        "Lease %s has been transferred to another client. "
+                        "Your session is no longer valid.",
+                        self.name,
+                    )
+                else:
+                    logger.warning("Connection to exporter lost: %s", e.details())
                 return
         async with connect_router_stream(
             response.router_endpoint, response.router_token, stream, self.tls_config, self.grpc_options

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -272,9 +272,10 @@ class ClientConfigV1Alpha1(BaseSettings):
         name: str,
         duration: timedelta | None = None,
         begin_time: datetime | None = None,
+        client: str | None = None,
     ):
         svc = ClientService(channel=await self.channel(), namespace=self.metadata.namespace)
-        return await svc.UpdateLease(name=name, duration=duration, begin_time=begin_time)
+        return await svc.UpdateLease(name=name, duration=duration, begin_time=begin_time, client=client)
 
     @asynccontextmanager
     async def lease_async(


### PR DESCRIPTION
Allow users to transfer the lease with:
```
 jmp update lease <lease name> --to-client <client name>
```