### PR TITLE
fix(opendal): pin opendal to <0.46 for Python Capability compatibility

### DIFF
--- a/python/packages/jumpstarter-driver-opendal/pyproject.toml
+++ b/python/packages/jumpstarter-driver-opendal/pyproject.toml
@@ -9,7 +9,11 @@ authors = [
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["jumpstarter", "opendal>=0.45.8", "click>=8.1.7.2"]
+dependencies = [
+  "jumpstarter",
+  "opendal>=0.45.8,<0.46",
+  "click>=8.1.7.2",
+]
 
 [project.entry-points."jumpstarter.adapters"]
 Opendal = "jumpstarter_driver_opendal.adapters:OpendalAdapter"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2111,7 +2111,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.7.2" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "opendal", specifier = ">=0.45.8" },
+    { name = "opendal", specifier = ">=0.45.8,<0.46" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
opendal 0.46.0 reshapes the Python Capability binding (it no longer exposes `blocking`, among other API shifts). Our Pydantic model still matches the 0.45.x surface; unbounded >=0.45.8 can resolve to 0.46.0 and break capability validation in isolated tests/CI.

This has been incorporated in release-0.8 through https://github.com/jumpstarter-dev/jumpstarter/pull/315