### PR TITLE
fix: handle certificate errors gracefully in jmp login

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -7,6 +7,7 @@ import aiohttp
 import click
 from jumpstarter_cli_common.blocking import blocking
 from jumpstarter_cli_common.config import opt_config
+from jumpstarter_cli_common.exceptions import handle_exceptions
 from jumpstarter_cli_common.oidc import Config, decode_jwt_issuer, opt_oidc
 from jumpstarter_cli_common.opt import (
     confirm_insecure_tls,
@@ -173,6 +174,7 @@ def parse_login_argument(login_arg: str) -> tuple[str | None, str]:
 )
 @opt_nointeractive
 @opt_config(allow_missing=True)
+@handle_exceptions
 @blocking
 async def login(  # noqa: C901
     config,

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import ssl
 
 import click
 import pytest
@@ -165,3 +166,41 @@ def test_login_cli_rejects_conflicting_insecure_flags() -> None:
 
     assert result.exit_code != 0
     assert "--insecure-login-http and --insecure-login-tls cannot be used together" in result.output
+
+
+def test_login_maps_ssl_cert_error_during_oidc_to_friendly_message(monkeypatch) -> None:
+    auth_config = {
+        "grpcEndpoint": "grpc.example.com:443",
+        "namespace": "default",
+        "oidc": [{"issuer": "https://auth.example.com", "clientId": "test-client"}],
+    }
+
+    async def fake_fetch_auth_config(*args, **kwargs):
+        return auth_config
+
+    class FakeOidcConfig:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def authorization_code_grant(self, **kwargs):
+            raise ssl.SSLCertVerificationError("certificate verify failed")
+
+    monkeypatch.setattr("jumpstarter_cli.login.fetch_auth_config", fake_fetch_auth_config)
+    monkeypatch.setattr("jumpstarter_cli.login.Config", FakeOidcConfig)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        jmp,
+        [
+            "login",
+            "test-client@login.example.com",
+            "--client-config",
+            "/tmp/nonexistent-client.yaml",
+            "--nointeractive",
+            "--unsafe",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "TLS certificate validation failed" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary
- Add `@handle_exceptions` decorator to `jmp login` command to catch SSL certificate errors and display user-friendly messages instead of raw stack traces

Fixes #175

## Test plan
- [x] Unit test: SSL certificate error is mapped to a friendly ClickException (`test_login_ssl_cert_error_mapped_to_click_exception`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)