### PR TITLE
fix: attach config to ConnectionError on pre-flight token expiry check

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -261,7 +261,9 @@ async def _shell_with_signal_handling(  # noqa: C901
     if token:
         remaining = get_token_remaining_seconds(token)
         if remaining is not None and remaining <= 0:
-            raise ConnectionError("token is expired")
+            err = ConnectionError("token is expired")
+            err.set_config(config)
+            raise err
 
     async with create_task_group() as tg:
         tg.start_soon(signal_handler, tg.cancel_scope)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -1,4 +1,7 @@
+import base64
 import inspect
+import json
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
@@ -6,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import anyio
 import click
 import pytest
+from jumpstarter_cli_common.exceptions import handle_exceptions_with_reauthentication
 
 from jumpstarter_cli.shell import _resolve_lease_from_active_async, _shell_with_signal_handling, shell
 
@@ -269,3 +273,40 @@ def test_resolve_lease_handles_async_list_leases():
     selected = anyio.run(_resolve_lease_from_active_async, config)
     assert selected == "async-lease"
     config.list_leases.assert_called_once_with(only_active=True)
+
+
+def _make_expired_jwt() -> str:
+    """Create a JWT with an exp claim in the past (no signature verification needed)."""
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = b64url(json.dumps({"exp": int(time.time()) - 3600, "iss": "https://example.com"}).encode())
+    sig = b64url(b"fakesig")
+    return f"{header}.{payload}.{sig}"
+
+
+def test_expired_token_triggers_reauth():
+    config = _DummyConfig()
+    config.token = _make_expired_jwt()
+
+    login_mock = Mock()
+
+    @handle_exceptions_with_reauthentication(login_mock)
+    def run_shell():
+        anyio.run(
+            _shell_with_signal_handling,
+            config,
+            "board-type=virtual",
+            None,
+            None,
+            timedelta(minutes=1),
+            False,
+            (),
+            None,
+        )
+
+    with pytest.raises(click.ClickException, match="Please try again now"):
+        run_shell()
+
+    login_mock.assert_called_once_with(config)


### PR DESCRIPTION
The pre-flight token expiry check in _shell_with_signal_handling raised a bare ConnectionError("token is expired") without attaching the client config. When the re-auth handler called exc.get_config() it received None, causing an AttributeError crash in relogin_client().

Fixes: https://github.com/jumpstarter-dev/jumpstarter/issues/162