### PR TITLE
Fix path traversal vulnerability in TFTP server

### DIFF
--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/server.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/server.py
@@ -231,7 +231,7 @@ class TftpServerProtocol(asyncio.DatagramProtocol):
 
     async def _resolve_and_validate_path(self, filename: str, addr: Tuple[str, int]) -> Optional[str]:
         normalized = pathlib.PurePosixPath(filename)
-        if ".." in normalized.parts:
+        if ".." in normalized.parts or normalized.is_absolute():
             self.logger.error(f"Path traversal attempt from {addr}: {filename}")
             self._send_error(addr, TftpErrorCode.ACCESS_VIOLATION, "Access violation")
             return None

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/server.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/server.py
@@ -230,6 +230,12 @@ class TftpServerProtocol(asyncio.DatagramProtocol):
         return True
 
     async def _resolve_and_validate_path(self, filename: str, addr: Tuple[str, int]) -> Optional[str]:
+        normalized = pathlib.PurePosixPath(filename)
+        if ".." in normalized.parts:
+            self.logger.error(f"Path traversal attempt from {addr}: {filename}")
+            self._send_error(addr, TftpErrorCode.ACCESS_VIOLATION, "Access violation")
+            return None
+
         try:
             stat = await self.server.operator.stat(filename)
         except FileNotFoundError:

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/test_path_traversal.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/test_path_traversal.py
@@ -62,6 +62,11 @@ class TestResolveAndValidatePath:
         assert result == "file..name.txt"
 
     @pytest.mark.asyncio
+    async def test_rejects_absolute_path(self, protocol):
+        result = await protocol._resolve_and_validate_path("/etc/passwd", ("127.0.0.1", 12345))
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_sends_access_violation_on_traversal(self, protocol):
         await protocol._resolve_and_validate_path("../secret", ("127.0.0.1", 12345))
         protocol.transport.sendto.assert_called_once()

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/test_path_traversal.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/test_path_traversal.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jumpstarter_driver_tftp.server import TftpErrorCode, TftpServer, TftpServerProtocol
+
+
+@pytest.fixture
+def server():
+    operator = AsyncMock()
+    return TftpServer(
+        host="127.0.0.1",
+        port=0,
+        operator=operator,
+    )
+
+
+@pytest.fixture
+def protocol(server):
+    proto = TftpServerProtocol(server)
+    proto.transport = MagicMock()
+    return proto
+
+
+class TestResolveAndValidatePath:
+    @pytest.mark.asyncio
+    async def test_rejects_dot_dot_path(self, protocol):
+        result = await protocol._resolve_and_validate_path("..", ("127.0.0.1", 12345))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_dot_dot_prefix(self, protocol):
+        result = await protocol._resolve_and_validate_path("../etc/passwd", ("127.0.0.1", 12345))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_dot_dot_in_middle(self, protocol):
+        result = await protocol._resolve_and_validate_path("subdir/../../../etc/passwd", ("127.0.0.1", 12345))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_dot_dot_at_end(self, protocol):
+        result = await protocol._resolve_and_validate_path("subdir/..", ("127.0.0.1", 12345))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_allows_valid_filename(self, protocol, server):
+        stat_result = MagicMock()
+        stat_result.mode.is_file.return_value = True
+        server.operator.stat = AsyncMock(return_value=stat_result)
+
+        result = await protocol._resolve_and_validate_path("boot.img", ("127.0.0.1", 12345))
+        assert result == "boot.img"
+
+    @pytest.mark.asyncio
+    async def test_allows_filename_containing_dots(self, protocol, server):
+        stat_result = MagicMock()
+        stat_result.mode.is_file.return_value = True
+        server.operator.stat = AsyncMock(return_value=stat_result)
+
+        result = await protocol._resolve_and_validate_path("file..name.txt", ("127.0.0.1", 12345))
+        assert result == "file..name.txt"
+
+    @pytest.mark.asyncio
+    async def test_sends_access_violation_on_traversal(self, protocol):
+        await protocol._resolve_and_validate_path("../secret", ("127.0.0.1", 12345))
+        protocol.transport.sendto.assert_called_once()
+        sent_data = protocol.transport.sendto.call_args[0][0]
+        error_code = int.from_bytes(sent_data[2:4], "big")
+        assert error_code == TftpErrorCode.ACCESS_VIOLATION


### PR DESCRIPTION
## Summary

- Add path validation to `_resolve_and_validate_path` in the TFTP server to reject directory traversal (`..`) and absolute paths
- Returns `ACCESS_VIOLATION` error to the TFTP client on invalid paths
- Defense-in-depth: `_parse_request` already blocks `/` in filenames, but this guards against future filter changes

Closes #346

## Test plan

- [x] 8 unit tests covering traversal patterns (`..`, `../x`, `x/../../y`, `x/..`), absolute paths (`/etc/passwd`), valid filenames, and filenames with dots
- [x] Verified `ACCESS_VIOLATION` error code is sent to client
- [x] `ruff check` passes with zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)