### PR TITLE
fix(operator): exclude internal DNS names from certs when using external issuer

### DIFF
--- a/controller/deploy/operator/internal/controller/jumpstarter/certificates.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/certificates.go
@@ -353,14 +353,16 @@ func (r *JumpstarterReconciler) reconcileServerCertificate(
 // reconcileControllerCertificate creates the TLS certificate for the controller.
 func (r *JumpstarterReconciler) reconcileControllerCertificate(ctx context.Context, js *operatorv1alpha1.Jumpstarter, issuerRef cmmeta.ObjectReference) error {
 	certName := js.Name + controllerCertSuffix
-	dnsNames := r.collectControllerDNSNames(js)
+	includeInternalNames := !isExternalIssuer(js)
+	dnsNames := r.collectControllerDNSNames(js, includeInternalNames)
 	return r.reconcileServerCertificate(ctx, js, issuerRef, certName, "controller", dnsNames, nil)
 }
 
 // reconcileRouterCertificate creates the TLS certificate for a specific router replica.
 func (r *JumpstarterReconciler) reconcileRouterCertificate(ctx context.Context, js *operatorv1alpha1.Jumpstarter, issuerRef cmmeta.ObjectReference, replicaIndex int32) error {
 	certName := fmt.Sprintf(js.Name+routerCertSuffix, replicaIndex)
-	dnsNames := r.collectRouterDNSNames(js, replicaIndex)
+	includeInternalNames := !isExternalIssuer(js)
+	dnsNames := r.collectRouterDNSNames(js, replicaIndex, includeInternalNames)
 	extraLabels := map[string]string{
 		"router-index": fmt.Sprintf("%d", replicaIndex),
 	}
@@ -368,16 +370,20 @@ func (r *JumpstarterReconciler) reconcileRouterCertificate(ctx context.Context, 
 }
 
 // collectControllerDNSNames collects all DNS names for the controller certificate.
-func (r *JumpstarterReconciler) collectControllerDNSNames(js *operatorv1alpha1.Jumpstarter) []string {
+// When includeInternalNames is false, internal Kubernetes service DNS names are
+// omitted so that external issuers (e.g. ACME/Let's Encrypt) don't attempt to
+// validate cluster-local domains they cannot resolve.
+func (r *JumpstarterReconciler) collectControllerDNSNames(js *operatorv1alpha1.Jumpstarter, includeInternalNames bool) []string {
 	dnsNames := make([]string, 0)
 
-	// Add default controller service name
-	dnsNames = append(dnsNames,
-		fmt.Sprintf("%s-controller", js.Name),
-		fmt.Sprintf("%s-controller.%s", js.Name, js.Namespace),
-		fmt.Sprintf("%s-controller.%s.svc", js.Name, js.Namespace),
-		fmt.Sprintf("%s-controller.%s.svc.cluster.local", js.Name, js.Namespace),
-	)
+	if includeInternalNames {
+		dnsNames = append(dnsNames,
+			fmt.Sprintf("%s-controller", js.Name),
+			fmt.Sprintf("%s-controller.%s", js.Name, js.Namespace),
+			fmt.Sprintf("%s-controller.%s.svc", js.Name, js.Namespace),
+			fmt.Sprintf("%s-controller.%s.svc.cluster.local", js.Name, js.Namespace),
+		)
+	}
 
 	// Add DNS names from configured endpoints
 	for _, endpoint := range js.Spec.Controller.GRPC.Endpoints {
@@ -401,17 +407,21 @@ func (r *JumpstarterReconciler) collectControllerDNSNames(js *operatorv1alpha1.J
 }
 
 // collectRouterDNSNames collects all DNS names for a specific router replica certificate.
-func (r *JumpstarterReconciler) collectRouterDNSNames(js *operatorv1alpha1.Jumpstarter, replicaIndex int32) []string {
+// When includeInternalNames is false, internal Kubernetes service DNS names are
+// omitted so that external issuers (e.g. ACME/Let's Encrypt) don't attempt to
+// validate cluster-local domains they cannot resolve.
+func (r *JumpstarterReconciler) collectRouterDNSNames(js *operatorv1alpha1.Jumpstarter, replicaIndex int32, includeInternalNames bool) []string {
 	dnsNames := make([]string, 0)
 
-	// Add default router service name
-	serviceName := fmt.Sprintf("%s-router-%d", js.Name, replicaIndex)
-	dnsNames = append(dnsNames,
-		serviceName,
-		fmt.Sprintf("%s.%s", serviceName, js.Namespace),
-		fmt.Sprintf("%s.%s.svc", serviceName, js.Namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, js.Namespace),
-	)
+	if includeInternalNames {
+		serviceName := fmt.Sprintf("%s-router-%d", js.Name, replicaIndex)
+		dnsNames = append(dnsNames,
+			serviceName,
+			fmt.Sprintf("%s.%s", serviceName, js.Namespace),
+			fmt.Sprintf("%s.%s.svc", serviceName, js.Namespace),
+			fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, js.Namespace),
+		)
+	}
 
 	// Add DNS names from configured endpoints (with replica substitution)
 	for _, endpoint := range js.Spec.Routers.GRPC.Endpoints {
@@ -602,6 +612,13 @@ func extractHostname(address string) string {
 	// If SplitHostPort failed, there's no port in the address
 	// Return the full address (handles plain IPv6, IPv4, or hostname)
 	return address
+}
+
+// isExternalIssuer returns true when the Jumpstarter CR is configured to use
+// an external cert-manager Issuer/ClusterIssuer rather than the operator-managed
+// self-signed CA.
+func isExternalIssuer(js *operatorv1alpha1.Jumpstarter) bool {
+	return js.Spec.CertManager.Server != nil && js.Spec.CertManager.Server.IssuerRef != nil
 }
 
 // contains checks if a string slice contains a specific string.

--- a/controller/deploy/operator/internal/controller/jumpstarter/certificates_test.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/certificates_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2025. The Jumpstarter Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jumpstarter
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/deploy/operator/api/v1alpha1"
+)
+
+var _ = Describe("isExternalIssuer", func() {
+	It("should return false when Server is nil", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				CertManager: operatorv1alpha1.CertManagerConfig{
+					Enabled: true,
+				},
+			},
+		}
+		Expect(isExternalIssuer(js)).To(BeFalse())
+	})
+
+	It("should return false when IssuerRef is nil (self-signed)", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				CertManager: operatorv1alpha1.CertManagerConfig{
+					Enabled: true,
+					Server: &operatorv1alpha1.ServerCertConfig{
+						SelfSigned: &operatorv1alpha1.SelfSignedConfig{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		}
+		Expect(isExternalIssuer(js)).To(BeFalse())
+	})
+
+	It("should return true when IssuerRef is set", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				CertManager: operatorv1alpha1.CertManagerConfig{
+					Enabled: true,
+					Server: &operatorv1alpha1.ServerCertConfig{
+						IssuerRef: &operatorv1alpha1.IssuerReference{
+							Name: "letsencrypt-prod",
+							Kind: "ClusterIssuer",
+						},
+					},
+				},
+			},
+		}
+		Expect(isExternalIssuer(js)).To(BeTrue())
+	})
+})
+
+var _ = Describe("collectControllerDNSNames", func() {
+	var r *JumpstarterReconciler
+
+	BeforeEach(func() {
+		r = &JumpstarterReconciler{}
+	})
+
+	Context("with includeInternalNames=true (self-signed mode)", func() {
+		It("should include internal K8s service DNS names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+				},
+			}
+
+			names := r.collectControllerDNSNames(js, true)
+			Expect(names).To(ContainElements(
+				"jumpstarter-controller",
+				"jumpstarter-controller.test-ns",
+				"jumpstarter-controller.test-ns.svc",
+				"jumpstarter-controller.test-ns.svc.cluster.local",
+				"grpc.example.com",
+			))
+		})
+
+		It("should include both internal names and endpoint names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+					Controller: operatorv1alpha1.ControllerConfig{
+						GRPC: operatorv1alpha1.GRPCConfig{
+							Endpoints: []operatorv1alpha1.Endpoint{
+								{Address: "grpc.custom.example.com:443"},
+							},
+						},
+					},
+				},
+			}
+
+			names := r.collectControllerDNSNames(js, true)
+			Expect(names).To(ContainElements(
+				"jumpstarter-controller",
+				"jumpstarter-controller.test-ns",
+				"jumpstarter-controller.test-ns.svc",
+				"jumpstarter-controller.test-ns.svc.cluster.local",
+				"grpc.custom.example.com",
+				"grpc.example.com",
+			))
+		})
+	})
+
+	Context("with includeInternalNames=false (external issuer mode)", func() {
+		It("should NOT include internal K8s service DNS names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+				},
+			}
+
+			names := r.collectControllerDNSNames(js, false)
+			Expect(names).NotTo(ContainElement("jumpstarter-controller"))
+			Expect(names).NotTo(ContainElement("jumpstarter-controller.test-ns"))
+			Expect(names).NotTo(ContainElement("jumpstarter-controller.test-ns.svc"))
+			Expect(names).NotTo(ContainElement("jumpstarter-controller.test-ns.svc.cluster.local"))
+			Expect(names).To(ContainElement("grpc.example.com"))
+		})
+
+		It("should include only endpoint and baseDomain names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+					Controller: operatorv1alpha1.ControllerConfig{
+						GRPC: operatorv1alpha1.GRPCConfig{
+							Endpoints: []operatorv1alpha1.Endpoint{
+								{Address: "grpc.custom.example.com:443"},
+							},
+						},
+					},
+				},
+			}
+
+			names := r.collectControllerDNSNames(js, false)
+			Expect(names).To(ConsistOf(
+				"grpc.custom.example.com",
+				"grpc.example.com",
+			))
+		})
+
+		It("should return only baseDomain name when no endpoints configured", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+				},
+			}
+
+			names := r.collectControllerDNSNames(js, false)
+			Expect(names).To(ConsistOf("grpc.example.com"))
+		})
+	})
+})
+
+var _ = Describe("collectRouterDNSNames", func() {
+	var r *JumpstarterReconciler
+
+	BeforeEach(func() {
+		r = &JumpstarterReconciler{}
+	})
+
+	Context("with includeInternalNames=true (self-signed mode)", func() {
+		It("should include internal K8s service DNS names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+				},
+			}
+
+			names := r.collectRouterDNSNames(js, 0, true)
+			Expect(names).To(ContainElements(
+				"jumpstarter-router-0",
+				"jumpstarter-router-0.test-ns",
+				"jumpstarter-router-0.test-ns.svc",
+				"jumpstarter-router-0.test-ns.svc.cluster.local",
+				"router-0.example.com",
+			))
+		})
+
+		It("should include both internal names and endpoint names with replica substitution", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+					Routers: operatorv1alpha1.RoutersConfig{
+						GRPC: operatorv1alpha1.GRPCConfig{
+							Endpoints: []operatorv1alpha1.Endpoint{
+								{Address: "router-$(replica).custom.example.com:443"},
+							},
+						},
+					},
+				},
+			}
+
+			names := r.collectRouterDNSNames(js, 2, true)
+			Expect(names).To(ContainElements(
+				"jumpstarter-router-2",
+				"jumpstarter-router-2.test-ns",
+				"jumpstarter-router-2.test-ns.svc",
+				"jumpstarter-router-2.test-ns.svc.cluster.local",
+				"router-2.custom.example.com",
+				"router-2.example.com",
+			))
+		})
+	})
+
+	Context("with includeInternalNames=false (external issuer mode)", func() {
+		It("should NOT include internal K8s service DNS names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+				},
+			}
+
+			names := r.collectRouterDNSNames(js, 0, false)
+			Expect(names).NotTo(ContainElement("jumpstarter-router-0"))
+			Expect(names).NotTo(ContainElement("jumpstarter-router-0.test-ns"))
+			Expect(names).NotTo(ContainElement("jumpstarter-router-0.test-ns.svc"))
+			Expect(names).NotTo(ContainElement("jumpstarter-router-0.test-ns.svc.cluster.local"))
+			Expect(names).To(ContainElement("router-0.example.com"))
+		})
+
+		It("should include only endpoint and baseDomain names", func() {
+			js := &operatorv1alpha1.Jumpstarter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jumpstarter",
+					Namespace: "test-ns",
+				},
+				Spec: operatorv1alpha1.JumpstarterSpec{
+					BaseDomain: "example.com",
+					Routers: operatorv1alpha1.RoutersConfig{
+						GRPC: operatorv1alpha1.GRPCConfig{
+							Endpoints: []operatorv1alpha1.Endpoint{
+								{Address: "router-$(replica).custom.example.com:443"},
+							},
+						},
+					},
+				},
+			}
+
+			names := r.collectRouterDNSNames(js, 1, false)
+			Expect(names).To(ConsistOf(
+				"router-1.custom.example.com",
+				"router-1.example.com",
+			))
+		})
+	})
+})

--- a/controller/deploy/operator/test/e2e/e2e_test.go
+++ b/controller/deploy/operator/test/e2e/e2e_test.go
@@ -1817,6 +1817,12 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(cert.Spec.IssuerRef.Name).To(Equal(clusterIssuerName))
 				g.Expect(cert.Spec.IssuerRef.Kind).To(Equal("ClusterIssuer"))
+
+				// External issuer certificates must NOT contain internal K8s service DNS
+				// names, otherwise ACME issuers (e.g. Let's Encrypt) will reject them.
+				g.Expect(cert.Spec.DNSNames).NotTo(ContainElement(jumpstarterName + "-controller"))
+				g.Expect(cert.Spec.DNSNames).NotTo(ContainElement(ContainSubstring(".svc.cluster.local")))
+				g.Expect(cert.Spec.DNSNames).To(ContainElement("grpc." + baseDomain))
 			}, 1*time.Minute).Should(Succeed())
 
 			waitForCertificateReady(externalIssuerTestNamespace, controllerCertName, 2*time.Minute)
@@ -1837,6 +1843,12 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(cert.Spec.IssuerRef.Name).To(Equal(clusterIssuerName))
 				g.Expect(cert.Spec.IssuerRef.Kind).To(Equal("ClusterIssuer"))
+
+				// External issuer certificates must NOT contain internal K8s service DNS
+				// names, otherwise ACME issuers (e.g. Let's Encrypt) will reject them.
+				g.Expect(cert.Spec.DNSNames).NotTo(ContainElement(fmt.Sprintf("%s-router-0", jumpstarterName)))
+				g.Expect(cert.Spec.DNSNames).NotTo(ContainElement(ContainSubstring(".svc.cluster.local")))
+				g.Expect(cert.Spec.DNSNames).To(ContainElement("router-0." + baseDomain))
 			}, 1*time.Minute).Should(Succeed())
 
 			waitForCertificateReady(externalIssuerTestNamespace, routerCertName, 2*time.Minute)


### PR DESCRIPTION
## Summary

- When an external cert-manager issuer (e.g. Let's Encrypt) is configured via `spec.certManager.server.issuerRef`, the operator no longer includes internal Kubernetes service DNS names (like `jumpstarter-controller`, `*.svc.cluster.local`) in Certificate resources. These caused ACME validation failures because such domains are not publicly resolvable.
- Internal K8s service DNS names are still included when using self-signed CA mode (the default), which has no trouble issuing certs for any domain.
- Added unit tests for `collectControllerDNSNames`, `collectRouterDNSNames`, and `isExternalIssuer`, plus e2e test assertions verifying external issuer certificates contain only public DNS names.

Fixes #384

## Test plan

- [x] Unit tests pass (`make test` in operator directory)
- [x] New unit tests cover both `includeInternalNames=true` (self-signed) and `includeInternalNames=false` (external issuer) paths
- [x] E2e tests updated to assert controller/router certs do NOT contain internal DNS names when external issuer is used
- [ ] Manual validation: deploy with an ACME ClusterIssuer and verify Certificate resources only contain public DNS names


Made with [Cursor](https://cursor.com)