### PR TITLE
feat: show expires at and remaining columns in lease listing

### DIFF
--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -388,13 +388,16 @@ EOF
 
   jmp config client use test-client-oidc
 
-  jmp create lease --selector example.com/board=oidc --duration 1d
+  run jmp create lease --selector example.com/board=oidc --duration 1d -o yaml
+  assert_success
+  LEASE_NAME=$(echo "$output" | go run github.com/mikefarah/yq/v4@latest '.name')
 
   run env COLUMNS=200 jmp get leases
   assert_success
   assert_output --partial "EXPIRES AT"
   assert_output --partial "REMAINING"
-  jmp delete leases --all
+
+  jmp delete leases "$LEASE_NAME"
 }
 
 @test "can transfer lease to another client" {

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -388,16 +388,13 @@ EOF
 
   jmp config client use test-client-oidc
 
-  run jmp create lease --selector example.com/board=oidc --duration 1d -o yaml
-  assert_success
-  LEASE_NAME=$(echo "$output" | go run github.com/mikefarah/yq/v4@latest '.name')
+  jmp create lease --selector example.com/board=oidc --duration 1d
 
   run env COLUMNS=200 jmp get leases
   assert_success
   assert_output --partial "EXPIRES AT"
   assert_output --partial "REMAINING"
-
-  jmp delete leases "$LEASE_NAME"
+  jmp delete leases --all
 }
 
 @test "can transfer lease to another client" {

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -390,7 +390,7 @@ EOF
 
   jmp create lease --selector example.com/board=oidc --duration 1d
 
-  run jmp get leases
+  run env COLUMNS=200 jmp get leases
   assert_success
   assert_output --partial "EXPIRES AT"
   assert_output --partial "REMAINING"

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -383,6 +383,20 @@ EOF
   done
 }
 
+@test "lease listing shows expires at and remaining columns" {
+  wait_for_exporter
+
+  jmp config client use test-client-oidc
+
+  jmp create lease --selector example.com/board=oidc --duration 1d
+
+  run jmp get leases
+  assert_success
+  assert_output --partial "EXPIRES AT"
+  assert_output --partial "REMAINING"
+  jmp delete leases --all
+}
+
 @test "can transfer lease to another client" {
   wait_for_exporter
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
@@ -241,7 +241,7 @@ class TestGetExportersCallsPaginatedMethod:
 
         with patch("jumpstarter_cli.get.model_print"):
             get_leases.callback.__wrapped__.__wrapped__(
-                config=config, selector=None, output="text", show_all=False
+                config=config, selector=None, output="text", show_all=False, all_clients=False
             )
 
         config.list_leases.assert_called_once_with(filter=None, only_active=True)

--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -218,10 +218,11 @@ class Lease(BaseModel):
         return None
 
     @staticmethod
-    def _format_remaining(expires_at):
+    def _format_remaining(expires_at, *, now=None):
         if expires_at is None:
             return ""
-        now = datetime.now(tz=expires_at.tzinfo)
+        if now is None:
+            now = datetime.now(tz=expires_at.tzinfo)
         remaining = expires_at - now
         if remaining.total_seconds() <= 0:
             return "expired"

--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -225,10 +225,9 @@ class Lease(BaseModel):
         remaining = expires_at - now
         if remaining.total_seconds() <= 0:
             return "expired"
-        total_seconds = int(remaining.total_seconds())
-        days, remainder = divmod(total_seconds, 86400)
-        hours, remainder = divmod(remainder, 3600)
-        minutes, _ = divmod(remainder, 60)
+        days = remaining.days
+        hours = remaining.seconds // 3600
+        minutes = (remaining.seconds % 3600) // 60
         parts = []
         if days:
             parts.append(f"{days}d")

--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -203,27 +203,51 @@ class Lease(BaseModel):
     def rich_add_columns(cls, table):
         table.add_column("NAME", no_wrap=True)
         table.add_column("SELECTOR")
-        table.add_column("BEGIN TIME")
-        table.add_column("DURATION")
+        table.add_column("EXPIRES AT")
+        table.add_column("REMAINING")
         table.add_column("CLIENT")
         table.add_column("EXPORTER")
 
-    def rich_add_rows(self, table):
-        # Show effective_begin_time if active, otherwise show scheduled begin_time
-        begin_time = ""
-        if self.effective_begin_time:
-            begin_time = self.effective_begin_time.strftime("%Y-%m-%d %H:%M:%S")
-        elif self.begin_time:
-            begin_time = self.begin_time.strftime("%Y-%m-%d %H:%M:%S")
+    def _compute_expires_at(self):
+        if self.effective_end_time:
+            return self.effective_end_time
+        if self.effective_begin_time and self.duration:
+            return self.effective_begin_time + self.duration
+        if self.begin_time and self.duration:
+            return self.begin_time + self.duration
+        return None
 
-        # Show actual duration for ended leases, requested duration otherwise
-        duration = str(self.effective_duration if self.effective_end_time else self.duration or "")
+    @staticmethod
+    def _format_remaining(expires_at):
+        if expires_at is None:
+            return ""
+        now = datetime.now(tz=expires_at.tzinfo)
+        remaining = expires_at - now
+        if remaining.total_seconds() <= 0:
+            return "expired"
+        total_seconds = int(remaining.total_seconds())
+        days, remainder = divmod(total_seconds, 86400)
+        hours, remainder = divmod(remainder, 3600)
+        minutes, _ = divmod(remainder, 60)
+        parts = []
+        if days:
+            parts.append(f"{days}d")
+        if hours:
+            parts.append(f"{hours}h")
+        if minutes or not parts:
+            parts.append(f"{minutes}m")
+        return " ".join(parts)
+
+    def rich_add_rows(self, table):
+        expires_at = self._compute_expires_at()
+        expires_at_str = expires_at.strftime("%Y-%m-%d %H:%M:%S") if expires_at else ""
+        remaining_str = self._format_remaining(expires_at)
 
         table.add_row(
             self.name,
             self.selector,
-            begin_time,
-            duration,
+            expires_at_str,
+            remaining_str,
             self.client,
             self.exporter,
         )

--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -218,11 +218,10 @@ class Lease(BaseModel):
         return None
 
     @staticmethod
-    def _format_remaining(expires_at, *, now=None):
+    def _format_remaining(expires_at):
         if expires_at is None:
             return ""
-        if now is None:
-            now = datetime.now(tz=expires_at.tzinfo)
+        now = datetime.now(tz=expires_at.tzinfo)
         remaining = expires_at - now
         if remaining.total_seconds() <= 0:
             return "expired"

--- a/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
@@ -374,3 +374,101 @@ class TestExporterList:
         assert "my-client" in output
         assert "Scheduled" in output
         assert "2023-01-01 11:00:00" in output  # begin_time (10:00) + duration (1h)
+
+
+class TestLeaseRichDisplay:
+    def create_lease(
+        self,
+        name="test-lease",
+        selector="env=test",
+        duration=timedelta(hours=1),
+        effective_duration=None,
+        begin_time=None,
+        effective_begin_time=None,
+        effective_end_time=None,
+        client="test-client",
+        exporter="test-exporter",
+    ):
+        return Lease(
+            namespace="default",
+            name=name,
+            selector=selector,
+            duration=duration,
+            effective_duration=effective_duration,
+            begin_time=begin_time,
+            effective_begin_time=effective_begin_time,
+            effective_end_time=effective_end_time,
+            client=client,
+            exporter=exporter,
+            conditions=[],
+        )
+
+    def test_rich_add_columns_has_expires_at_and_remaining(self):
+        table = Table()
+        Lease.rich_add_columns(table)
+        columns = [col.header for col in table.columns]
+        assert columns == ["NAME", "SELECTOR", "EXPIRES AT", "REMAINING", "CLIENT", "EXPORTER"]
+
+    def test_rich_add_columns_excludes_begin_time_and_duration(self):
+        table = Table()
+        Lease.rich_add_columns(table)
+        columns = [col.header for col in table.columns]
+        assert "BEGIN TIME" not in columns
+        assert "DURATION" not in columns
+
+    def test_compute_expires_at_from_effective_end_time(self):
+        lease = self.create_lease(
+            effective_end_time=datetime(2023, 1, 1, 11, 0, 0),
+        )
+        assert lease._compute_expires_at() == datetime(2023, 1, 1, 11, 0, 0)
+
+    def test_compute_expires_at_from_effective_begin_and_duration(self):
+        lease = self.create_lease(
+            effective_begin_time=datetime(2023, 6, 15, 14, 30, 0),
+            duration=timedelta(hours=2),
+        )
+        assert lease._compute_expires_at() == datetime(2023, 6, 15, 16, 30, 0)
+
+    def test_compute_expires_at_from_begin_time_and_duration(self):
+        lease = self.create_lease(
+            begin_time=datetime(2023, 3, 10, 8, 0, 0),
+            duration=timedelta(minutes=30),
+        )
+        assert lease._compute_expires_at() == datetime(2023, 3, 10, 8, 30, 0)
+
+    def test_compute_expires_at_none_when_no_begin_time(self):
+        lease = self.create_lease()
+        assert lease._compute_expires_at() is None
+
+    def test_format_remaining_expired(self):
+        past = datetime(2020, 1, 1, 0, 0, 0)
+        assert Lease._format_remaining(past) == "expired"
+
+    def test_format_remaining_none(self):
+        assert Lease._format_remaining(None) == ""
+
+    def test_rich_add_rows_shows_expires_at(self):
+        lease = self.create_lease(
+            effective_begin_time=datetime(2023, 1, 1, 10, 0, 0),
+            effective_end_time=datetime(2023, 1, 1, 11, 0, 0),
+        )
+        table = Table()
+        Lease.rich_add_columns(table)
+        lease.rich_add_rows(table)
+
+        console = Console(file=StringIO(), width=200)
+        console.print(table)
+        output = console.file.getvalue()
+        assert "2023-01-01 11:00:00" in output
+
+    def test_rich_add_rows_empty_when_no_timing_data(self):
+        lease = self.create_lease()
+        table = Table()
+        Lease.rich_add_columns(table)
+        lease.rich_add_rows(table)
+
+        console = Console(file=StringIO(), width=200)
+        console.print(table)
+        output = console.file.getvalue()
+        assert "test-lease" in output
+        assert "test-client" in output

--- a/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
@@ -447,6 +447,21 @@ class TestLeaseRichDisplay:
     def test_format_remaining_none(self):
         assert Lease._format_remaining(None) == ""
 
+    def test_format_remaining_future(self):
+        now = datetime(2020, 1, 1, 0, 0, 0)
+        future = now + timedelta(days=1, hours=2, minutes=3)
+        assert Lease._format_remaining(future, now=now) == "1d 2h 3m"
+
+    def test_format_remaining_future_hours_only(self):
+        now = datetime(2020, 1, 1, 0, 0, 0)
+        future = now + timedelta(hours=5)
+        assert Lease._format_remaining(future, now=now) == "5h 0m"
+
+    def test_format_remaining_future_minutes_only(self):
+        now = datetime(2020, 1, 1, 0, 0, 0)
+        future = now + timedelta(minutes=45)
+        assert Lease._format_remaining(future, now=now) == "45m"
+
     def test_rich_add_rows_shows_expires_at(self):
         lease = self.create_lease(
             effective_begin_time=datetime(2023, 1, 1, 10, 0, 0),

--- a/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
@@ -447,21 +447,6 @@ class TestLeaseRichDisplay:
     def test_format_remaining_none(self):
         assert Lease._format_remaining(None) == ""
 
-    def test_format_remaining_future(self):
-        now = datetime(2020, 1, 1, 0, 0, 0)
-        future = now + timedelta(days=1, hours=2, minutes=3)
-        assert Lease._format_remaining(future, now=now) == "1d 2h 3m"
-
-    def test_format_remaining_future_hours_only(self):
-        now = datetime(2020, 1, 1, 0, 0, 0)
-        future = now + timedelta(hours=5)
-        assert Lease._format_remaining(future, now=now) == "5h 0m"
-
-    def test_format_remaining_future_minutes_only(self):
-        now = datetime(2020, 1, 1, 0, 0, 0)
-        future = now + timedelta(minutes=45)
-        assert Lease._format_remaining(future, now=now) == "45m"
-
     def test_rich_add_rows_shows_expires_at(self):
         lease = self.create_lease(
             effective_begin_time=datetime(2023, 1, 1, 10, 0, 0),

--- a/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from io import StringIO
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from rich.console import Console
 from rich.table import Table
@@ -446,6 +446,41 @@ class TestLeaseRichDisplay:
 
     def test_format_remaining_none(self):
         assert Lease._format_remaining(None) == ""
+
+    def test_format_remaining_days_hours_minutes(self):
+        now = datetime(2023, 1, 1, 0, 0, 0)
+        expires_at = datetime(2023, 1, 3, 3, 45, 0)
+        with patch("jumpstarter.client.grpc.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = now
+            assert Lease._format_remaining(expires_at) == "2d 3h 45m"
+
+    def test_format_remaining_hours_and_minutes(self):
+        now = datetime(2023, 1, 1, 0, 0, 0)
+        expires_at = datetime(2023, 1, 1, 5, 30, 0)
+        with patch("jumpstarter.client.grpc.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = now
+            assert Lease._format_remaining(expires_at) == "5h 30m"
+
+    def test_format_remaining_minutes_only(self):
+        now = datetime(2023, 1, 1, 0, 0, 0)
+        expires_at = datetime(2023, 1, 1, 0, 15, 0)
+        with patch("jumpstarter.client.grpc.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = now
+            assert Lease._format_remaining(expires_at) == "15m"
+
+    def test_format_remaining_zero_minutes_shows_0m(self):
+        now = datetime(2023, 1, 1, 0, 0, 0)
+        expires_at = datetime(2023, 1, 1, 0, 0, 30)
+        with patch("jumpstarter.client.grpc.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = now
+            assert Lease._format_remaining(expires_at) == "0m"
+
+    def test_format_remaining_days_only(self):
+        now = datetime(2023, 1, 1, 0, 0, 0)
+        expires_at = datetime(2023, 1, 4, 0, 0, 0)
+        with patch("jumpstarter.client.grpc.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = now
+            assert Lease._format_remaining(expires_at) == "3d"
 
     def test_rich_add_rows_shows_expires_at(self):
         lease = self.create_lease(


### PR DESCRIPTION
## Summary
- Replace `BEGIN TIME` and `DURATION` columns with `EXPIRES AT` and `REMAINING` in `jmp get leases` output
- `EXPIRES AT` shows the calculated expiration timestamp
- `REMAINING` shows human-readable time left (e.g. `2h 15m`) or `expired`

Fixes #32

## Test plan
- [x] Unit tests: column headers include EXPIRES AT and REMAINING (`test_rich_add_columns_has_expires_at_and_remaining`)
- [x] Unit tests: expiration computed from effective_end_time, effective_begin_time+duration, begin_time+duration (`test_compute_expires_at_*`)
- [x] Unit tests: remaining time formatting including expired state (`test_format_remaining_*`)
- [x] Unit tests: table rendering with and without timing data (`test_rich_add_rows_*`)
- [x] E2E BATS test: verify `jmp get leases` output contains EXPIRES AT and REMAINING columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)