### PR TITLE
Fix test_get_leases to include all_clients parameter

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
@@ -241,7 +241,7 @@ class TestGetExportersCallsPaginatedMethod:
 
         with patch("jumpstarter_cli.get.model_print"):
             get_leases.callback.__wrapped__.__wrapped__(
-                config=config, selector=None, output="text", show_all=False
+                config=config, selector=None, output="text", show_all=False, all_clients=False
             )
 
         config.list_leases.assert_called_once_with(filter=None, only_active=True)


### PR DESCRIPTION
The get_leases function now requires an all_clients parameter, but the test was not passing it, causing the test to fail.
