### PR TITLE
docs: align production service guide with operator TLS and gRPC behavior

### DIFF
--- a/python/docs/source/getting-started/installation/service/service-production.md
+++ b/python/docs/source/getting-started/installation/service/service-production.md
@@ -23,28 +23,12 @@ Jumpstarter uses gRPC for communication, which has specific requirements for pro
 
 ### gRPC Requirements
 
-- **HTTP/2 Support**: gRPC requires HTTP/2, ensure your ingress controller or load balancer supports it
-- **gRPC Protocol**: Some ingress controllers require specific annotations for gRPC traffic
-- **Keep-Alive Settings**: Long-lived gRPC connections may need keep-alive configuration
-- **Load Balancing**: Use consistent hashing or session affinity for gRPC connections
+- **HTTP/2 Support**: gRPC requires HTTP/2; ensure the path from clients to the service supports it
+- **Keep-Alive Settings**: The Jumpstarter service and client configure gRPC keep-alive by default; you usually do not need to tune these separately.
 
-### TLS Termination Options
+### TLS for gRPC
 
-Choose one of these TLS termination approaches:
-
-**Option 1: TLS Termination at Ingress/Route (Recommended)**
-- Terminate TLS at the ingress controller or OpenShift route
-- Simpler certificate management
-- Better performance with fewer encryption hops
-
-**Option 2: End-to-End TLS**
-- TLS from client to Jumpstarter service
-- Higher security but more complex certificate management
-- Required for strict compliance environments
-
-```{warning}
-gRPC over HTTP/1.1 is not supported. Ensure your ingress controller supports HTTP/2 and is properly configured for gRPC traffic.
-```
+The [Jumpstarter operator](service-operator.md) installs gRPC with **TLS passthrough** at the ingress or route: encrypted traffic is forwarded to the controller and router pods, which terminate TLS. HTTP login endpoints use edge TLS termination instead.
 
 ## Installation
 


### PR DESCRIPTION
Simplify gRPC requirements to match how the cluster is actually wired: HTTP/2 path and built-in keep-alive. Replace generic TLS termination options with the operator model: gRPC TLS passthrough to controller and router, edge termination for HTTP login.