### PR TITLE
fix: use paginated resource listing to avoid gRPC message size limit

### DIFF
--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -367,19 +367,23 @@ EOF
 
   jmp config client use test-client-oidc
 
+  local pids=()
   for i in $(seq 1 101); do
     jmp admin create exporter -n "${JS_NAMESPACE}" "pagination-exp-${i}" --nointeractive \
       -l pagination=true --oidc-username "dex:pagination-exp-${i}" &
+    pids+=("$!")
     if (( i % 10 == 0 )); then wait; fi
   done
-  wait
+  for pid in "${pids[@]}"; do
+    wait "$pid"
+  done
 
-  run jmp get exporters -o yaml
+  run jmp get exporters --selector pagination=true -o yaml
   assert_success
 
   local count
   count=$(echo "$output" | grep -c '^ *name:')
-  [ "$count" -ge 101 ]
+  [ "$count" -eq 101 ]
 
   for i in $(seq 1 101); do
     jmp admin delete exporter --namespace "${JS_NAMESPACE}" "pagination-exp-${i}" --delete &

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -369,7 +369,7 @@ EOF
 
   for i in $(seq 1 101); do
     jmp admin create exporter -n "${JS_NAMESPACE}" "pagination-exp-${i}" --nointeractive \
-      --oidc-username "dex:pagination-exp-${i}" &
+      -l pagination=true --oidc-username "dex:pagination-exp-${i}" &
     if (( i % 10 == 0 )); then wait; fi
   done
   wait

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -348,9 +348,8 @@ EOF
   jmp config client use test-client-oidc
 
   for i in $(seq 1 101); do
-    jmp create lease --selector example.com/board=oidc --duration 1d &
+    jmp create lease --selector example.com/board=oidc --duration 1d
   done
-  wait
 
   run jmp get leases -o yaml
   assert_success
@@ -367,15 +366,9 @@ EOF
 
   jmp config client use test-client-oidc
 
-  local pids=()
   for i in $(seq 1 101); do
     jmp admin create exporter -n "${JS_NAMESPACE}" "pagination-exp-${i}" --nointeractive \
-      -l pagination=true --oidc-username "dex:pagination-exp-${i}" &
-    pids+=("$!")
-    if (( i % 10 == 0 )); then wait; fi
-  done
-  for pid in "${pids[@]}"; do
-    wait "$pid"
+      -l pagination=true --oidc-username "dex:pagination-exp-${i}"
   done
 
   run jmp get exporters --selector pagination=true -o yaml
@@ -386,10 +379,8 @@ EOF
   [ "$count" -eq 101 ]
 
   for i in $(seq 1 101); do
-    jmp admin delete exporter --namespace "${JS_NAMESPACE}" "pagination-exp-${i}" --delete &
-    if (( i % 10 == 0 )); then wait; fi
+    jmp admin delete exporter --namespace "${JS_NAMESPACE}" "pagination-exp-${i}" --delete
   done
-  wait
 }
 
 @test "can transfer lease to another client" {

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -342,6 +342,52 @@ EOF
   jmp delete leases    --all
 }
 
+@test "paginated lease listing returns all leases" {
+  wait_for_exporter
+
+  jmp config client use test-client-oidc
+
+  for i in $(seq 1 101); do
+    jmp create lease --selector example.com/board=oidc --duration 1d &
+  done
+  wait
+
+  run jmp get leases -o yaml
+  assert_success
+
+  local count
+  count=$(echo "$output" | grep -c '^ *name:')
+  [ "$count" -eq 101 ]
+
+  jmp delete leases --all
+}
+
+@test "paginated exporter listing returns all exporters" {
+  wait_for_exporter
+
+  jmp config client use test-client-oidc
+
+  for i in $(seq 1 101); do
+    jmp admin create exporter -n "${JS_NAMESPACE}" "pagination-exp-${i}" --nointeractive \
+      --oidc-username "dex:pagination-exp-${i}" &
+    if (( i % 10 == 0 )); then wait; fi
+  done
+  wait
+
+  run jmp get exporters -o yaml
+  assert_success
+
+  local count
+  count=$(echo "$output" | grep -c '^ *name:')
+  [ "$count" -ge 101 ]
+
+  for i in $(seq 1 101); do
+    jmp admin delete exporter --namespace "${JS_NAMESPACE}" "pagination-exp-${i}" --delete &
+    if (( i % 10 == 0 )); then wait; fi
+  done
+  wait
+}
+
 @test "can transfer lease to another client" {
   wait_for_exporter
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
@@ -207,6 +207,44 @@ class TestGetExportersLogic:
         assert exporters.include_leases is True
 
 
+class TestGetExportersCallsPaginatedMethod:
+    def test_get_exporters_calls_list_exporters(self):
+        from unittest.mock import patch
+
+        config = Mock()
+        config.list_exporters.return_value = ExporterList(
+            exporters=[], next_page_token=None
+        )
+
+        from jumpstarter_cli.get import get_exporters
+
+        with patch("jumpstarter_cli.get.model_print"):
+            get_exporters.callback.__wrapped__.__wrapped__(
+                config=config, selector=None, output="text", with_options=[]
+            )
+
+        config.list_exporters.assert_called_once_with(
+            filter=None, include_leases=False, include_online=False, include_status=False
+        )
+
+    def test_get_leases_calls_list_leases(self):
+        from unittest.mock import patch
+
+        lease_list = LeaseList(leases=[], next_page_token=None)
+
+        config = Mock()
+        config.list_leases.return_value = lease_list
+
+        from jumpstarter_cli.get import get_leases
+
+        with patch("jumpstarter_cli.get.model_print"):
+            get_leases.callback.__wrapped__.__wrapped__(
+                config=config, selector=None, output="text", show_all=False
+            )
+
+        config.list_leases.assert_called_once_with(filter=None, only_active=True)
+
+
 class TestGetExportersIntegration:
     """Integration tests for data flow"""
 

--- a/python/packages/jumpstarter/jumpstarter/common/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/common/grpc_test.py
@@ -1,0 +1,14 @@
+from jumpstarter.common.grpc import _override_default_grpc_options
+
+
+def test_default_options_preserve_existing_defaults():
+    options = dict(_override_default_grpc_options(None))
+    assert options["grpc.lb_policy_name"] == "round_robin"
+    assert options["grpc.keepalive_time_ms"] == 20000
+
+
+
+def test_user_options_override_defaults():
+    user_options = {"grpc.keepalive_time_ms": 50000}
+    options = dict(_override_default_grpc_options(user_options))
+    assert options["grpc.keepalive_time_ms"] == 50000

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -173,28 +173,57 @@ class ClientConfigV1Alpha1(BaseSettings):
         svc = ClientService(channel=await self.channel(), namespace=self.metadata.namespace)
         return await svc.GetExporter(name=name)
 
+    async def _collect_all_leases(self, svc, page_size=100, only_active=True, filter=None):
+        from jumpstarter.client.grpc import LeaseList
+
+        all_leases = []
+        page_token = None
+        while True:
+            page = await svc.ListLeases(
+                page_size=page_size,
+                page_token=page_token,
+                filter=filter,
+                only_active=only_active,
+            )
+            all_leases.extend(page.leases)
+            if not page.next_page_token:
+                break
+            page_token = page.next_page_token
+        return LeaseList(leases=all_leases, next_page_token=None)
+
     @_blocking_compat
     @_handle_connection_error
     async def list_exporters(
         self,
-        page_size: int | None = None,
-        page_token: str | None = None,
         filter: str | None = None,
         include_leases: bool = False,
         include_online: bool = False,
         include_status: bool = False,
+        page_size: int = 100,
     ):
-        svc = ClientService(channel=await self.channel(), namespace=self.metadata.namespace)
-        exporters_response = await svc.ListExporters(page_size=page_size, page_token=page_token, filter=filter)
+        from jumpstarter.client.grpc import ExporterList
 
-        # Set the include flags for display purposes
-        exporters_response.include_online = include_online
-        exporters_response.include_status = include_status
+        svc = ClientService(channel=await self.channel(), namespace=self.metadata.namespace)
+        all_exporters = []
+        page_token = None
+        while True:
+            page = await svc.ListExporters(
+                page_size=page_size,
+                page_token=page_token,
+                filter=filter,
+            )
+            all_exporters.extend(page.exporters)
+            if not page.next_page_token:
+                break
+            page_token = page.next_page_token
+        result = ExporterList(exporters=all_exporters, next_page_token=None)
+        result.include_online = include_online
+        result.include_status = include_status
 
         if not include_leases:
-            return exporters_response
+            return result
 
-        leases_response = await svc.ListLeases()
+        leases_response = await self._collect_all_leases(svc)
         lease_map = {}
         for lease in leases_response.leases:
             if lease.exporter and lease.effective_begin_time:
@@ -204,7 +233,7 @@ class ClientConfigV1Alpha1(BaseSettings):
                         lease_map[lease.exporter] = lease
 
         exporters_with_leases = []
-        for exporter in exporters_response.exporters:
+        for exporter in result.exporters:
             lease = lease_map.get(exporter.name)
             exporter_with_lease = Exporter(
                 namespace=exporter.namespace,
@@ -214,9 +243,9 @@ class ClientConfigV1Alpha1(BaseSettings):
                 lease=lease,
             )
             exporters_with_leases.append(exporter_with_lease)
-        exporters_response.include_leases = True
-        exporters_response.exporters = exporters_with_leases
-        return exporters_response
+        result.include_leases = True
+        result.exporters = exporters_with_leases
+        return result
 
     @_blocking_compat
     @_handle_connection_error
@@ -252,18 +281,12 @@ class ClientConfigV1Alpha1(BaseSettings):
     @_handle_connection_error
     async def list_leases(
         self,
-        page_size: int | None = None,
-        page_token: str | None = None,
         filter: str | None = None,
         only_active: bool = True,
+        page_size: int = 100,
     ):
         svc = ClientService(channel=await self.channel(), namespace=self.metadata.namespace)
-        return await svc.ListLeases(
-            page_size=page_size,
-            page_token=page_token,
-            filter=filter,
-            only_active=only_active,
-        )
+        return await self._collect_all_leases(svc, page_size=page_size, only_active=only_active, filter=filter)
 
     @_blocking_compat
     @_handle_connection_error

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -223,7 +223,7 @@ class ClientConfigV1Alpha1(BaseSettings):
         if not include_leases:
             return result
 
-        leases_response = await self._collect_all_leases(svc)
+        leases_response = await self._collect_all_leases(svc, page_size=page_size)
         lease_map = {}
         for lease in leases_response.leases:
             if lease.exporter and lease.effective_begin_time:

--- a/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -443,3 +443,128 @@ async def test_create_lease_passes_exporter_name():
         begin_time=None,
         lease_id=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_list_leases_paginates():
+    from jumpstarter.client.grpc import Lease, LeaseList
+
+    lease_a = Lease(
+        namespace="default", name="lease-a", selector="env=test",
+        duration=timedelta(hours=1), client="c", exporter="e", conditions=[],
+    )
+    lease_b = Lease(
+        namespace="default", name="lease-b", selector="env=test",
+        duration=timedelta(hours=1), client="c", exporter="e", conditions=[],
+    )
+    lease_c = Lease(
+        namespace="default", name="lease-c", selector="env=test",
+        duration=timedelta(hours=1), client="c", exporter="e", conditions=[],
+    )
+
+    page1 = LeaseList(leases=[lease_a], next_page_token="token1")
+    page2 = LeaseList(leases=[lease_b], next_page_token="token2")
+    page3 = LeaseList(leases=[lease_c], next_page_token="")
+
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+
+    mock_service = Mock()
+    mock_service.ListLeases = AsyncMock(side_effect=[page1, page2, page3])
+
+    with (
+        patch("jumpstarter.config.client.ClientConfigV1Alpha1.channel", AsyncMock(return_value=Mock())),
+        patch("jumpstarter.config.client.ClientService", return_value=mock_service),
+    ):
+        result = await config.list_leases(filter=None, only_active=False)
+
+    assert len(result.leases) == 3
+    assert [lease.name for lease in result.leases] == ["lease-a", "lease-b", "lease-c"]
+    assert result.next_page_token is None
+    assert mock_service.ListLeases.await_count == 3
+    calls = mock_service.ListLeases.call_args_list
+    assert calls[0].kwargs["page_size"] == 100
+    assert calls[0].kwargs["page_token"] is None
+    assert calls[1].kwargs["page_token"] == "token1"
+    assert calls[2].kwargs["page_token"] == "token2"
+
+
+@pytest.mark.asyncio
+async def test_list_leases_single_page():
+    from jumpstarter.client.grpc import Lease, LeaseList
+
+    lease_a = Lease(
+        namespace="default", name="lease-a", selector="env=test",
+        duration=timedelta(hours=1), client="c", exporter="e", conditions=[],
+    )
+
+    page1 = LeaseList(leases=[lease_a], next_page_token="")
+
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+
+    mock_service = Mock()
+    mock_service.ListLeases = AsyncMock(return_value=page1)
+
+    with (
+        patch("jumpstarter.config.client.ClientConfigV1Alpha1.channel", AsyncMock(return_value=Mock())),
+        patch("jumpstarter.config.client.ClientService", return_value=mock_service),
+    ):
+        result = await config.list_leases(filter=None, only_active=True)
+
+    assert len(result.leases) == 1
+    assert result.leases[0].name == "lease-a"
+    mock_service.ListLeases.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_exporters_paginates():
+    from jumpstarter.client.grpc import Exporter, ExporterList
+
+    exp_a = Exporter(
+        namespace="default", name="exporter-a", labels={"env": "test"},
+        online=True, lease=None,
+    )
+    exp_b = Exporter(
+        namespace="default", name="exporter-b", labels={"env": "test"},
+        online=True, lease=None,
+    )
+
+    page1 = ExporterList(exporters=[exp_a], next_page_token="tok1")
+    page2 = ExporterList(exporters=[exp_b], next_page_token="")
+
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+
+    mock_service = Mock()
+    mock_service.ListExporters = AsyncMock(side_effect=[page1, page2])
+
+    with (
+        patch("jumpstarter.config.client.ClientConfigV1Alpha1.channel", AsyncMock(return_value=Mock())),
+        patch("jumpstarter.config.client.ClientService", return_value=mock_service),
+    ):
+        result = await config.list_exporters(filter=None)
+
+    assert len(result.exporters) == 2
+    assert [e.name for e in result.exporters] == ["exporter-a", "exporter-b"]
+    assert result.next_page_token is None
+    assert mock_service.ListExporters.await_count == 2
+    calls = mock_service.ListExporters.call_args_list
+    assert calls[0].kwargs["page_size"] == 100
+    assert calls[0].kwargs["page_token"] is None
+    assert calls[1].kwargs["page_token"] == "tok1"

--- a/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -568,3 +568,42 @@ async def test_list_exporters_paginates():
     assert calls[0].kwargs["page_size"] == 100
     assert calls[0].kwargs["page_token"] is None
     assert calls[1].kwargs["page_token"] == "tok1"
+
+
+@pytest.mark.asyncio
+async def test_list_exporters_with_leases_propagates_page_size():
+    from jumpstarter.client.grpc import Exporter, ExporterList, Lease, LeaseList
+
+    exp = Exporter(
+        namespace="default", name="exporter-a", labels={"env": "test"},
+        online=True, lease=None,
+    )
+    lease = Lease(
+        namespace="default", name="lease-a", selector="env=test",
+        duration=timedelta(hours=1), client="c", exporter="exporter-a",
+        conditions=[],
+    )
+
+    exporter_page = ExporterList(exporters=[exp], next_page_token="")
+    lease_page = LeaseList(leases=[lease], next_page_token="")
+
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+
+    mock_service = Mock()
+    mock_service.ListExporters = AsyncMock(return_value=exporter_page)
+    mock_service.ListLeases = AsyncMock(return_value=lease_page)
+
+    with (
+        patch("jumpstarter.config.client.ClientConfigV1Alpha1.channel", AsyncMock(return_value=Mock())),
+        patch("jumpstarter.config.client.ClientService", return_value=mock_service),
+    ):
+        await config.list_exporters(filter=None, include_leases=True, page_size=50)
+
+    lease_calls = mock_service.ListLeases.call_args_list
+    assert lease_calls[0].kwargs["page_size"] == 50


### PR DESCRIPTION
## Summary
- Implement client-side pagination for `list_leases` and `list_exporters` on `ClientConfigV1Alpha1`, iterating through all pages (page_size=100) instead of returning a single page
- Remove duplicate single-page `list_leases`/`list_exporters` methods, keeping only the paginated versions
- Add `_collect_all_leases` shared helper to avoid duplicating the pagination loop (also used by `list_exporters` when enriching exporters with lease data)

Fixes #337

## Test plan
- [x] Unit tests: pagination across multiple pages for both leases and exporters (`test_list_leases_paginates`, `test_list_exporters_paginates`, `test_list_leases_single_page`)
- [x] Unit tests: CLI commands call paginated methods (`test_get_exporters_calls_list_exporters`, `test_get_leases_calls_list_leases`)
- [x] Unit tests: gRPC default options (`test_default_options_preserve_existing_defaults`, `test_user_options_override_defaults`)
- [x] E2E BATS test: create 101 leases and verify all are returned (`paginated lease listing returns all leases`)
- [x] E2E BATS test: create 101 exporters and verify all are returned (`paginated exporter listing returns all exporters`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)