### PR TITLE
Remove unused Python code

### DIFF
--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
@@ -213,22 +213,6 @@ def get_token_remaining_seconds(token: str) -> float | None:
 TOKEN_EXPIRY_WARNING_SECONDS = 300
 
 
-def is_token_expired(token: str, buffer_seconds: int = 0) -> bool:
-    """Check if token is expired or will expire within buffer_seconds.
-
-    Args:
-        token: JWT token string
-        buffer_seconds: Consider expired if less than this many seconds remain
-
-    Returns:
-        True if token is expired or will expire within buffer
-        False if token is still valid (or has no exp claim)
-    """
-    remaining = get_token_remaining_seconds(token)
-    if remaining is None:
-        return False
-    return remaining < buffer_seconds
-
 
 def format_duration(seconds: float) -> str:
     """Format a duration in seconds as a human-readable string.

--- a/python/packages/jumpstarter-driver-http/jumpstarter_driver_http/driver.py
+++ b/python/packages/jumpstarter-driver-http/jumpstarter_driver_http/driver.py
@@ -15,9 +15,6 @@ class HttpServerError(Exception):
     """Base exception for HTTP server errors"""
 
 
-class FileWriteError(HttpServerError):
-    """Exception raised when file writing fails"""
-
 
 @dataclass(kw_only=True)
 class HttpServer(Driver):

--- a/python/packages/jumpstarter-driver-iscsi/jumpstarter_driver_iscsi/driver.py
+++ b/python/packages/jumpstarter-driver-iscsi/jumpstarter_driver_iscsi/driver.py
@@ -26,11 +26,6 @@ class ConfigurationError(ISCSIError):
     pass
 
 
-class StorageObjectError(ISCSIError):
-    """Error related to storage objects"""
-
-    pass
-
 
 @dataclass(kw_only=True)
 class ISCSI(Driver):

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/server.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/server.py
@@ -313,13 +313,6 @@ class TftpServerProtocol(asyncio.DatagramProtocol):
         asyncio.create_task(transfer.start())
 
 
-def is_subpath(path: pathlib.Path, root: pathlib.Path) -> bool:
-    try:
-        path.relative_to(root)
-        return True
-    except ValueError:
-        return False
-
 
 class TftpTransfer:
     """

--- a/python/packages/jumpstarter/jumpstarter/common/exceptions.py
+++ b/python/packages/jumpstarter/jumpstarter/common/exceptions.py
@@ -63,11 +63,6 @@ class ArgumentError(JumpstarterException):
     pass
 
 
-class FileAccessError(JumpstarterException):
-    """Raised when a file access error occurs."""
-
-    pass
-
 
 class FileNotFoundError(JumpstarterException, FileNotFoundError):
     """Raised when a file is not found."""

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
-from typing import Annotated, ClassVar, Literal, NoReturn, Optional, Self
+from typing import Annotated, ClassVar, Literal, Optional, Self
 
 import grpc
 import yaml
@@ -55,12 +55,6 @@ def _attach_config_if_expired_token(exc: ConnectionError, config: ClientConfigV1
     if "token is expired" in str(exc):
         exc.set_config(config)
 
-
-def raise_expired_token_error(config: ClientConfigV1Alpha1) -> NoReturn:
-    """Raise ConnectionError for expired token with config attached so re-auth can run."""
-    err = ConnectionError("token is expired")
-    err.set_config(config)
-    raise err
 
 
 def _handle_connection_error(f):

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -40,6 +40,9 @@ class HookExecutionError(Exception):
         """Returns True if the exporter should be shut down entirely."""
         return self.on_failure == "exit"
 
+    def should_end_lease(self) -> bool:
+        """Returns True if the lease should be ended."""
+        return self.on_failure in ("endLease", "exit")
 
 
 @dataclass

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -40,9 +40,6 @@ class HookExecutionError(Exception):
         """Returns True if the exporter should be shut down entirely."""
         return self.on_failure == "exit"
 
-    def should_end_lease(self) -> bool:
-        """Returns True if the lease should be ended."""
-        return self.on_failure in ("endLease", "exit")
 
 
 @dataclass

--- a/python/packages/jumpstarter/jumpstarter/exporter/session.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/session.py
@@ -348,10 +348,6 @@ class Session(
         """Add a log source mapping for a specific logger."""
         self._logging_handler.add_child_handler(logger_name, source)
 
-    def remove_logger_source(self, logger_name: str):
-        """Remove a log source mapping for a specific logger."""
-        self._logging_handler.remove_child_handler(logger_name)
-
     def context_log_source(self, logger_name: str, source: LogSource):
         """Context manager to temporarily set a log source for a specific logger."""
         return self._logging_handler.context_log_source(logger_name, source)


### PR DESCRIPTION
## Summary

- Remove 7 confirmed dead code symbols across 7 files (47 lines removed):
  - `FileAccessError` exception class (jumpstarter core)
  - `raise_expired_token_error` function (client config)
  - `remove_logger_source` method (exporter session)
  - `is_token_expired` function (CLI common)
  - `FileWriteError` exception class (HTTP driver)
  - `StorageObjectError` exception class (iSCSI driver)
  - `is_subpath` function (TFTP server) - filed #346 for missing path traversal check
- Restore `should_end_lease` on `HookExecutionError` (incorrectly identified as dead)

## Test plan

- [x] `make lint` passes with zero violations
- [x] `make test` passes (18 suites pass, 1 pre-existing opendal failure)
- [x] Verified zero remaining references to all removed symbols via grep
- [x] Re-ran vulture to confirm no cascading dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)