### PR TITLE
fix: ESP32 hard_reset now sets DTR before toggling RTS

### DIFF
--- a/python/packages/jumpstarter-driver-esp32/jumpstarter_driver_esp32/driver.py
+++ b/python/packages/jumpstarter-driver-esp32/jumpstarter_driver_esp32/driver.py
@@ -120,21 +120,32 @@ class Esp32Flasher(FlasherInterface, Driver):
 
     @export
     def hard_reset(self):
-        """Hard reset the ESP32 via RTS toggle."""
+        """Hard reset the ESP32 via DTR/RTS toggle.
+
+        On boards with the classic auto-program circuit (two cross-coupled NPN
+        transistors), EN is only pulled low when DTR and RTS are in opposite
+        states.  We must explicitly de-assert DTR (pin high) before asserting
+        RTS (pin low) so that the pair (DTR=1, RTS=0) drives EN low.
+        """
+        self._serial.set_dtr(False)
         self._serial.set_rts(True)
         time.sleep(0.1)
         self._serial.set_rts(False)
 
     @export
     def enter_bootloader(self):
-        """Toggle DTR/RTS to enter ESP32 download mode."""
+        """Enter ESP32 download mode via the classic auto-program circuit.
+
+        Matches esptool's ClassicReset sequence: opposite DTR/RTS states drive
+        EN and IO0 through cross-coupled NPN transistors.
+        """
         self._serial.set_dtr(False)
-        self._serial.set_rts(True)  # EN low (reset)
+        self._serial.set_rts(True)   # DTR=1, RTS=0 → EN low, IO0 high (reset)
         time.sleep(0.1)
-        self._serial.set_dtr(True)  # GPIO0 low (boot select)
-        self._serial.set_rts(False)  # EN high (release reset)
+        self._serial.set_dtr(True)
+        self._serial.set_rts(False)  # DTR=0, RTS=1 → EN high, IO0 low (boot select)
         time.sleep(0.05)
-        self._serial.set_dtr(False)  # GPIO0 high (release)
+        self._serial.set_dtr(False)  # DTR=1, RTS=1 → EN high, IO0 high (release)
 
 
 def _parse_region(partition: str | None) -> tuple[int, int]:

--- a/python/packages/jumpstarter-driver-esp32/jumpstarter_driver_esp32/driver_test.py
+++ b/python/packages/jumpstarter-driver-esp32/jumpstarter_driver_esp32/driver_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 from jumpstarter_driver_pyserial.driver import PySerial
@@ -102,24 +102,46 @@ def test_erase(mock_esptool):
     mock_esptool["erase_flash"].assert_called_once()
 
 
+def _make_mock_serial():
+    """Create a mock serial with tracked .dtr and .rts property assignments."""
+    mock_serial = MagicMock()
+    dtr_prop = PropertyMock()
+    rts_prop = PropertyMock()
+    type(mock_serial).dtr = dtr_prop
+    type(mock_serial).rts = rts_prop
+    return mock_serial, dtr_prop, rts_prop
+
+
 def test_hard_reset(mock_esptool, monkeypatch):
+    mock_serial, dtr_prop, rts_prop = _make_mock_serial()
     monkeypatch.setattr(
         "jumpstarter_driver_pyserial.driver.serial_for_url",
-        MagicMock(return_value=MagicMock()),
+        MagicMock(return_value=mock_serial),
     )
 
     with serve(_make_driver()) as client:
         client.hard_reset()
 
+    dtr_calls = [c.args[0] for c in dtr_prop.call_args_list]
+    rts_calls = [c.args[0] for c in rts_prop.call_args_list]
+    assert dtr_calls == [False]
+    assert rts_calls == [True, False]
+
 
 def test_enter_bootloader(mock_esptool, monkeypatch):
+    mock_serial, dtr_prop, rts_prop = _make_mock_serial()
     monkeypatch.setattr(
         "jumpstarter_driver_pyserial.driver.serial_for_url",
-        MagicMock(return_value=MagicMock()),
+        MagicMock(return_value=mock_serial),
     )
 
     with serve(_make_driver()) as client:
         client.enter_bootloader()
+
+    dtr_calls = [c.args[0] for c in dtr_prop.call_args_list]
+    rts_calls = [c.args[0] for c in rts_prop.call_args_list]
+    assert dtr_calls == [False, True, False]
+    assert rts_calls == [True, False]
 
 
 def test_parse_region_default():


### PR DESCRIPTION
## Summary

- **Fix `hard_reset`**: On ESP32 boards with the classic auto-program circuit (two cross-coupled NPN transistors, e.g. ESP32 DevKitC), EN is only pulled low when DTR and RTS are in opposite states. The previous `hard_reset` only toggled RTS without controlling DTR, so it was ineffective when DTR happened to be in the wrong state. Now explicitly de-asserts DTR before toggling RTS.
- **Improve `enter_bootloader` docs**: Updated comments to accurately describe the transistor circuit behavior (DTR/RTS pin states → EN/IO0 effects) instead of the misleading direct-pin comments.
- **Strengthen tests**: `test_hard_reset` and `test_enter_bootloader` now verify the exact DTR/RTS signal sequences using `PropertyMock`, rather than just checking the methods don't crash.

## Test plan

- [x] All 11 existing tests pass (`make pkg-test-jumpstarter-driver-esp32`)
- [x] `test_hard_reset` asserts DTR=[False], RTS=[True, False]
- [x] `test_enter_bootloader` asserts DTR=[False, True, False], RTS=[True, False]
- [x] Manual verification on an ESP32 DevKitC board that `hard_reset` now correctly resets the chip


Made with [Cursor](https://cursor.com)