### PR TITLE
feat: add DDS driver using Eclipse CycloneDDS

### DIFF
--- a/python/docs/source/reference/package-apis/drivers/dds.md
+++ b/python/docs/source/reference/package-apis/drivers/dds.md
@@ -1,0 +1,1 @@
+../../../../../packages/jumpstarter-driver-dds/README.md

--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -37,6 +37,8 @@ Drivers that provide various communication interfaces:
 * **[BLE](ble.md)** (`jumpstarter-driver-ble`) - Bluetooth Low Energy communication
 * **[CAN](can.md)** (`jumpstarter-driver-can`) - Controller Area Network
   communication
+* **[DDS](dds.md)** (`jumpstarter-driver-dds`) - DDS (Data Distribution Service)
+  pub/sub communication using Eclipse CycloneDDS
 * **[HTTP](http.md)** (`jumpstarter-driver-http`) - HTTP communication
 * **[Mitmproxy](mitmproxy.md)** (`jumpstarter-driver-mitmproxy`) - HTTP(S) interception, mocking, and traffic recording
 * **[Network](network.md)** (`jumpstarter-driver-network`) - Network interfaces
@@ -117,6 +119,7 @@ androidemulator.md
 ble.md
 can.md
 corellium.md
+dds.md
 doip.md
 dutlink.md
 energenie.md

--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -30,6 +30,7 @@ Drivers that provide various communication interfaces:
 - **[ADB](adb.md)** (`jumpstarter-driver-adb`) - Android Debug Bridge tunneling
 - **[BLE](ble.md)** (`jumpstarter-driver-ble`) - Bluetooth Low Energy communication
 - **[CAN](can.md)** (`jumpstarter-driver-can`) - Controller Area Network communication
+- **[DDS](dds.md)** (`jumpstarter-driver-dds`) - DDS (Data Distribution Service) pub/sub communication using Eclipse CycloneDDS
 - **[HTTP](http.md)** (`jumpstarter-driver-http`) - HTTP communication
 - **[mitmproxy](mitmproxy.md)** (`jumpstarter-driver-mitmproxy`) - HTTP/HTTPS interception, mocking, and traffic recording
 - **[DUT Network](dut-network.md)** (`jumpstarter-driver-dut-network`) - DUT network isolation with bridge, DHCP, DNS, and NAT
@@ -102,6 +103,7 @@ androidemulator.md
 ble.md
 can.md
 corellium.md
+dds.md
 doip.md
 dut-network.md
 dutlink.md

--- a/python/packages/jumpstarter-driver-dds/.gitignore
+++ b/python/packages/jumpstarter-driver-dds/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-dds/README.md
+++ b/python/packages/jumpstarter-driver-dds/README.md
@@ -98,9 +98,11 @@ with env() as client:
     for sample in result.samples:
         print(f"Temp: {sample.data['value']} {sample.data['unit']}")
 
-    # Stream samples
-    for sample in dds.monitor("sensor/temperature"):
+    # Stream samples (bounded read -- monitor is infinite by default)
+    for i, sample in enumerate(dds.monitor("sensor/temperature")):
         print(f"Live: {sample.data}")
+        if i + 1 >= 10:
+            break
 
     dds.disconnect()
 ```

--- a/python/packages/jumpstarter-driver-dds/README.md
+++ b/python/packages/jumpstarter-driver-dds/README.md
@@ -1,0 +1,106 @@
+# DDS Driver
+
+`jumpstarter-driver-dds` provides DDS (Data Distribution Service) publish/subscribe
+communication for Jumpstarter using [Eclipse CycloneDDS](https://cyclonedds.io/).
+
+DDS is a middleware protocol standard (OMG DDS) for data-centric connectivity, widely used
+in automotive (AUTOSAR Adaptive), robotics (ROS 2), and IoT applications. This driver
+enables remote DDS domain participation, topic management, and pub/sub messaging.
+
+## Installation
+
+```shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-dds
+```
+
+## Configuration
+
+| Parameter              | Type   | Default      | Description                              |
+|------------------------|--------|--------------|------------------------------------------|
+| `domain_id`            | int    | 0            | DDS domain ID                            |
+| `default_reliability`  | str    | `RELIABLE`   | Default QoS reliability (`RELIABLE` or `BEST_EFFORT`) |
+| `default_durability`   | str    | `VOLATILE`   | Default QoS durability (`VOLATILE`, `TRANSIENT_LOCAL`, `TRANSIENT`, `PERSISTENT`) |
+| `default_history_depth`| int    | 10           | Default history depth for topics         |
+
+### Example exporter configuration
+
+```yaml
+export:
+  dds:
+    type: jumpstarter_driver_dds.driver.Dds
+    config:
+      domain_id: 0
+      default_reliability: RELIABLE
+      default_durability: VOLATILE
+      default_history_depth: 10
+```
+
+## Client API
+
+### Domain Lifecycle
+
+| Method                   | Description                                  |
+|--------------------------|----------------------------------------------|
+| `connect()`              | Connect to the DDS domain, create participant |
+| `disconnect()`           | Disconnect and release all resources          |
+| `get_participant_info()` | Get domain participant information            |
+
+### Topic Management
+
+| Method                                                 | Description                        |
+|--------------------------------------------------------|------------------------------------|
+| `create_topic(name, fields, reliability, durability, history_depth)` | Create a topic with schema and QoS |
+| `list_topics()`                                        | List all registered topics         |
+
+### Publish / Subscribe
+
+| Method                              | Description                              |
+|-------------------------------------|------------------------------------------|
+| `publish(topic_name, data)`         | Publish a data sample to a topic         |
+| `read(topic_name, max_samples=10)`  | Read (take) samples from a topic         |
+| `monitor(topic_name)`               | Stream samples from a topic as they arrive |
+
+### QoS Options
+
+**Reliability:**
+- `RELIABLE` -- Guaranteed delivery with acknowledgment
+- `BEST_EFFORT` -- Fire-and-forget, lowest latency
+
+**Durability:**
+- `VOLATILE` -- Samples only delivered to currently connected readers
+- `TRANSIENT_LOCAL` -- Late-joining readers receive cached samples
+- `TRANSIENT` -- Samples survive writer restarts
+- `PERSISTENT` -- Samples survive system restarts
+
+## Example Usage
+
+```python
+from jumpstarter.common.utils import env
+
+with env() as client:
+    dds = client.dds
+
+    # Connect to DDS domain
+    dds.connect()
+
+    # Create a topic with schema
+    dds.create_topic("sensor/temperature", ["value", "unit", "location"])
+
+    # Publish data
+    dds.publish("sensor/temperature", {
+        "value": "22.5",
+        "unit": "C",
+        "location": "lab1",
+    })
+
+    # Read samples
+    result = dds.read("sensor/temperature")
+    for sample in result.samples:
+        print(f"Temp: {sample.data['value']} {sample.data['unit']}")
+
+    # Stream samples
+    for sample in dds.monitor("sensor/temperature"):
+        print(f"Live: {sample.data}")
+
+    dds.disconnect()
+```

--- a/python/packages/jumpstarter-driver-dds/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-dds/examples/exporter.yaml
@@ -1,0 +1,15 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: dds-exporter
+endpoint: ""
+token: ""
+export:
+  dds:
+    type: jumpstarter_driver_dds.driver.Dds
+    config:
+      domain_id: 0
+      default_reliability: RELIABLE
+      default_durability: VOLATILE
+      default_history_depth: 10

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Generator
 from dataclasses import dataclass
 from typing import Any
@@ -73,6 +74,7 @@ class DdsClient(DriverClient):
 
     def _register_lifecycle_commands(self, base):
         """Register connect, disconnect, topics, and info CLI commands."""
+
         @base.command(name="connect")
         def connect_cmd():
             """Connect to DDS domain"""
@@ -94,9 +96,7 @@ class DdsClient(DriverClient):
                 return
             for t in topic_list:
                 click.echo(
-                    f"  {t.name}: fields={t.fields} "
-                    f"reliability={t.qos.reliability.value} "
-                    f"samples={t.sample_count}"
+                    f"  {t.name}: fields={t.fields} reliability={t.qos.reliability.value} samples={t.sample_count}"
                 )
 
         @base.command()
@@ -108,7 +108,28 @@ class DdsClient(DriverClient):
             click.echo(f"Topic count:  {pinfo.topic_count}")
 
     def _register_data_commands(self, base):
-        """Register read and monitor CLI commands."""
+        """Register create-topic, publish, read, and monitor CLI commands."""
+
+        @base.command(name="create-topic")
+        @click.argument("name")
+        @click.argument("fields", nargs=-1, required=True)
+        @click.option("--reliability", "-r", default=None, help="QoS reliability")
+        @click.option("--durability", "-d", default=None, help="QoS durability")
+        @click.option("--history-depth", "-h", default=None, type=int, help="History depth")
+        def create_topic_cmd(name, fields, reliability, durability, history_depth):
+            """Create a topic: create-topic NAME FIELD1 FIELD2 ..."""
+            topic = self.create_topic(name, list(fields), reliability, durability, history_depth)
+            click.echo(f"Created topic '{topic.name}' with fields {topic.fields}")
+
+        @base.command(name="publish")
+        @click.argument("topic_name")
+        @click.argument("data_json")
+        def publish_cmd(topic_name, data_json):
+            """Publish JSON data to a topic: publish TOPIC '{"key": "val"}'"""
+            data = json.loads(data_json)
+            result = self.publish(topic_name, data)
+            click.echo(f"Published {result.samples_written} sample(s) to {topic_name}")
+
         @base.command(name="read")
         @click.argument("topic_name")
         @click.option("--max-samples", "-n", default=10, help="Max samples to read")
@@ -131,6 +152,7 @@ class DdsClient(DriverClient):
 
     def cli(self):
         """Build and return the Click command group for this driver."""
+
         @driver_click_group(self)
         def base():
             """DDS pub/sub communication"""

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
@@ -50,9 +50,9 @@ class DdsClient(DriverClient):
     def list_topics(self) -> list[DdsTopicInfo]:
         """List all registered topics."""
         raw = self.call("list_topics")
-        if isinstance(raw, list):
-            return [DdsTopicInfo.model_validate(t) for t in raw]
-        return []
+        if not isinstance(raw, list):
+            raise TypeError(f"Expected list from list_topics(), got {type(raw).__name__}")
+        return [DdsTopicInfo.model_validate(t) for t in raw]
 
     def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
         """Publish a data sample to a DDS topic."""
@@ -72,13 +72,14 @@ class DdsClient(DriverClient):
             yield DdsSample.model_validate(v)
 
     def _register_lifecycle_commands(self, base):
-        @base.command()
+        """Register connect, disconnect, topics, and info CLI commands."""
+        @base.command(name="connect")
         def connect_cmd():
             """Connect to DDS domain"""
             info = self.connect()
             click.echo(f"Connected to DDS domain {info.domain_id}")
 
-        @base.command()
+        @base.command(name="disconnect")
         def disconnect_cmd():
             """Disconnect from DDS domain"""
             self.disconnect()
@@ -107,7 +108,8 @@ class DdsClient(DriverClient):
             click.echo(f"Topic count:  {pinfo.topic_count}")
 
     def _register_data_commands(self, base):
-        @base.command()
+        """Register read and monitor CLI commands."""
+        @base.command(name="read")
         @click.argument("topic_name")
         @click.option("--max-samples", "-n", default=10, help="Max samples to read")
         def read_cmd(topic_name, max_samples):
@@ -117,7 +119,7 @@ class DdsClient(DriverClient):
             for s in result.samples:
                 click.echo(f"  {s.data}")
 
-        @base.command()
+        @base.command(name="monitor")
         @click.argument("topic_name")
         @click.option("--count", "-n", default=10, help="Number of events")
         def monitor_cmd(topic_name, count):
@@ -128,6 +130,7 @@ class DdsClient(DriverClient):
                     break
 
     def cli(self):
+        """Build and return the Click command group for this driver."""
         @driver_click_group(self)
         def base():
             """DDS pub/sub communication"""

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
@@ -115,7 +115,7 @@ class DdsClient(DriverClient):
         @click.argument("fields", nargs=-1, required=True)
         @click.option("--reliability", "-r", default=None, help="QoS reliability")
         @click.option("--durability", "-d", default=None, help="QoS durability")
-        @click.option("--history-depth", "-h", default=None, type=int, help="History depth")
+        @click.option("--history-depth", "-H", default=None, type=int, help="History depth")
         def create_topic_cmd(name, fields, reliability, durability, history_depth):
             """Create a topic: create-topic NAME FIELD1 FIELD2 ..."""
             topic = self.create_topic(name, list(fields), reliability, durability, history_depth)

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+
+import click
+
+from .common import (
+    DdsParticipantInfo,
+    DdsPublishResult,
+    DdsReadResult,
+    DdsSample,
+    DdsTopicInfo,
+)
+from jumpstarter.client import DriverClient
+from jumpstarter.client.decorators import driver_click_group
+
+
+@dataclass(kw_only=True)
+class DdsClient(DriverClient):
+    """Client interface for DDS (Data Distribution Service).
+
+    Provides methods to manage DDS domain participation, create topics,
+    publish and subscribe to data, and monitor topic streams via the
+    Jumpstarter remoting layer.
+    """
+
+    def connect(self) -> DdsParticipantInfo:
+        """Connect to the DDS domain and create a domain participant."""
+        return DdsParticipantInfo.model_validate(self.call("connect"))
+
+    def disconnect(self) -> None:
+        """Disconnect from the DDS domain."""
+        self.call("disconnect")
+
+    def create_topic(
+        self,
+        name: str,
+        fields: list[str],
+        reliability: str | None = None,
+        durability: str | None = None,
+        history_depth: int | None = None,
+    ) -> DdsTopicInfo:
+        """Create a DDS topic with the given schema and QoS."""
+        return DdsTopicInfo.model_validate(
+            self.call("create_topic", name, fields, reliability, durability, history_depth)
+        )
+
+    def list_topics(self) -> list[DdsTopicInfo]:
+        """List all registered topics."""
+        raw = self.call("list_topics")
+        if isinstance(raw, list):
+            return [DdsTopicInfo.model_validate(t) for t in raw]
+        return []
+
+    def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        """Publish a data sample to a DDS topic."""
+        return DdsPublishResult.model_validate(self.call("publish", topic_name, data))
+
+    def read(self, topic_name: str, max_samples: int = 10) -> DdsReadResult:
+        """Read (take) samples from a DDS topic."""
+        return DdsReadResult.model_validate(self.call("read", topic_name, max_samples))
+
+    def get_participant_info(self) -> DdsParticipantInfo:
+        """Get information about the DDS domain participant."""
+        return DdsParticipantInfo.model_validate(self.call("get_participant_info"))
+
+    def monitor(self, topic_name: str) -> Generator[DdsSample, None, None]:
+        """Stream data samples from a topic as they arrive."""
+        for v in self.streamingcall("monitor", topic_name):
+            yield DdsSample.model_validate(v)
+
+    def _register_lifecycle_commands(self, base):
+        @base.command()
+        def connect_cmd():
+            """Connect to DDS domain"""
+            info = self.connect()
+            click.echo(f"Connected to DDS domain {info.domain_id}")
+
+        @base.command()
+        def disconnect_cmd():
+            """Disconnect from DDS domain"""
+            self.disconnect()
+            click.echo("Disconnected from DDS domain")
+
+        @base.command()
+        def topics():
+            """List registered topics"""
+            topic_list = self.list_topics()
+            if not topic_list:
+                click.echo("No topics registered")
+                return
+            for t in topic_list:
+                click.echo(
+                    f"  {t.name}: fields={t.fields} "
+                    f"reliability={t.qos.reliability.value} "
+                    f"samples={t.sample_count}"
+                )
+
+        @base.command()
+        def info():
+            """Show DDS participant info"""
+            pinfo = self.get_participant_info()
+            click.echo(f"Domain ID:    {pinfo.domain_id}")
+            click.echo(f"Connected:    {pinfo.is_connected}")
+            click.echo(f"Topic count:  {pinfo.topic_count}")
+
+    def _register_data_commands(self, base):
+        @base.command()
+        @click.argument("topic_name")
+        @click.option("--max-samples", "-n", default=10, help="Max samples to read")
+        def read_cmd(topic_name, max_samples):
+            """Read samples from a topic"""
+            result = self.read(topic_name, max_samples)
+            click.echo(f"Read {result.sample_count} samples from {topic_name}:")
+            for s in result.samples:
+                click.echo(f"  {s.data}")
+
+        @base.command()
+        @click.argument("topic_name")
+        @click.option("--count", "-n", default=10, help="Number of events")
+        def monitor_cmd(topic_name, count):
+            """Monitor samples from a topic"""
+            for i, sample in enumerate(self.monitor(topic_name)):
+                click.echo(f"[{sample.topic_name}] {sample.data}")
+                if i + 1 >= count:
+                    break
+
+    def cli(self):
+        @driver_click_group(self)
+        def base():
+            """DDS pub/sub communication"""
+            pass
+
+        self._register_lifecycle_commands(base)
+        self._register_data_commands(base)
+        return base

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/client.py
@@ -67,9 +67,9 @@ class DdsClient(DriverClient):
         """Get information about the DDS domain participant."""
         return DdsParticipantInfo.model_validate(self.call("get_participant_info"))
 
-    def monitor(self, topic_name: str) -> Generator[DdsSample, None, None]:
+    def monitor(self, topic_name: str, max_iterations: int = 0) -> Generator[DdsSample, None, None]:
         """Stream data samples from a topic as they arrive."""
-        for v in self.streamingcall("monitor", topic_name):
+        for v in self.streamingcall("monitor", topic_name, max_iterations):
             yield DdsSample.model_validate(v)
 
     def _register_lifecycle_commands(self, base):
@@ -142,10 +142,10 @@ class DdsClient(DriverClient):
 
         @base.command(name="monitor")
         @click.argument("topic_name")
-        @click.option("--count", "-n", default=10, help="Number of events")
+        @click.option("--count", "-n", default=10, type=click.IntRange(min=1), help="Number of events to display")
         def monitor_cmd(topic_name, count):
             """Monitor samples from a topic"""
-            for i, sample in enumerate(self.monitor(topic_name)):
+            for i, sample in enumerate(self.monitor(topic_name, max_iterations=count)):
                 click.echo(f"[{sample.topic_name}] {sample.data}")
                 if i + 1 >= count:
                     break

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/common.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/common.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class DdsReliability(str, Enum):
+    """DDS reliability QoS."""
+
+    BEST_EFFORT = "BEST_EFFORT"
+    RELIABLE = "RELIABLE"
+
+
+class DdsDurability(str, Enum):
+    """DDS durability QoS."""
+
+    VOLATILE = "VOLATILE"
+    TRANSIENT_LOCAL = "TRANSIENT_LOCAL"
+    TRANSIENT = "TRANSIENT"
+    PERSISTENT = "PERSISTENT"
+
+
+class DdsTopicQos(BaseModel):
+    """Quality of Service settings for a DDS topic."""
+
+    reliability: DdsReliability = DdsReliability.RELIABLE
+    durability: DdsDurability = DdsDurability.VOLATILE
+    history_depth: int = 10
+
+
+class DdsParticipantInfo(BaseModel):
+    """Information about the DDS domain participant."""
+
+    domain_id: int
+    topic_count: int = 0
+    is_connected: bool = False
+
+
+class DdsTopicInfo(BaseModel):
+    """Information about a registered DDS topic."""
+
+    name: str
+    fields: list[str] = []
+    qos: DdsTopicQos = DdsTopicQos()
+    sample_count: int = 0
+
+
+class DdsSample(BaseModel):
+    """A single DDS data sample."""
+
+    topic_name: str
+    data: dict[str, Any]
+    timestamp: float = 0.0
+
+
+class DdsPublishResult(BaseModel):
+    """Result of a publish operation."""
+
+    topic_name: str
+    success: bool
+    samples_written: int = 0
+
+
+class DdsReadResult(BaseModel):
+    """Result of a read/take operation."""
+
+    topic_name: str
+    samples: list[DdsSample] = []
+    sample_count: int = 0

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/common.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class DdsReliability(str, Enum):
@@ -56,10 +56,13 @@ class DdsSample(BaseModel):
 
 
 class DdsPublishResult(BaseModel):
-    """Result of a publish operation."""
+    """Result of a publish operation.
+
+    Publish failures always raise exceptions; this model is only
+    returned on success.
+    """
 
     topic_name: str
-    success: bool
     samples_written: int = 0
 
 
@@ -69,3 +72,10 @@ class DdsReadResult(BaseModel):
     topic_name: str
     samples: list[DdsSample] = []
     sample_count: int = 0
+
+    @model_validator(mode="after")
+    def _validate_sample_count(self) -> DdsReadResult:
+        """Ensure sample_count matches the actual number of samples."""
+        if self.sample_count != len(self.samples):
+            raise ValueError(f"sample_count ({self.sample_count}) does not match len(samples) ({len(self.samples)})")
+        return self

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/common.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 class DdsReliability(str, Enum):
@@ -27,7 +27,7 @@ class DdsTopicQos(BaseModel):
 
     reliability: DdsReliability = DdsReliability.RELIABLE
     durability: DdsDurability = DdsDurability.VOLATILE
-    history_depth: int = 10
+    history_depth: int = Field(10, ge=1)
 
 
 class DdsParticipantInfo(BaseModel):

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
@@ -25,10 +25,11 @@ class StatefulDdsBackend(MockDdsBackend):
     Tracks:
     - Connection lifecycle (connected/disconnected)
     - Topic creation and uniqueness
-    - Publish field validation against topic schema
+    - Publish field validation against topic schema (unknown AND missing fields)
     - Read buffer management with history depth
     - Operation ordering (must connect before other ops)
-    - Call log for audit
+    - Call log for audit -- intentionally preserved across disconnect
+      so callers can inspect the full session history
     """
 
     def __init__(self, domain_id: int = 0):
@@ -38,6 +39,7 @@ class StatefulDdsBackend(MockDdsBackend):
         self._total_read: int = 0
 
     def connect(self):
+        """Connect and record the operation in the call log."""
         if self._connected:
             raise DdsAlreadyConnectedError("Already connected to DDS domain")
         result = super().connect()
@@ -45,6 +47,7 @@ class StatefulDdsBackend(MockDdsBackend):
         return result
 
     def disconnect(self):
+        """Disconnect, reset counters, and record in the call log."""
         if not self._connected:
             raise DdsNotConnectedError("Not connected to DDS domain")
         super().disconnect()
@@ -53,10 +56,12 @@ class StatefulDdsBackend(MockDdsBackend):
         self._call_log.append("disconnect")
 
     def _require_connected(self):
+        """Raise ``DdsNotConnectedError`` if the backend is not connected."""
         if not self._connected:
             raise DdsNotConnectedError("Not connected -- call connect() first")
 
     def create_topic(self, name, fields, qos):
+        """Create a topic, enforcing non-empty fields and uniqueness."""
         self._require_connected()
         if name in self._topics:
             raise DdsTopicError(f"Topic '{name}' already exists")
@@ -67,6 +72,7 @@ class StatefulDdsBackend(MockDdsBackend):
         return result
 
     def publish(self, topic_name, data):
+        """Publish data after validating both unknown and missing fields."""
         self._require_connected()
         if topic_name not in self._topics:
             raise DdsTopicError(f"Topic '{topic_name}' not registered")
@@ -75,6 +81,11 @@ class StatefulDdsBackend(MockDdsBackend):
         for key in data:
             if key not in fields:
                 raise DdsTopicError(f"Unknown field '{key}' for topic '{topic_name}', valid: {fields}")
+        missing = [f for f in fields if f not in data]
+        if missing:
+            raise DdsTopicError(
+                f"Missing required field(s) {missing} for topic '{topic_name}'"
+            )
 
         result = super().publish(topic_name, data)
         self._total_published += 1
@@ -82,6 +93,7 @@ class StatefulDdsBackend(MockDdsBackend):
         return result
 
     def read(self, topic_name, max_samples):
+        """Read samples and update the total-read counter."""
         self._require_connected()
         if topic_name not in self._topics:
             raise DdsTopicError(f"Topic '{topic_name}' not registered")

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
@@ -97,6 +97,14 @@ class StatefulDdsBackend(MockDdsBackend):
         return result
 
 
+@pytest.fixture(params=["mock", "stateful"])
+def any_backend(request):
+    """Yield every backend implementation so parity tests run against all."""
+    if request.param == "mock":
+        return MockDdsBackend()
+    return StatefulDdsBackend()
+
+
 @pytest.fixture
 def stateful_backend():
     return StatefulDdsBackend(domain_id=0)

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+
+from .driver import MockDds, MockDdsBackend
+from jumpstarter.common.utils import serve
+
+
+class DdsNotConnectedError(RuntimeError):
+    pass
+
+
+class DdsAlreadyConnectedError(RuntimeError):
+    pass
+
+
+class DdsTopicError(ValueError):
+    pass
+
+
+class StatefulDdsBackend(MockDdsBackend):
+    """Drop-in replacement for MockDdsBackend that enforces
+    DDS lifecycle rules and tracks operation history.
+
+    Tracks:
+    - Connection lifecycle (connected/disconnected)
+    - Topic creation and uniqueness
+    - Publish field validation against topic schema
+    - Read buffer management with history depth
+    - Operation ordering (must connect before other ops)
+    - Call log for audit
+    """
+
+    def __init__(self, domain_id: int = 0):
+        super().__init__(domain_id=domain_id)
+        self._call_log: list[str] = []
+        self._total_published: int = 0
+        self._total_read: int = 0
+
+    def connect(self):
+        if self._connected:
+            raise DdsAlreadyConnectedError("Already connected to DDS domain")
+        result = super().connect()
+        self._call_log.append("connect")
+        return result
+
+    def disconnect(self):
+        if not self._connected:
+            raise DdsNotConnectedError("Not connected to DDS domain")
+        super().disconnect()
+        self._total_published = 0
+        self._total_read = 0
+        self._call_log.append("disconnect")
+
+    def _require_connected(self):
+        if not self._connected:
+            raise DdsNotConnectedError("Not connected -- call connect() first")
+
+    def create_topic(self, name, fields, qos):
+        self._require_connected()
+        if name in self._topics:
+            raise DdsTopicError(f"Topic '{name}' already exists")
+        if not fields:
+            raise DdsTopicError("Topic must have at least one field")
+        result = super().create_topic(name, fields, qos)
+        self._call_log.append(f"create_topic({name})")
+        return result
+
+    def publish(self, topic_name, data):
+        self._require_connected()
+        if topic_name not in self._topics:
+            raise DdsTopicError(f"Topic '{topic_name}' not registered")
+
+        fields = self._topic_fields[topic_name]
+        for key in data:
+            if key not in fields:
+                raise DdsTopicError(f"Unknown field '{key}' for topic '{topic_name}', valid: {fields}")
+
+        result = super().publish(topic_name, data)
+        self._total_published += 1
+        self._call_log.append(f"publish({topic_name})")
+        return result
+
+    def read(self, topic_name, max_samples):
+        self._require_connected()
+        if topic_name not in self._topics:
+            raise DdsTopicError(f"Topic '{topic_name}' not registered")
+        result = super().read(topic_name, max_samples)
+        self._total_read += result.sample_count
+        self._call_log.append(f"read({topic_name})")
+        return result
+
+
+@pytest.fixture
+def stateful_backend():
+    return StatefulDdsBackend(domain_id=0)
+
+
+@pytest.fixture
+def stateful_client(stateful_backend):
+    """Create a MockDds driver backed by StatefulDdsBackend and serve it.
+
+    The MockDds @export methods delegate to the stateful backend,
+    so gRPC routing works correctly while enforcing DDS lifecycle rules.
+    """
+    driver = MockDds(backend=stateful_backend)
+    with serve(driver) as client:
+        yield client, stateful_backend

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/conftest.py
@@ -20,12 +20,13 @@ class DdsTopicError(ValueError):
 
 class StatefulDdsBackend(MockDdsBackend):
     """Drop-in replacement for MockDdsBackend that enforces
-    DDS lifecycle rules and tracks operation history.
+    the same rules as the real and mock backends while tracking
+    operation history for test assertions.
 
     Tracks:
     - Connection lifecycle (connected/disconnected)
     - Topic creation and uniqueness
-    - Publish field validation against topic schema (unknown AND missing fields)
+    - Publish field validation (same as MockDdsBackend)
     - Read buffer management with history depth
     - Operation ordering (must connect before other ops)
     - Call log for audit -- intentionally preserved across disconnect
@@ -61,31 +62,24 @@ class StatefulDdsBackend(MockDdsBackend):
             raise DdsNotConnectedError("Not connected -- call connect() first")
 
     def create_topic(self, name, fields, qos):
-        """Create a topic, enforcing non-empty fields and uniqueness."""
+        """Create a topic, enforcing uniqueness."""
         self._require_connected()
         if name in self._topics:
             raise DdsTopicError(f"Topic '{name}' already exists")
-        if not fields:
-            raise DdsTopicError("Topic must have at least one field")
         result = super().create_topic(name, fields, qos)
         self._call_log.append(f"create_topic({name})")
         return result
 
     def publish(self, topic_name, data):
-        """Publish data after validating both unknown and missing fields."""
+        """Publish data after validating unknown fields (matching MockDdsBackend)."""
         self._require_connected()
         if topic_name not in self._topics:
             raise DdsTopicError(f"Topic '{topic_name}' not registered")
 
         fields = self._topic_fields[topic_name]
-        for key in data:
-            if key not in fields:
-                raise DdsTopicError(f"Unknown field '{key}' for topic '{topic_name}', valid: {fields}")
-        missing = [f for f in fields if f not in data]
-        if missing:
-            raise DdsTopicError(
-                f"Missing required field(s) {missing} for topic '{topic_name}'"
-            )
+        unknown = set(data) - set(fields)
+        if unknown:
+            raise DdsTopicError(f"Unknown field(s) {unknown} for topic '{topic_name}', valid: {fields}")
 
         result = super().publish(topic_name, data)
         self._total_published += 1

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses as dc
+import hashlib
 import logging
 import time
 from collections.abc import AsyncGenerator
@@ -54,14 +56,19 @@ def _make_idl_type(topic_name: str, fields: list[str]):
 
     Each field name maps to a ``str`` type. For complex or mixed-type
     schemas, define custom IdlStruct subclasses directly and register
-    them with the backend. The generated class name is derived from the
-    topic name to avoid collisions between topics.
-    """
-    import dataclasses as dc
+    them with the backend.
 
+    A hash suffix is appended to the generated class name to prevent
+    collisions when distinct topic names sanitise to the same identifier
+    (e.g. ``"sensor/temp"`` and ``"sensor-temp"``).
+    """
     from cyclonedds.idl import IdlStruct
 
-    cls_name = topic_name.replace("/", "_").replace("-", "_").replace(".", "_") + "_Type"
+    sanitised = topic_name.replace("/", "_").replace("-", "_").replace(".", "_")
+    hash_suffix = hashlib.md5(topic_name.encode()).hexdigest()[:8]
+    cls_name = f"{sanitised}_{hash_suffix}_Type"
+    if not cls_name.isidentifier():
+        cls_name = f"Topic_{hash_suffix}_Type"
     dc_fields = [(f, str, dc.field(default="")) for f in fields]
     idl_cls = dc.make_dataclass(cls_name, dc_fields, bases=(IdlStruct,))
     return idl_cls
@@ -108,6 +115,26 @@ class DdsBackend:
         """Tear down all DDS entities and release the participant."""
         if not self._connected:
             raise RuntimeError("Not connected to DDS domain")
+        for writer in self._writers.values():
+            try:
+                writer.close()
+            except Exception:
+                pass
+        for reader in self._readers.values():
+            try:
+                reader.close()
+            except Exception:
+                pass
+        for topic in self._topics.values():
+            try:
+                topic.close()
+            except Exception:
+                pass
+        if self._participant is not None:
+            try:
+                self._participant.close()
+            except Exception:
+                pass
         self._writers.clear()
         self._readers.clear()
         self._topics.clear()
@@ -157,13 +184,13 @@ class DdsBackend:
         result = []
         for name in self._topics:
             idl_type = self._idl_types[name]
-            fields = [f.name for f in idl_type.__dataclass_fields__.values()]
+            fields = [f.name for f in dc.fields(idl_type)]
             result.append(
                 DdsTopicInfo(
                     name=name,
                     fields=fields,
-                    qos=self._qos_map.get(name, DdsTopicQos()),
-                    sample_count=self._sample_counts.get(name, 0),
+                    qos=self._qos_map[name],
+                    sample_count=self._sample_counts[name],
                 )
             )
         return result
@@ -175,14 +202,24 @@ class DdsBackend:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
 
         idl_type = self._idl_types[topic_name]
+        valid_fields = {f.name for f in dc.fields(idl_type)}
+        unknown = set(data) - valid_fields
+        if unknown:
+            raise ValueError(f"Unknown field(s) {unknown} for topic '{topic_name}'")
+
         sample = idl_type(**data)
         self._writers[topic_name].write(sample)
-        self._sample_counts[topic_name] = self._sample_counts.get(topic_name, 0) + 1
+        self._sample_counts[topic_name] += 1
 
-        return DdsPublishResult(topic_name=topic_name, success=True, samples_written=1)
+        return DdsPublishResult(topic_name=topic_name, samples_written=1)
 
     def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
-        """Take up to *max_samples* from the topic's DataReader."""
+        """Take up to *max_samples* from the topic's DataReader.
+
+        Note: ``read`` and ``monitor`` both consume from the same
+        DataReader buffer; using them concurrently on the same topic
+        will cause samples to be split unpredictably between the two.
+        """
         self._require_connected()
         if topic_name not in self._readers:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
@@ -192,9 +229,7 @@ class DdsBackend:
 
         samples = []
         for s in raw_samples:
-            data = {}
-            for f in s.__dataclass_fields__:
-                data[f] = getattr(s, f)
+            data = {f.name: getattr(s, f.name) for f in dc.fields(s)}
             samples.append(DdsSample(topic_name=topic_name, data=data, timestamp=time.time()))
 
         return DdsReadResult(topic_name=topic_name, samples=samples, sample_count=len(samples))
@@ -283,30 +318,36 @@ class MockDdsBackend:
                     name=info.name,
                     fields=info.fields,
                     qos=info.qos,
-                    sample_count=self._sample_counts.get(name, 0),
+                    sample_count=self._sample_counts[name],
                 )
             )
         return result
 
     def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
-        """Buffer a sample, enforcing history depth and field validation."""
+        """Buffer a sample, filling defaults for missing fields.
+
+        Mirrors the real ``DdsBackend`` where the CycloneDDS dataclass
+        constructor fills unset fields with their defaults (empty string).
+        """
         self._require_connected()
         if topic_name not in self._topics:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
 
         fields = self._topic_fields[topic_name]
-        for key in data:
-            if key not in fields:
-                raise ValueError(f"Unknown field '{key}' for topic '{topic_name}'")
+        unknown = set(data) - set(fields)
+        if unknown:
+            raise ValueError(f"Unknown field(s) {unknown} for topic '{topic_name}'")
 
-        sample = DdsSample(topic_name=topic_name, data=data, timestamp=time.time())
+        full_data = {f: data.get(f, "") for f in fields}
+
+        sample = DdsSample(topic_name=topic_name, data=full_data, timestamp=time.time())
         qos = self._topics[topic_name].qos
         buf = self._buffers[topic_name]
         buf.append(sample)
         if len(buf) > qos.history_depth:
-            self._buffers[topic_name] = buf[-qos.history_depth:]
-        self._sample_counts[topic_name] = self._sample_counts.get(topic_name, 0) + 1
-        return DdsPublishResult(topic_name=topic_name, success=True, samples_written=1)
+            self._buffers[topic_name] = buf[-qos.history_depth :]
+        self._sample_counts[topic_name] += 1
+        return DdsPublishResult(topic_name=topic_name, samples_written=1)
 
     def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
         """Take up to *max_samples* from the in-memory buffer."""
@@ -365,7 +406,7 @@ class Dds(Driver):
         if self._backend.is_connected:
             try:
                 self._backend.disconnect()
-            except Exception:
+            except RuntimeError:
                 logger.warning("Failed to disconnect DDS backend", exc_info=True)
         super().close()
 
@@ -434,23 +475,32 @@ class Dds(Driver):
         return self._backend.get_participant_info()
 
     @export
-    async def monitor(self, topic_name: str) -> AsyncGenerator[DdsSample, None]:
+    async def monitor(self, topic_name: str, max_iterations: int = 0) -> AsyncGenerator[DdsSample, None]:
         """Stream data samples from a topic as they arrive.
 
         Polls the topic reader periodically and yields new samples.
+        If *max_iterations* is 0 (default), polls indefinitely until
+        the client cancels the stream. ``read`` and ``monitor`` both
+        consume from the same reader buffer; do not use them
+        concurrently on the same topic.
         """
-        import asyncio
+        import anyio
 
         if not self._backend.is_connected:
             raise RuntimeError("Not connected -- call connect() first")
         if not self._backend.has_topic(topic_name):
             raise ValueError(f"Topic '{topic_name}' not registered")
 
-        for _ in range(100):
-            result = self._backend.read(topic_name, max_samples=10)
+        iterations = 0
+        while max_iterations == 0 or iterations < max_iterations:
+            try:
+                result = self._backend.read(topic_name, max_samples=10)
+            except RuntimeError:
+                return
             for sample in result.samples:
                 yield sample
-            await asyncio.sleep(0.1)
+            await anyio.sleep(0.1)
+            iterations += 1
 
 
 @dataclass(kw_only=True, config=ConfigDict(arbitrary_types_allowed=True))
@@ -465,6 +515,9 @@ class MockDds(Driver):
     """
 
     domain_id: int = 0
+    default_reliability: DdsReliability = DdsReliability.RELIABLE
+    default_durability: DdsDurability = DdsDurability.VOLATILE
+    default_history_depth: int = 10
     backend: MockDdsBackend | None = field(default=None, repr=False)
 
     _internal_backend: MockDdsBackend = field(init=False, repr=False)
@@ -479,6 +532,23 @@ class MockDds(Driver):
     def client(cls) -> str:
         """Return the fully-qualified path to the matching client class."""
         return "jumpstarter_driver_dds.client.DdsClient"
+
+    def close(self):
+        """Disconnect the mock backend (if connected) and release resources."""
+        if self._internal_backend.is_connected:
+            try:
+                self._internal_backend.disconnect()
+            except RuntimeError:
+                logger.warning("Failed to disconnect mock DDS backend", exc_info=True)
+        super().close()
+
+    def _default_qos(self) -> DdsTopicQos:
+        """Build a ``DdsTopicQos`` from this driver's default settings."""
+        return DdsTopicQos(
+            reliability=self.default_reliability,
+            durability=self.default_durability,
+            history_depth=self.default_history_depth,
+        )
 
     @export
     @validate_call(validate_return=True)
@@ -503,7 +573,7 @@ class MockDds(Driver):
         history_depth: int | None = None,
     ) -> DdsTopicInfo:
         """Create a topic on the mock backend."""
-        qos = DdsTopicQos()
+        qos = self._default_qos()
         if reliability is not None:
             qos.reliability = DdsReliability(reliability)
         if durability is not None:
@@ -537,17 +607,26 @@ class MockDds(Driver):
         return self._internal_backend.get_participant_info()
 
     @export
-    async def monitor(self, topic_name: str) -> AsyncGenerator[DdsSample, None]:
-        """Stream data samples from a mock topic."""
-        import asyncio
+    async def monitor(self, topic_name: str, max_iterations: int = 0) -> AsyncGenerator[DdsSample, None]:
+        """Stream data samples from a mock topic.
+
+        ``read`` and ``monitor`` both consume from the same buffer;
+        do not use them concurrently on the same topic.
+        """
+        import anyio
 
         if not self._internal_backend.is_connected:
             raise RuntimeError("Not connected -- call connect() first")
         if not self._internal_backend.has_topic(topic_name):
             raise ValueError(f"Topic '{topic_name}' not registered")
 
-        for _ in range(100):
-            result = self._internal_backend.read(topic_name, max_samples=10)
+        iterations = 0
+        while max_iterations == 0 or iterations < max_iterations:
+            try:
+                result = self._internal_backend.read(topic_name, max_samples=10)
+            except RuntimeError:
+                return
             for sample in result.samples:
                 yield sample
-            await asyncio.sleep(0.1)
+            await anyio.sleep(0.1)
+            iterations += 1

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
@@ -51,6 +51,25 @@ def _build_cyclonedds_qos(qos: DdsTopicQos):
     return Qos(*policies)
 
 
+def _validate_field_names(fields: list[str]) -> None:
+    """Reject field names that are not valid Python identifiers or are duplicated.
+
+    Both the real CycloneDDS backend (via ``dataclasses.make_dataclass``) and
+    the mock backend must agree on which schemas are valid.
+    """
+    import keyword
+
+    seen: set[str] = set()
+    for name in fields:
+        if not name.isidentifier():
+            raise ValueError(f"Field name {name!r} is not a valid Python identifier")
+        if keyword.iskeyword(name):
+            raise ValueError(f"Field name {name!r} is a Python keyword")
+        if name in seen:
+            raise ValueError(f"Duplicate field name {name!r}")
+        seen.add(name)
+
+
 def _make_idl_type(topic_name: str, fields: list[str]):
     """Dynamically create a CycloneDDS IdlStruct type for the given fields.
 
@@ -115,26 +134,26 @@ class DdsBackend:
         """Tear down all DDS entities and release the participant."""
         if not self._connected:
             raise RuntimeError("Not connected to DDS domain")
-        for writer in self._writers.values():
+        for name, writer in self._writers.items():
             try:
                 writer.close()
-            except Exception:
-                pass
-        for reader in self._readers.values():
+            except RuntimeError:
+                logger.debug("Failed to close writer for topic '%s'", name, exc_info=True)
+        for name, reader in self._readers.items():
             try:
                 reader.close()
-            except Exception:
-                pass
-        for topic in self._topics.values():
+            except RuntimeError:
+                logger.debug("Failed to close reader for topic '%s'", name, exc_info=True)
+        for name, topic in self._topics.items():
             try:
                 topic.close()
-            except Exception:
-                pass
+            except RuntimeError:
+                logger.debug("Failed to close topic '%s'", name, exc_info=True)
         if self._participant is not None:
             try:
                 self._participant.close()
-            except Exception:
-                pass
+            except RuntimeError:
+                logger.debug("Failed to close DDS participant", exc_info=True)
         self._writers.clear()
         self._readers.clear()
         self._topics.clear()
@@ -155,26 +174,39 @@ class DdsBackend:
         fields: list[str],
         qos: DdsTopicQos,
     ) -> DdsTopicInfo:
-        """Register a topic, create its writer/reader, and return topic info."""
+        """Register a topic, create its writer/reader, and return topic info.
+
+        All DDS objects are created before any internal state is updated
+        so that a failure leaves no half-registered topic.
+        """
         self._require_connected()
         if name in self._topics:
             raise ValueError(f"Topic '{name}' already exists")
+        _validate_field_names(fields)
 
         from cyclonedds.pub import DataWriter
         from cyclonedds.sub import DataReader
         from cyclonedds.topic import Topic
 
         idl_type = _make_idl_type(name, fields)
-        self._idl_types[name] = idl_type
-
         cqos = _build_cyclonedds_qos(qos)
         topic = Topic(self._participant, name, idl_type, qos=cqos)
+        writer = None
+        try:
+            writer = DataWriter(self._participant, topic, qos=cqos)
+            reader = DataReader(self._participant, topic, qos=cqos)
+        except Exception:
+            if writer is not None:
+                writer.close()
+            topic.close()
+            raise
+
+        self._idl_types[name] = idl_type
         self._topics[name] = topic
         self._qos_map[name] = qos
         self._sample_counts[name] = 0
-
-        self._writers[name] = DataWriter(self._participant, topic, qos=cqos)
-        self._readers[name] = DataReader(self._participant, topic, qos=cqos)
+        self._writers[name] = writer
+        self._readers[name] = reader
 
         return DdsTopicInfo(name=name, fields=fields, qos=qos)
 
@@ -300,6 +332,7 @@ class MockDdsBackend:
         self._require_connected()
         if name in self._topics:
             raise ValueError(f"Topic '{name}' already exists")
+        _validate_field_names(fields)
 
         info = DdsTopicInfo(name=name, fields=fields, qos=qos)
         self._topics[name] = info

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
@@ -52,8 +52,10 @@ def _build_cyclonedds_qos(qos: DdsTopicQos):
 def _make_idl_type(topic_name: str, fields: list[str]):
     """Dynamically create a CycloneDDS IdlStruct type for the given fields.
 
-    Each field name maps to a ``str`` type. The generated class name is
-    derived from the topic name to avoid collisions between topics.
+    Each field name maps to a ``str`` type. For complex or mixed-type
+    schemas, define custom IdlStruct subclasses directly and register
+    them with the backend. The generated class name is derived from the
+    topic name to avoid collisions between topics.
     """
     import dataclasses as dc
 
@@ -79,7 +81,17 @@ class DdsBackend:
         self._sample_counts: dict[str, int] = {}
         self._connected = False
 
+    @property
+    def is_connected(self) -> bool:
+        """Whether the backend is currently connected to a DDS domain."""
+        return self._connected
+
+    def has_topic(self, name: str) -> bool:
+        """Check whether a topic with the given name has been registered."""
+        return name in self._topics
+
     def connect(self) -> DdsParticipantInfo:
+        """Create a CycloneDDS DomainParticipant and mark the backend as connected."""
         if self._connected:
             raise RuntimeError("Already connected to DDS domain")
         from cyclonedds.domain import DomainParticipant
@@ -93,6 +105,7 @@ class DdsBackend:
         )
 
     def disconnect(self) -> None:
+        """Tear down all DDS entities and release the participant."""
         if not self._connected:
             raise RuntimeError("Not connected to DDS domain")
         self._writers.clear()
@@ -105,6 +118,7 @@ class DdsBackend:
         self._connected = False
 
     def _require_connected(self):
+        """Raise ``RuntimeError`` if the backend is not connected."""
         if not self._connected:
             raise RuntimeError("Not connected -- call connect() first")
 
@@ -114,6 +128,7 @@ class DdsBackend:
         fields: list[str],
         qos: DdsTopicQos,
     ) -> DdsTopicInfo:
+        """Register a topic, create its writer/reader, and return topic info."""
         self._require_connected()
         if name in self._topics:
             raise ValueError(f"Topic '{name}' already exists")
@@ -137,6 +152,7 @@ class DdsBackend:
         return DdsTopicInfo(name=name, fields=fields, qos=qos)
 
     def list_topics(self) -> list[DdsTopicInfo]:
+        """Return info for every registered topic."""
         self._require_connected()
         result = []
         for name in self._topics:
@@ -153,6 +169,7 @@ class DdsBackend:
         return result
 
     def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        """Write a data sample via the topic's DataWriter."""
         self._require_connected()
         if topic_name not in self._writers:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
@@ -165,6 +182,7 @@ class DdsBackend:
         return DdsPublishResult(topic_name=topic_name, success=True, samples_written=1)
 
     def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
+        """Take up to *max_samples* from the topic's DataReader."""
         self._require_connected()
         if topic_name not in self._readers:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
@@ -182,6 +200,7 @@ class DdsBackend:
         return DdsReadResult(topic_name=topic_name, samples=samples, sample_count=len(samples))
 
     def get_participant_info(self) -> DdsParticipantInfo:
+        """Return metadata about this DDS domain participant."""
         self._require_connected()
         return DdsParticipantInfo(
             domain_id=self._domain_id,
@@ -201,7 +220,17 @@ class MockDdsBackend:
         self._buffers: dict[str, list[DdsSample]] = {}
         self._sample_counts: dict[str, int] = {}
 
+    @property
+    def is_connected(self) -> bool:
+        """Whether the backend is currently connected to a DDS domain."""
+        return self._connected
+
+    def has_topic(self, name: str) -> bool:
+        """Check whether a topic with the given name has been registered."""
+        return name in self._topics
+
     def connect(self) -> DdsParticipantInfo:
+        """Mark the mock backend as connected."""
         if self._connected:
             raise RuntimeError("Already connected to DDS domain")
         self._connected = True
@@ -212,6 +241,7 @@ class MockDdsBackend:
         )
 
     def disconnect(self) -> None:
+        """Disconnect and clear all in-memory state."""
         if not self._connected:
             raise RuntimeError("Not connected to DDS domain")
         self._connected = False
@@ -221,6 +251,7 @@ class MockDdsBackend:
         self._sample_counts.clear()
 
     def _require_connected(self):
+        """Raise ``RuntimeError`` if the backend is not connected."""
         if not self._connected:
             raise RuntimeError("Not connected -- call connect() first")
 
@@ -230,6 +261,7 @@ class MockDdsBackend:
         fields: list[str],
         qos: DdsTopicQos,
     ) -> DdsTopicInfo:
+        """Register a topic in the in-memory store."""
         self._require_connected()
         if name in self._topics:
             raise ValueError(f"Topic '{name}' already exists")
@@ -242,6 +274,7 @@ class MockDdsBackend:
         return info
 
     def list_topics(self) -> list[DdsTopicInfo]:
+        """Return info for every registered topic in the mock store."""
         self._require_connected()
         result = []
         for name, info in self._topics.items():
@@ -256,6 +289,7 @@ class MockDdsBackend:
         return result
 
     def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        """Buffer a sample, enforcing history depth and field validation."""
         self._require_connected()
         if topic_name not in self._topics:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
@@ -275,6 +309,7 @@ class MockDdsBackend:
         return DdsPublishResult(topic_name=topic_name, success=True, samples_written=1)
 
     def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
+        """Take up to *max_samples* from the in-memory buffer."""
         self._require_connected()
         if topic_name not in self._topics:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
@@ -285,6 +320,7 @@ class MockDdsBackend:
         return DdsReadResult(topic_name=topic_name, samples=taken, sample_count=len(taken))
 
     def get_participant_info(self) -> DdsParticipantInfo:
+        """Return metadata about this mock participant."""
         self._require_connected()
         return DdsParticipantInfo(
             domain_id=self._domain_id,
@@ -311,6 +347,7 @@ class Dds(Driver):
     _backend: DdsBackend | MockDdsBackend = field(init=False, repr=False)
 
     def __post_init__(self):
+        """Initialise the real or mock backend based on ``use_mock``."""
         if hasattr(super(), "__post_init__"):
             super().__post_init__()
         if self.use_mock:
@@ -320,10 +357,12 @@ class Dds(Driver):
 
     @classmethod
     def client(cls) -> str:
+        """Return the fully-qualified path to the matching client class."""
         return "jumpstarter_driver_dds.client.DdsClient"
 
     def close(self):
-        if self._backend._connected:
+        """Disconnect the backend (if connected) and release resources."""
+        if self._backend.is_connected:
             try:
                 self._backend.disconnect()
             except Exception:
@@ -331,6 +370,7 @@ class Dds(Driver):
         super().close()
 
     def _default_qos(self) -> DdsTopicQos:
+        """Build a ``DdsTopicQos`` from this driver's default settings."""
         return DdsTopicQos(
             reliability=self.default_reliability,
             durability=self.default_durability,
@@ -401,8 +441,9 @@ class Dds(Driver):
         """
         import asyncio
 
-        self._backend._require_connected()
-        if topic_name not in self._backend._topics:
+        if not self._backend.is_connected:
+            raise RuntimeError("Not connected -- call connect() first")
+        if not self._backend.has_topic(topic_name):
             raise ValueError(f"Topic '{topic_name}' not registered")
 
         for _ in range(100):
@@ -429,12 +470,14 @@ class MockDds(Driver):
     _internal_backend: MockDdsBackend = field(init=False, repr=False)
 
     def __post_init__(self):
+        """Initialise the internal mock backend (or use the injected one)."""
         if hasattr(super(), "__post_init__"):
             super().__post_init__()
         self._internal_backend = self.backend or MockDdsBackend(domain_id=self.domain_id)
 
     @classmethod
     def client(cls) -> str:
+        """Return the fully-qualified path to the matching client class."""
         return "jumpstarter_driver_dds.client.DdsClient"
 
     @export
@@ -498,8 +541,9 @@ class MockDds(Driver):
         """Stream data samples from a mock topic."""
         import asyncio
 
-        self._internal_backend._require_connected()
-        if topic_name not in self._internal_backend._topics:
+        if not self._internal_backend.is_connected:
+            raise RuntimeError("Not connected -- call connect() first")
+        if not self._internal_backend.has_topic(topic_name):
             raise ValueError(f"Topic '{topic_name}' not registered")
 
         for _ in range(100):

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import AsyncGenerator
+from dataclasses import field
+from typing import Any
+
+from pydantic import ConfigDict, validate_call
+from pydantic.dataclasses import dataclass
+
+from .common import (
+    DdsDurability,
+    DdsParticipantInfo,
+    DdsPublishResult,
+    DdsReadResult,
+    DdsReliability,
+    DdsSample,
+    DdsTopicInfo,
+    DdsTopicQos,
+)
+from jumpstarter.driver import Driver, export
+
+logger = logging.getLogger(__name__)
+
+
+def _build_cyclonedds_qos(qos: DdsTopicQos):
+    """Build a CycloneDDS Qos object from our config model."""
+    from cyclonedds.core import Policy, Qos
+
+    policies = []
+
+    if qos.reliability == DdsReliability.RELIABLE:
+        policies.append(Policy.Reliability.Reliable(max_blocking_time=1_000_000_000))
+    else:
+        policies.append(Policy.Reliability.BestEffort)
+
+    if qos.durability == DdsDurability.VOLATILE:
+        policies.append(Policy.Durability.Volatile)
+    elif qos.durability == DdsDurability.TRANSIENT_LOCAL:
+        policies.append(Policy.Durability.TransientLocal)
+    elif qos.durability == DdsDurability.TRANSIENT:
+        policies.append(Policy.Durability.Transient)
+    elif qos.durability == DdsDurability.PERSISTENT:
+        policies.append(Policy.Durability.Persistent)
+
+    policies.append(Policy.History.KeepLast(qos.history_depth))
+
+    return Qos(*policies)
+
+
+def _make_idl_type(topic_name: str, fields: list[str]):
+    """Dynamically create a CycloneDDS IdlStruct type for the given fields.
+
+    Each field name maps to a ``str`` type. The generated class name is
+    derived from the topic name to avoid collisions between topics.
+    """
+    import dataclasses as dc
+
+    from cyclonedds.idl import IdlStruct
+
+    cls_name = topic_name.replace("/", "_").replace("-", "_").replace(".", "_") + "_Type"
+    dc_fields = [(f, str, dc.field(default="")) for f in fields]
+    idl_cls = dc.make_dataclass(cls_name, dc_fields, bases=(IdlStruct,))
+    return idl_cls
+
+
+class DdsBackend:
+    """Default CycloneDDS backend managing real DDS entities."""
+
+    def __init__(self, domain_id: int):
+        self._domain_id = domain_id
+        self._participant = None
+        self._topics: dict[str, Any] = {}
+        self._writers: dict[str, Any] = {}
+        self._readers: dict[str, Any] = {}
+        self._idl_types: dict[str, type] = {}
+        self._qos_map: dict[str, DdsTopicQos] = {}
+        self._sample_counts: dict[str, int] = {}
+        self._connected = False
+
+    def connect(self) -> DdsParticipantInfo:
+        if self._connected:
+            raise RuntimeError("Already connected to DDS domain")
+        from cyclonedds.domain import DomainParticipant
+
+        self._participant = DomainParticipant(domain_id=self._domain_id)
+        self._connected = True
+        return DdsParticipantInfo(
+            domain_id=self._domain_id,
+            topic_count=len(self._topics),
+            is_connected=True,
+        )
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            raise RuntimeError("Not connected to DDS domain")
+        self._writers.clear()
+        self._readers.clear()
+        self._topics.clear()
+        self._idl_types.clear()
+        self._qos_map.clear()
+        self._sample_counts.clear()
+        self._participant = None
+        self._connected = False
+
+    def _require_connected(self):
+        if not self._connected:
+            raise RuntimeError("Not connected -- call connect() first")
+
+    def create_topic(
+        self,
+        name: str,
+        fields: list[str],
+        qos: DdsTopicQos,
+    ) -> DdsTopicInfo:
+        self._require_connected()
+        if name in self._topics:
+            raise ValueError(f"Topic '{name}' already exists")
+
+        from cyclonedds.pub import DataWriter
+        from cyclonedds.sub import DataReader
+        from cyclonedds.topic import Topic
+
+        idl_type = _make_idl_type(name, fields)
+        self._idl_types[name] = idl_type
+
+        cqos = _build_cyclonedds_qos(qos)
+        topic = Topic(self._participant, name, idl_type, qos=cqos)
+        self._topics[name] = topic
+        self._qos_map[name] = qos
+        self._sample_counts[name] = 0
+
+        self._writers[name] = DataWriter(self._participant, topic, qos=cqos)
+        self._readers[name] = DataReader(self._participant, topic, qos=cqos)
+
+        return DdsTopicInfo(name=name, fields=fields, qos=qos)
+
+    def list_topics(self) -> list[DdsTopicInfo]:
+        self._require_connected()
+        result = []
+        for name in self._topics:
+            idl_type = self._idl_types[name]
+            fields = [f.name for f in idl_type.__dataclass_fields__.values()]
+            result.append(
+                DdsTopicInfo(
+                    name=name,
+                    fields=fields,
+                    qos=self._qos_map.get(name, DdsTopicQos()),
+                    sample_count=self._sample_counts.get(name, 0),
+                )
+            )
+        return result
+
+    def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        self._require_connected()
+        if topic_name not in self._writers:
+            raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
+
+        idl_type = self._idl_types[topic_name]
+        sample = idl_type(**data)
+        self._writers[topic_name].write(sample)
+        self._sample_counts[topic_name] = self._sample_counts.get(topic_name, 0) + 1
+
+        return DdsPublishResult(topic_name=topic_name, success=True, samples_written=1)
+
+    def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
+        self._require_connected()
+        if topic_name not in self._readers:
+            raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
+
+        reader = self._readers[topic_name]
+        raw_samples = reader.take(N=max_samples)
+
+        samples = []
+        for s in raw_samples:
+            data = {}
+            for f in s.__dataclass_fields__:
+                data[f] = getattr(s, f)
+            samples.append(DdsSample(topic_name=topic_name, data=data, timestamp=time.time()))
+
+        return DdsReadResult(topic_name=topic_name, samples=samples, sample_count=len(samples))
+
+    def get_participant_info(self) -> DdsParticipantInfo:
+        self._require_connected()
+        return DdsParticipantInfo(
+            domain_id=self._domain_id,
+            topic_count=len(self._topics),
+            is_connected=self._connected,
+        )
+
+
+class MockDdsBackend:
+    """In-memory mock backend for testing without real CycloneDDS dependencies."""
+
+    def __init__(self, domain_id: int = 0):
+        self._domain_id = domain_id
+        self._connected = False
+        self._topics: dict[str, DdsTopicInfo] = {}
+        self._topic_fields: dict[str, list[str]] = {}
+        self._buffers: dict[str, list[DdsSample]] = {}
+        self._sample_counts: dict[str, int] = {}
+
+    def connect(self) -> DdsParticipantInfo:
+        if self._connected:
+            raise RuntimeError("Already connected to DDS domain")
+        self._connected = True
+        return DdsParticipantInfo(
+            domain_id=self._domain_id,
+            topic_count=len(self._topics),
+            is_connected=True,
+        )
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            raise RuntimeError("Not connected to DDS domain")
+        self._connected = False
+        self._topics.clear()
+        self._topic_fields.clear()
+        self._buffers.clear()
+        self._sample_counts.clear()
+
+    def _require_connected(self):
+        if not self._connected:
+            raise RuntimeError("Not connected -- call connect() first")
+
+    def create_topic(
+        self,
+        name: str,
+        fields: list[str],
+        qos: DdsTopicQos,
+    ) -> DdsTopicInfo:
+        self._require_connected()
+        if name in self._topics:
+            raise ValueError(f"Topic '{name}' already exists")
+
+        info = DdsTopicInfo(name=name, fields=fields, qos=qos)
+        self._topics[name] = info
+        self._topic_fields[name] = fields
+        self._buffers[name] = []
+        self._sample_counts[name] = 0
+        return info
+
+    def list_topics(self) -> list[DdsTopicInfo]:
+        self._require_connected()
+        result = []
+        for name, info in self._topics.items():
+            result.append(
+                DdsTopicInfo(
+                    name=info.name,
+                    fields=info.fields,
+                    qos=info.qos,
+                    sample_count=self._sample_counts.get(name, 0),
+                )
+            )
+        return result
+
+    def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        self._require_connected()
+        if topic_name not in self._topics:
+            raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
+
+        fields = self._topic_fields[topic_name]
+        for key in data:
+            if key not in fields:
+                raise ValueError(f"Unknown field '{key}' for topic '{topic_name}'")
+
+        sample = DdsSample(topic_name=topic_name, data=data, timestamp=time.time())
+        qos = self._topics[topic_name].qos
+        buf = self._buffers[topic_name]
+        buf.append(sample)
+        if len(buf) > qos.history_depth:
+            self._buffers[topic_name] = buf[-qos.history_depth:]
+        self._sample_counts[topic_name] = self._sample_counts.get(topic_name, 0) + 1
+        return DdsPublishResult(topic_name=topic_name, success=True, samples_written=1)
+
+    def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
+        self._require_connected()
+        if topic_name not in self._topics:
+            raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
+
+        buf = self._buffers[topic_name]
+        taken = buf[:max_samples]
+        self._buffers[topic_name] = buf[max_samples:]
+        return DdsReadResult(topic_name=topic_name, samples=taken, sample_count=len(taken))
+
+    def get_participant_info(self) -> DdsParticipantInfo:
+        self._require_connected()
+        return DdsParticipantInfo(
+            domain_id=self._domain_id,
+            topic_count=len(self._topics),
+            is_connected=self._connected,
+        )
+
+
+@dataclass(kw_only=True, config=ConfigDict(arbitrary_types_allowed=True))
+class Dds(Driver):
+    """DDS (Data Distribution Service) driver using Eclipse CycloneDDS.
+
+    Provides publish/subscribe messaging over DDS with configurable
+    QoS, topics, and domain participation. Supports both real CycloneDDS
+    transport and an in-memory mock backend for testing.
+    """
+
+    domain_id: int = 0
+    default_reliability: DdsReliability = DdsReliability.RELIABLE
+    default_durability: DdsDurability = DdsDurability.VOLATILE
+    default_history_depth: int = 10
+    use_mock: bool = False
+
+    _backend: DdsBackend | MockDdsBackend = field(init=False, repr=False)
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+        if self.use_mock:
+            self._backend = MockDdsBackend(domain_id=self.domain_id)
+        else:
+            self._backend = DdsBackend(domain_id=self.domain_id)
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_dds.client.DdsClient"
+
+    def close(self):
+        if self._backend._connected:
+            try:
+                self._backend.disconnect()
+            except Exception:
+                logger.warning("Failed to disconnect DDS backend", exc_info=True)
+        super().close()
+
+    def _default_qos(self) -> DdsTopicQos:
+        return DdsTopicQos(
+            reliability=self.default_reliability,
+            durability=self.default_durability,
+            history_depth=self.default_history_depth,
+        )
+
+    @export
+    @validate_call(validate_return=True)
+    def connect(self) -> DdsParticipantInfo:
+        """Connect to the DDS domain and create a domain participant."""
+        return self._backend.connect()
+
+    @export
+    @validate_call(validate_return=True)
+    def disconnect(self) -> None:
+        """Disconnect from the DDS domain."""
+        self._backend.disconnect()
+
+    @export
+    @validate_call(validate_return=True)
+    def create_topic(
+        self,
+        name: str,
+        fields: list[str],
+        reliability: str | None = None,
+        durability: str | None = None,
+        history_depth: int | None = None,
+    ) -> DdsTopicInfo:
+        """Create a DDS topic with the given schema and QoS settings."""
+        qos = self._default_qos()
+        if reliability is not None:
+            qos.reliability = DdsReliability(reliability)
+        if durability is not None:
+            qos.durability = DdsDurability(durability)
+        if history_depth is not None:
+            qos.history_depth = history_depth
+        return self._backend.create_topic(name, fields, qos)
+
+    @export
+    @validate_call(validate_return=True)
+    def list_topics(self) -> list[DdsTopicInfo]:
+        """List all registered topics in this participant."""
+        return self._backend.list_topics()
+
+    @export
+    @validate_call(validate_return=True)
+    def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        """Publish a data sample to a DDS topic."""
+        return self._backend.publish(topic_name, data)
+
+    @export
+    @validate_call(validate_return=True)
+    def read(self, topic_name: str, max_samples: int = 10) -> DdsReadResult:
+        """Read (take) samples from a DDS topic."""
+        return self._backend.read(topic_name, max_samples)
+
+    @export
+    @validate_call(validate_return=True)
+    def get_participant_info(self) -> DdsParticipantInfo:
+        """Get information about the DDS domain participant."""
+        return self._backend.get_participant_info()
+
+    @export
+    async def monitor(self, topic_name: str) -> AsyncGenerator[DdsSample, None]:
+        """Stream data samples from a topic as they arrive.
+
+        Polls the topic reader periodically and yields new samples.
+        """
+        import asyncio
+
+        self._backend._require_connected()
+        if topic_name not in self._backend._topics:
+            raise ValueError(f"Topic '{topic_name}' not registered")
+
+        for _ in range(100):
+            result = self._backend.read(topic_name, max_samples=10)
+            for sample in result.samples:
+                yield sample
+            await asyncio.sleep(0.1)
+
+
+@dataclass(kw_only=True, config=ConfigDict(arbitrary_types_allowed=True))
+class MockDds(Driver):
+    """Mock DDS driver for testing without real CycloneDDS.
+
+    Wraps MockDdsBackend with the same @export interface as Dds,
+    allowing full gRPC e2e testing without native dependencies.
+
+    Accepts an optional ``backend`` parameter to inject a custom
+    backend for stateful testing.
+    """
+
+    domain_id: int = 0
+    backend: MockDdsBackend | None = field(default=None, repr=False)
+
+    _internal_backend: MockDdsBackend = field(init=False, repr=False)
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+        self._internal_backend = self.backend or MockDdsBackend(domain_id=self.domain_id)
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_dds.client.DdsClient"
+
+    @export
+    @validate_call(validate_return=True)
+    def connect(self) -> DdsParticipantInfo:
+        """Connect to the mock DDS domain."""
+        return self._internal_backend.connect()
+
+    @export
+    @validate_call(validate_return=True)
+    def disconnect(self) -> None:
+        """Disconnect from the mock DDS domain."""
+        self._internal_backend.disconnect()
+
+    @export
+    @validate_call(validate_return=True)
+    def create_topic(
+        self,
+        name: str,
+        fields: list[str],
+        reliability: str | None = None,
+        durability: str | None = None,
+        history_depth: int | None = None,
+    ) -> DdsTopicInfo:
+        """Create a topic on the mock backend."""
+        qos = DdsTopicQos()
+        if reliability is not None:
+            qos.reliability = DdsReliability(reliability)
+        if durability is not None:
+            qos.durability = DdsDurability(durability)
+        if history_depth is not None:
+            qos.history_depth = history_depth
+        return self._internal_backend.create_topic(name, fields, qos)
+
+    @export
+    @validate_call(validate_return=True)
+    def list_topics(self) -> list[DdsTopicInfo]:
+        """List all topics on the mock backend."""
+        return self._internal_backend.list_topics()
+
+    @export
+    @validate_call(validate_return=True)
+    def publish(self, topic_name: str, data: dict[str, Any]) -> DdsPublishResult:
+        """Publish data to a mock topic."""
+        return self._internal_backend.publish(topic_name, data)
+
+    @export
+    @validate_call(validate_return=True)
+    def read(self, topic_name: str, max_samples: int = 10) -> DdsReadResult:
+        """Read samples from a mock topic."""
+        return self._internal_backend.read(topic_name, max_samples)
+
+    @export
+    @validate_call(validate_return=True)
+    def get_participant_info(self) -> DdsParticipantInfo:
+        """Get mock participant info."""
+        return self._internal_backend.get_participant_info()
+
+    @export
+    async def monitor(self, topic_name: str) -> AsyncGenerator[DdsSample, None]:
+        """Stream data samples from a mock topic."""
+        import asyncio
+
+        self._internal_backend._require_connected()
+        if topic_name not in self._internal_backend._topics:
+            raise ValueError(f"Topic '{topic_name}' not registered")
+
+        for _ in range(100):
+            result = self._internal_backend.read(topic_name, max_samples=10)
+            for sample in result.samples:
+                yield sample
+            await asyncio.sleep(0.1)

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver.py
@@ -65,6 +65,8 @@ def _validate_field_names(fields: list[str]) -> None:
             raise ValueError(f"Field name {name!r} is not a valid Python identifier")
         if keyword.iskeyword(name):
             raise ValueError(f"Field name {name!r} is a Python keyword")
+        if name.startswith("__") and name.endswith("__"):
+            raise ValueError(f"Field name {name!r} is a dunder and conflicts with dataclass internals")
         if name in seen:
             raise ValueError(f"Duplicate field name {name!r}")
         seen.add(name)
@@ -137,22 +139,22 @@ class DdsBackend:
         for name, writer in self._writers.items():
             try:
                 writer.close()
-            except RuntimeError:
+            except Exception:
                 logger.debug("Failed to close writer for topic '%s'", name, exc_info=True)
         for name, reader in self._readers.items():
             try:
                 reader.close()
-            except RuntimeError:
+            except Exception:
                 logger.debug("Failed to close reader for topic '%s'", name, exc_info=True)
         for name, topic in self._topics.items():
             try:
                 topic.close()
-            except RuntimeError:
+            except Exception:
                 logger.debug("Failed to close topic '%s'", name, exc_info=True)
         if self._participant is not None:
             try:
                 self._participant.close()
-            except RuntimeError:
+            except Exception:
                 logger.debug("Failed to close DDS participant", exc_info=True)
         self._writers.clear()
         self._readers.clear()
@@ -197,8 +199,14 @@ class DdsBackend:
             reader = DataReader(self._participant, topic, qos=cqos)
         except Exception:
             if writer is not None:
-                writer.close()
-            topic.close()
+                try:
+                    writer.close()
+                except Exception:
+                    logger.debug("Failed to close writer during rollback", exc_info=True)
+            try:
+                topic.close()
+            except Exception:
+                logger.debug("Failed to close topic during rollback", exc_info=True)
             raise
 
         self._idl_types[name] = idl_type
@@ -253,6 +261,8 @@ class DdsBackend:
         will cause samples to be split unpredictably between the two.
         """
         self._require_connected()
+        if max_samples < 1:
+            raise ValueError("max_samples must be >= 1")
         if topic_name not in self._readers:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
 
@@ -385,6 +395,8 @@ class MockDdsBackend:
     def read(self, topic_name: str, max_samples: int) -> DdsReadResult:
         """Take up to *max_samples* from the in-memory buffer."""
         self._require_connected()
+        if max_samples < 1:
+            raise ValueError("max_samples must be >= 1")
         if topic_name not in self._topics:
             raise ValueError(f"Topic '{topic_name}' not registered -- call create_topic() first")
 
@@ -427,6 +439,13 @@ class Dds(Driver):
         if self.use_mock:
             self._backend = MockDdsBackend(domain_id=self.domain_id)
         else:
+            try:
+                from cyclonedds.domain import DomainParticipant  # noqa: F401
+            except ImportError as exc:
+                raise ImportError(
+                    "CycloneDDS native library is required when use_mock=False. "
+                    "Install with: pip install 'jumpstarter-driver-dds[cyclonedds]'"
+                ) from exc
             self._backend = DdsBackend(domain_id=self.domain_id)
 
     @classmethod
@@ -436,12 +455,14 @@ class Dds(Driver):
 
     def close(self):
         """Disconnect the backend (if connected) and release resources."""
-        if self._backend.is_connected:
-            try:
-                self._backend.disconnect()
-            except RuntimeError:
-                logger.warning("Failed to disconnect DDS backend", exc_info=True)
-        super().close()
+        try:
+            if self._backend.is_connected:
+                try:
+                    self._backend.disconnect()
+                except Exception:
+                    logger.warning("Failed to disconnect DDS backend", exc_info=True)
+        finally:
+            super().close()
 
     def _default_qos(self) -> DdsTopicQos:
         """Build a ``DdsTopicQos`` from this driver's default settings."""
@@ -519,6 +540,8 @@ class Dds(Driver):
         """
         import anyio
 
+        if max_iterations < 0:
+            raise ValueError("max_iterations must be >= 0 (0 = unlimited)")
         if not self._backend.is_connected:
             raise RuntimeError("Not connected -- call connect() first")
         if not self._backend.has_topic(topic_name):
@@ -568,12 +591,14 @@ class MockDds(Driver):
 
     def close(self):
         """Disconnect the mock backend (if connected) and release resources."""
-        if self._internal_backend.is_connected:
-            try:
-                self._internal_backend.disconnect()
-            except RuntimeError:
-                logger.warning("Failed to disconnect mock DDS backend", exc_info=True)
-        super().close()
+        try:
+            if self._internal_backend.is_connected:
+                try:
+                    self._internal_backend.disconnect()
+                except Exception:
+                    logger.warning("Failed to disconnect mock DDS backend", exc_info=True)
+        finally:
+            super().close()
 
     def _default_qos(self) -> DdsTopicQos:
         """Build a ``DdsTopicQos`` from this driver's default settings."""
@@ -648,6 +673,8 @@ class MockDds(Driver):
         """
         import anyio
 
+        if max_iterations < 0:
+            raise ValueError("max_iterations must be >= 0 (0 = unlimited)")
         if not self._internal_backend.is_connected:
             raise RuntimeError("Not connected -- call connect() first")
         if not self._internal_backend.has_topic(topic_name):

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver_test.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver_test.py
@@ -1,0 +1,620 @@
+from __future__ import annotations
+
+import pytest
+
+from .common import (
+    DdsDurability,
+    DdsParticipantInfo,
+    DdsPublishResult,
+    DdsReadResult,
+    DdsReliability,
+    DdsSample,
+    DdsTopicInfo,
+    DdsTopicQos,
+)
+from .driver import MockDds, MockDdsBackend
+from jumpstarter.client.core import DriverError
+from jumpstarter.common.utils import serve
+
+# =============================================================================
+# Level 1: Unit Tests (Pydantic models, backend logic)
+# =============================================================================
+
+
+class TestPydanticModels:
+    """1a. Pydantic model validation."""
+
+    def test_topic_qos_defaults(self):
+        qos = DdsTopicQos()
+        assert qos.reliability == DdsReliability.RELIABLE
+        assert qos.durability == DdsDurability.VOLATILE
+        assert qos.history_depth == 10
+
+    def test_topic_qos_custom(self):
+        qos = DdsTopicQos(
+            reliability=DdsReliability.BEST_EFFORT,
+            durability=DdsDurability.TRANSIENT_LOCAL,
+            history_depth=50,
+        )
+        assert qos.reliability == DdsReliability.BEST_EFFORT
+        assert qos.durability == DdsDurability.TRANSIENT_LOCAL
+        assert qos.history_depth == 50
+
+    def test_participant_info(self):
+        info = DdsParticipantInfo(domain_id=42, topic_count=3, is_connected=True)
+        assert info.domain_id == 42
+        assert info.topic_count == 3
+        assert info.is_connected is True
+
+    def test_topic_info(self):
+        info = DdsTopicInfo(name="sensor/temp", fields=["value", "unit"])
+        assert info.name == "sensor/temp"
+        assert info.fields == ["value", "unit"]
+        assert info.sample_count == 0
+
+    def test_dds_sample(self):
+        sample = DdsSample(
+            topic_name="test",
+            data={"x": "1", "y": "2"},
+            timestamp=1234567.0,
+        )
+        assert sample.topic_name == "test"
+        assert sample.data["x"] == "1"
+
+    def test_publish_result(self):
+        result = DdsPublishResult(topic_name="test", success=True, samples_written=1)
+        assert result.success is True
+        assert result.samples_written == 1
+
+    def test_read_result_empty(self):
+        result = DdsReadResult(topic_name="test", samples=[], sample_count=0)
+        assert result.sample_count == 0
+
+    def test_reliability_enum(self):
+        assert DdsReliability("RELIABLE") == DdsReliability.RELIABLE
+        assert DdsReliability("BEST_EFFORT") == DdsReliability.BEST_EFFORT
+        with pytest.raises(ValueError):
+            DdsReliability("INVALID")
+
+    def test_durability_enum(self):
+        assert DdsDurability("VOLATILE") == DdsDurability.VOLATILE
+        assert DdsDurability("TRANSIENT_LOCAL") == DdsDurability.TRANSIENT_LOCAL
+        assert DdsDurability("TRANSIENT") == DdsDurability.TRANSIENT
+        assert DdsDurability("PERSISTENT") == DdsDurability.PERSISTENT
+        with pytest.raises(ValueError):
+            DdsDurability("INVALID")
+
+
+class TestMockDdsBackendUnit:
+    """1b. MockDdsBackend unit tests (no gRPC)."""
+
+    def test_connect_disconnect(self):
+        backend = MockDdsBackend(domain_id=5)
+        info = backend.connect()
+        assert info.domain_id == 5
+        assert info.is_connected is True
+        backend.disconnect()
+        assert backend._connected is False
+
+    def test_double_connect_raises(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        with pytest.raises(RuntimeError, match="Already connected"):
+            backend.connect()
+
+    def test_disconnect_without_connect_raises(self):
+        backend = MockDdsBackend()
+        with pytest.raises(RuntimeError, match="Not connected"):
+            backend.disconnect()
+
+    def test_create_topic(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        qos = DdsTopicQos()
+        info = backend.create_topic("test_topic", ["field1", "field2"], qos)
+        assert info.name == "test_topic"
+        assert info.fields == ["field1", "field2"]
+
+    def test_create_duplicate_topic_raises(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        qos = DdsTopicQos()
+        backend.create_topic("test_topic", ["field1"], qos)
+        with pytest.raises(ValueError, match="already exists"):
+            backend.create_topic("test_topic", ["field2"], qos)
+
+    def test_publish_and_read(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["val"], DdsTopicQos())
+        result = backend.publish("t", {"val": "42"})
+        assert result.success is True
+        read_result = backend.read("t", 10)
+        assert read_result.sample_count == 1
+        assert read_result.samples[0].data["val"] == "42"
+
+    def test_read_empty_topic(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["val"], DdsTopicQos())
+        read_result = backend.read("t", 10)
+        assert read_result.sample_count == 0
+
+    def test_read_consumes_samples(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["val"], DdsTopicQos())
+        backend.publish("t", {"val": "1"})
+        backend.publish("t", {"val": "2"})
+        first = backend.read("t", 10)
+        assert first.sample_count == 2
+        second = backend.read("t", 10)
+        assert second.sample_count == 0
+
+    def test_history_depth_enforcement(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["val"], DdsTopicQos(history_depth=3))
+        for i in range(5):
+            backend.publish("t", {"val": str(i)})
+        result = backend.read("t", 10)
+        assert result.sample_count == 3
+        assert result.samples[0].data["val"] == "2"
+
+    def test_publish_to_nonexistent_topic_raises(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        with pytest.raises(ValueError, match="not registered"):
+            backend.publish("nope", {"val": "1"})
+
+    def test_read_from_nonexistent_topic_raises(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        with pytest.raises(ValueError, match="not registered"):
+            backend.read("nope", 10)
+
+    def test_operations_before_connect_raise(self):
+        backend = MockDdsBackend()
+        with pytest.raises(RuntimeError, match="Not connected"):
+            backend.create_topic("t", ["f"], DdsTopicQos())
+        with pytest.raises(RuntimeError, match="Not connected"):
+            backend.publish("t", {})
+        with pytest.raises(RuntimeError, match="Not connected"):
+            backend.read("t", 10)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            backend.list_topics()
+
+    def test_list_topics(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        assert backend.list_topics() == []
+        backend.create_topic("a", ["x"], DdsTopicQos())
+        backend.create_topic("b", ["y", "z"], DdsTopicQos())
+        topics = backend.list_topics()
+        assert len(topics) == 2
+        names = {t.name for t in topics}
+        assert names == {"a", "b"}
+
+    def test_disconnect_clears_state(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["f"], DdsTopicQos())
+        backend.publish("t", {"f": "v"})
+        backend.disconnect()
+        backend.connect()
+        assert backend.list_topics() == []
+
+    def test_get_participant_info(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t1", ["a"], DdsTopicQos())
+        backend.create_topic("t2", ["b"], DdsTopicQos())
+        info = backend.get_participant_info()
+        assert info.domain_id == 0
+        assert info.topic_count == 2
+        assert info.is_connected is True
+
+
+# =============================================================================
+# Level 2: E2E Tests with MockDds (gRPC boundary, always run)
+# =============================================================================
+
+
+class TestMockDdsE2E:
+    """2a. Full e2e tests through gRPC with MockDds driver."""
+
+    def test_connect_disconnect(self):
+        with serve(MockDds()) as client:
+            info = client.connect()
+            assert info.is_connected is True
+            assert info.domain_id == 0
+            client.disconnect()
+
+    def test_create_topic_and_list(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            topic = client.create_topic("sensor/temp", ["value", "unit"])
+            assert topic.name == "sensor/temp"
+            assert topic.fields == ["value", "unit"]
+
+            topics = client.list_topics()
+            assert len(topics) == 1
+            assert topics[0].name == "sensor/temp"
+            client.disconnect()
+
+    def test_publish_and_read(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("data", ["x", "y"])
+            pub_result = client.publish("data", {"x": "10", "y": "20"})
+            assert pub_result.success is True
+            assert pub_result.samples_written == 1
+
+            read_result = client.read("data")
+            assert read_result.sample_count == 1
+            assert read_result.samples[0].data["x"] == "10"
+            assert read_result.samples[0].data["y"] == "20"
+            client.disconnect()
+
+    def test_multiple_topics(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("a", ["f1"])
+            client.create_topic("b", ["f2"])
+            client.publish("a", {"f1": "A"})
+            client.publish("b", {"f2": "B"})
+
+            ra = client.read("a")
+            rb = client.read("b")
+            assert ra.samples[0].data["f1"] == "A"
+            assert rb.samples[0].data["f2"] == "B"
+            client.disconnect()
+
+    def test_custom_qos(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            topic = client.create_topic(
+                "reliable_topic",
+                ["val"],
+                reliability="RELIABLE",
+                durability="TRANSIENT_LOCAL",
+                history_depth=5,
+            )
+            assert topic.qos.reliability == DdsReliability.RELIABLE
+            assert topic.qos.durability == DdsDurability.TRANSIENT_LOCAL
+            assert topic.qos.history_depth == 5
+            client.disconnect()
+
+    def test_get_participant_info(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("t1", ["a"])
+            info = client.get_participant_info()
+            assert info.domain_id == 0
+            assert info.topic_count == 1
+            assert info.is_connected is True
+            client.disconnect()
+
+    def test_streaming_monitor(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("stream", ["val"])
+            client.publish("stream", {"val": "hello"})
+            client.publish("stream", {"val": "world"})
+
+            events = []
+            for sample in client.monitor("stream"):
+                events.append(sample)
+                if len(events) >= 2:
+                    break
+            assert len(events) == 2
+            assert events[0].data["val"] == "hello"
+            assert events[1].data["val"] == "world"
+            client.disconnect()
+
+    def test_read_multiple_samples(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("multi", ["v"])
+            for i in range(5):
+                client.publish("multi", {"v": str(i)})
+            result = client.read("multi", max_samples=3)
+            assert result.sample_count == 3
+            client.disconnect()
+
+
+class TestMockDdsErrorPaths:
+    """2b. Error path tests through gRPC."""
+
+    def test_operations_before_connect(self):
+        with serve(MockDds()) as client:
+            with pytest.raises(DriverError, match="Not connected"):
+                client.create_topic("t", ["f"])
+            with pytest.raises(DriverError, match="Not connected"):
+                client.publish("t", {"f": "v"})
+            with pytest.raises(DriverError, match="Not connected"):
+                client.read("t")
+            with pytest.raises(DriverError, match="Not connected"):
+                client.list_topics()
+
+    def test_double_connect(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="Already connected"):
+                client.connect()
+
+    def test_disconnect_without_connect(self):
+        with serve(MockDds()) as client:
+            with pytest.raises(DriverError, match="Not connected"):
+                client.disconnect()
+
+    def test_publish_nonexistent_topic(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="not registered"):
+                client.publish("nope", {"f": "v"})
+
+    def test_read_nonexistent_topic(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            with pytest.raises(DriverError, match="not registered"):
+                client.read("nope")
+
+    def test_duplicate_topic_creation(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("t", ["f"])
+            with pytest.raises(DriverError, match="already exists"):
+                client.create_topic("t", ["f"])
+
+
+class TestClientCli:
+    """2c. Client CLI interface tests."""
+
+    def test_cli_interface(self):
+        with serve(MockDds()) as client:
+            cli = client.cli()
+            assert hasattr(cli, "commands")
+            assert "topics" in cli.commands
+            assert "info" in cli.commands
+
+
+# =============================================================================
+# Level 2.5: Stateful Tests (DDS lifecycle enforcement)
+# =============================================================================
+
+
+class TestStatefulConnectionLifecycle:
+    """2.5a. Connection lifecycle with stateful backend."""
+
+    def test_stateful_connect_disconnect(self, stateful_client):
+        client, backend = stateful_client
+        info = client.connect()
+        assert info.is_connected is True
+        assert backend._connected is True
+
+        client.disconnect()
+        assert backend._connected is False
+
+    def test_stateful_double_connect_raises(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        with pytest.raises(DriverError, match="Already connected"):
+            client.connect()
+
+    def test_stateful_disconnect_without_connect_raises(self, stateful_client):
+        client, _backend = stateful_client
+        with pytest.raises(DriverError, match="Not connected"):
+            client.disconnect()
+
+    def test_stateful_operations_before_connect_raise(self, stateful_client):
+        client, _backend = stateful_client
+        with pytest.raises(DriverError):
+            client.create_topic("t", ["f"])
+        with pytest.raises(DriverError):
+            client.publish("t", {"f": "v"})
+        with pytest.raises(DriverError):
+            client.read("t")
+
+
+class TestStatefulTopicManagement:
+    """2.5b. Topic creation and schema enforcement."""
+
+    def test_stateful_create_topic(self, stateful_client):
+        client, backend = stateful_client
+        client.connect()
+        topic = client.create_topic("sensor", ["temp", "humidity"])
+        assert topic.name == "sensor"
+        assert topic.fields == ["temp", "humidity"]
+        assert "sensor" in backend._topics
+
+    def test_stateful_duplicate_topic_rejected(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("sensor", ["temp"])
+        with pytest.raises(DriverError, match="already exists"):
+            client.create_topic("sensor", ["humidity"])
+
+    def test_stateful_empty_fields_rejected(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        with pytest.raises(DriverError, match="at least one field"):
+            client.create_topic("empty", [])
+
+    def test_stateful_multiple_topics_independent(self, stateful_client):
+        client, backend = stateful_client
+        client.connect()
+        client.create_topic("a", ["x"])
+        client.create_topic("b", ["y"])
+        assert len(backend._topics) == 2
+
+        client.publish("a", {"x": "1"})
+        client.publish("b", {"y": "2"})
+
+        ra = client.read("a")
+        rb = client.read("b")
+        assert ra.samples[0].data["x"] == "1"
+        assert rb.samples[0].data["y"] == "2"
+
+
+class TestStatefulPublishSubscribe:
+    """2.5c. Publish and subscribe with schema validation."""
+
+    def test_stateful_publish_valid_fields(self, stateful_client):
+        client, backend = stateful_client
+        client.connect()
+        client.create_topic("data", ["x", "y"])
+        result = client.publish("data", {"x": "10", "y": "20"})
+        assert result.success is True
+        assert backend._total_published == 1
+
+    def test_stateful_publish_invalid_field_rejected(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("data", ["x", "y"])
+        with pytest.raises(DriverError, match="Unknown field"):
+            client.publish("data", {"x": "10", "z": "bad"})
+
+    def test_stateful_read_consumes_samples(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("t", ["v"])
+        client.publish("t", {"v": "1"})
+        client.publish("t", {"v": "2"})
+
+        first = client.read("t")
+        assert first.sample_count == 2
+
+        second = client.read("t")
+        assert second.sample_count == 0
+
+    def test_stateful_history_depth_enforcement(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("t", ["v"], history_depth=3)
+        for i in range(5):
+            client.publish("t", {"v": str(i)})
+
+        result = client.read("t")
+        assert result.sample_count == 3
+        assert result.samples[0].data["v"] == "2"
+        assert result.samples[2].data["v"] == "4"
+
+
+class TestStatefulReconnect:
+    """2.5d. Reconnect resets state."""
+
+    def test_stateful_reconnect_clears_topics(self, stateful_client):
+        client, backend = stateful_client
+        client.connect()
+        client.create_topic("t", ["f"])
+        client.publish("t", {"f": "v"})
+        client.disconnect()
+
+        client.connect()
+        topics = client.list_topics()
+        assert len(topics) == 0
+        assert backend._total_published == 0
+
+    def test_stateful_reconnect_allows_same_topic(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("t", ["f"])
+        client.disconnect()
+
+        client.connect()
+        topic = client.create_topic("t", ["f"])
+        assert topic.name == "t"
+
+
+class TestStatefulCallLog:
+    """2.5e. Call log / audit trail."""
+
+    def test_stateful_call_log_records_operations(self, stateful_client):
+        client, backend = stateful_client
+        client.connect()
+        client.create_topic("t", ["f"])
+        client.publish("t", {"f": "v"})
+        client.read("t")
+        client.disconnect()
+        assert backend._call_log == [
+            "connect",
+            "create_topic(t)",
+            "publish(t)",
+            "read(t)",
+            "disconnect",
+        ]
+
+    def test_stateful_counters(self, stateful_client):
+        client, backend = stateful_client
+        client.connect()
+        client.create_topic("t", ["f"])
+        client.publish("t", {"f": "a"})
+        client.publish("t", {"f": "b"})
+        client.read("t")
+        assert backend._total_published == 2
+        assert backend._total_read == 2
+
+
+class TestStatefulFullWorkflow:
+    """2.5f. End-to-end workflow tests."""
+
+    def test_stateful_sensor_data_workflow(self, stateful_client):
+        """Simulate a typical sensor data collection workflow."""
+        client, backend = stateful_client
+
+        client.connect()
+        client.create_topic("sensor/temperature", ["value", "unit", "location"])
+        client.create_topic("sensor/humidity", ["value", "unit"])
+
+        client.publish("sensor/temperature", {"value": "22.5", "unit": "C", "location": "lab1"})
+        client.publish("sensor/temperature", {"value": "23.1", "unit": "C", "location": "lab2"})
+        client.publish("sensor/humidity", {"value": "45", "unit": "%"})
+
+        info = client.get_participant_info()
+        assert info.topic_count == 2
+
+        temp_data = client.read("sensor/temperature")
+        assert temp_data.sample_count == 2
+
+        humid_data = client.read("sensor/humidity")
+        assert humid_data.sample_count == 1
+        assert humid_data.samples[0].data["value"] == "45"
+
+        assert backend._total_published == 3
+        assert backend._total_read == 3
+
+        client.disconnect()
+
+    def test_stateful_high_frequency_pubsub(self, stateful_client):
+        """Publish many samples and verify history depth trimming."""
+        client, backend = stateful_client
+        client.connect()
+        client.create_topic("fast", ["seq"], history_depth=5)
+
+        for i in range(100):
+            client.publish("fast", {"seq": str(i)})
+
+        assert backend._total_published == 100
+
+        result = client.read("fast")
+        assert result.sample_count == 5
+        assert result.samples[0].data["seq"] == "95"
+        assert result.samples[4].data["seq"] == "99"
+
+        client.disconnect()
+
+    def test_stateful_qos_combinations(self, stateful_client):
+        """Test different QoS combinations on separate topics."""
+        client, _backend = stateful_client
+        client.connect()
+
+        t1 = client.create_topic("reliable", ["v"], reliability="RELIABLE", durability="VOLATILE")
+        assert t1.qos.reliability == DdsReliability.RELIABLE
+        assert t1.qos.durability == DdsDurability.VOLATILE
+
+        t2 = client.create_topic("best_effort", ["v"], reliability="BEST_EFFORT", durability="TRANSIENT_LOCAL")
+        assert t2.qos.reliability == DdsReliability.BEST_EFFORT
+        assert t2.qos.durability == DdsDurability.TRANSIENT_LOCAL
+
+        client.disconnect()

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver_test.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver_test.py
@@ -375,8 +375,10 @@ class TestClientCli:
         with serve(MockDds()) as client:
             cli = client.cli()
             assert hasattr(cli, "commands")
-            assert "topics" in cli.commands
-            assert "info" in cli.commands
+            expected_commands = {"connect", "disconnect", "topics", "info", "read", "monitor"}
+            assert expected_commands.issubset(set(cli.commands)), (
+                f"Missing CLI commands: {expected_commands - set(cli.commands)}"
+            )
 
 
 # =============================================================================
@@ -474,6 +476,13 @@ class TestStatefulPublishSubscribe:
         client.create_topic("data", ["x", "y"])
         with pytest.raises(DriverError, match="Unknown field"):
             client.publish("data", {"x": "10", "z": "bad"})
+
+    def test_stateful_publish_missing_field_rejected(self, stateful_client):
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("data", ["x", "y"])
+        with pytest.raises(DriverError, match="Missing required field"):
+            client.publish("data", {"x": "10"})
 
     def test_stateful_read_consumes_samples(self, stateful_client):
         client, _backend = stateful_client

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver_test.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/driver_test.py
@@ -12,7 +12,7 @@ from .common import (
     DdsTopicInfo,
     DdsTopicQos,
 )
-from .driver import MockDds, MockDdsBackend
+from .driver import Dds, MockDds, MockDdsBackend
 from jumpstarter.client.core import DriverError
 from jumpstarter.common.utils import serve
 
@@ -62,13 +62,20 @@ class TestPydanticModels:
         assert sample.data["x"] == "1"
 
     def test_publish_result(self):
-        result = DdsPublishResult(topic_name="test", success=True, samples_written=1)
-        assert result.success is True
+        result = DdsPublishResult(topic_name="test", samples_written=1)
         assert result.samples_written == 1
 
     def test_read_result_empty(self):
         result = DdsReadResult(topic_name="test", samples=[], sample_count=0)
         assert result.sample_count == 0
+
+    def test_read_result_count_mismatch_raises(self):
+        with pytest.raises(ValueError, match="sample_count"):
+            DdsReadResult(
+                topic_name="test",
+                samples=[DdsSample(topic_name="test", data={"k": "v"})],
+                sample_count=0,
+            )
 
     def test_reliability_enum(self):
         assert DdsReliability("RELIABLE") == DdsReliability.RELIABLE
@@ -128,10 +135,26 @@ class TestMockDdsBackendUnit:
         backend.connect()
         backend.create_topic("t", ["val"], DdsTopicQos())
         result = backend.publish("t", {"val": "42"})
-        assert result.success is True
+        assert result.samples_written == 1
         read_result = backend.read("t", 10)
         assert read_result.sample_count == 1
         assert read_result.samples[0].data["val"] == "42"
+
+    def test_publish_partial_fills_defaults(self):
+        """Missing fields are filled with empty string, matching real backend."""
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["x", "y"], DdsTopicQos())
+        backend.publish("t", {"x": "10"})
+        result = backend.read("t", 10)
+        assert result.samples[0].data == {"x": "10", "y": ""}
+
+    def test_publish_unknown_field_raises(self):
+        backend = MockDdsBackend()
+        backend.connect()
+        backend.create_topic("t", ["x"], DdsTopicQos())
+        with pytest.raises(ValueError, match="Unknown field"):
+            backend.publish("t", {"x": "1", "z": "bad"})
 
     def test_read_empty_topic(self):
         backend = MockDdsBackend()
@@ -247,13 +270,22 @@ class TestMockDdsE2E:
             client.connect()
             client.create_topic("data", ["x", "y"])
             pub_result = client.publish("data", {"x": "10", "y": "20"})
-            assert pub_result.success is True
             assert pub_result.samples_written == 1
 
             read_result = client.read("data")
             assert read_result.sample_count == 1
             assert read_result.samples[0].data["x"] == "10"
             assert read_result.samples[0].data["y"] == "20"
+            client.disconnect()
+
+    def test_publish_partial_fills_defaults(self):
+        """Partial publish fills missing fields with empty string."""
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("data", ["x", "y"])
+            client.publish("data", {"x": "10"})
+            result = client.read("data")
+            assert result.samples[0].data == {"x": "10", "y": ""}
             client.disconnect()
 
     def test_multiple_topics(self):
@@ -367,6 +399,13 @@ class TestMockDdsErrorPaths:
             with pytest.raises(DriverError, match="already exists"):
                 client.create_topic("t", ["f"])
 
+    def test_publish_unknown_field(self):
+        with serve(MockDds()) as client:
+            client.connect()
+            client.create_topic("t", ["x"])
+            with pytest.raises(DriverError, match="Unknown field"):
+                client.publish("t", {"x": "1", "z": "bad"})
+
 
 class TestClientCli:
     """2c. Client CLI interface tests."""
@@ -375,10 +414,47 @@ class TestClientCli:
         with serve(MockDds()) as client:
             cli = client.cli()
             assert hasattr(cli, "commands")
-            expected_commands = {"connect", "disconnect", "topics", "info", "read", "monitor"}
+            expected_commands = {
+                "connect",
+                "disconnect",
+                "topics",
+                "info",
+                "create-topic",
+                "publish",
+                "read",
+                "monitor",
+            }
             assert expected_commands.issubset(set(cli.commands)), (
                 f"Missing CLI commands: {expected_commands - set(cli.commands)}"
             )
+
+
+class TestDdsUseMock:
+    """2d. Test Dds(use_mock=True) path."""
+
+    def test_use_mock_flag(self):
+        driver = Dds(use_mock=True)
+        with serve(driver) as client:
+            info = client.connect()
+            assert info.is_connected is True
+            client.create_topic("t", ["f"])
+            client.publish("t", {"f": "v"})
+            result = client.read("t")
+            assert result.sample_count == 1
+            client.disconnect()
+
+    def test_use_mock_custom_qos(self):
+        driver = Dds(
+            use_mock=True,
+            default_reliability=DdsReliability.BEST_EFFORT,
+            default_history_depth=5,
+        )
+        with serve(driver) as client:
+            client.connect()
+            topic = client.create_topic("t", ["v"])
+            assert topic.qos.reliability == DdsReliability.BEST_EFFORT
+            assert topic.qos.history_depth == 5
+            client.disconnect()
 
 
 # =============================================================================
@@ -437,12 +513,6 @@ class TestStatefulTopicManagement:
         with pytest.raises(DriverError, match="already exists"):
             client.create_topic("sensor", ["humidity"])
 
-    def test_stateful_empty_fields_rejected(self, stateful_client):
-        client, _backend = stateful_client
-        client.connect()
-        with pytest.raises(DriverError, match="at least one field"):
-            client.create_topic("empty", [])
-
     def test_stateful_multiple_topics_independent(self, stateful_client):
         client, backend = stateful_client
         client.connect()
@@ -467,8 +537,17 @@ class TestStatefulPublishSubscribe:
         client.connect()
         client.create_topic("data", ["x", "y"])
         result = client.publish("data", {"x": "10", "y": "20"})
-        assert result.success is True
+        assert result.samples_written == 1
         assert backend._total_published == 1
+
+    def test_stateful_publish_partial_fills_defaults(self, stateful_client):
+        """Partial publish fills missing fields with empty string."""
+        client, _backend = stateful_client
+        client.connect()
+        client.create_topic("data", ["x", "y"])
+        client.publish("data", {"x": "10"})
+        result = client.read("data")
+        assert result.samples[0].data == {"x": "10", "y": ""}
 
     def test_stateful_publish_invalid_field_rejected(self, stateful_client):
         client, _backend = stateful_client
@@ -476,13 +555,6 @@ class TestStatefulPublishSubscribe:
         client.create_topic("data", ["x", "y"])
         with pytest.raises(DriverError, match="Unknown field"):
             client.publish("data", {"x": "10", "z": "bad"})
-
-    def test_stateful_publish_missing_field_rejected(self, stateful_client):
-        client, _backend = stateful_client
-        client.connect()
-        client.create_topic("data", ["x", "y"])
-        with pytest.raises(DriverError, match="Missing required field"):
-            client.publish("data", {"x": "10"})
 
     def test_stateful_read_consumes_samples(self, stateful_client):
         client, _backend = stateful_client

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/regression_test.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/regression_test.py
@@ -1,0 +1,224 @@
+"""Regression tests to prevent recurrence of review-finding categories.
+
+These tests guard structural invariants that are easy to break when
+adding new backends, driver classes, CLI commands, or Pydantic models.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import pathlib
+
+import pytest
+
+from .common import (
+    DdsPublishResult,
+    DdsReadResult,
+    DdsSample,
+    DdsTopicQos,
+)
+from .driver import Dds, MockDds, _make_idl_type
+from jumpstarter.common.utils import serve
+
+# =============================================================================
+# 1. Backend parity: identical operations must produce identical results
+# =============================================================================
+
+
+class TestBackendParity:
+    """Run against ALL backends via the ``any_backend`` fixture."""
+
+    def test_partial_publish_fills_defaults(self, any_backend):
+        any_backend.connect()
+        any_backend.create_topic("t", ["x", "y"], DdsTopicQos())
+        any_backend.publish("t", {"x": "1"})
+        result = any_backend.read("t", 10)
+        assert result.samples[0].data == {"x": "1", "y": ""}
+
+    def test_empty_publish_fills_all_defaults(self, any_backend):
+        any_backend.connect()
+        any_backend.create_topic("t", ["a", "b"], DdsTopicQos())
+        any_backend.publish("t", {})
+        result = any_backend.read("t", 10)
+        assert result.samples[0].data == {"a": "", "b": ""}
+
+    def test_unknown_field_raises_valueerror(self, any_backend):
+        any_backend.connect()
+        any_backend.create_topic("t", ["x"], DdsTopicQos())
+        with pytest.raises(ValueError, match="Unknown field"):
+            any_backend.publish("t", {"z": "bad"})
+
+    def test_publish_nonexistent_topic_raises_valueerror(self, any_backend):
+        any_backend.connect()
+        with pytest.raises(ValueError, match="not registered"):
+            any_backend.publish("nope", {"x": "1"})
+
+    def test_read_nonexistent_topic_raises_valueerror(self, any_backend):
+        any_backend.connect()
+        with pytest.raises(ValueError, match="not registered"):
+            any_backend.read("nope", 10)
+
+    def test_duplicate_topic_raises_valueerror(self, any_backend):
+        any_backend.connect()
+        any_backend.create_topic("t", ["x"], DdsTopicQos())
+        with pytest.raises(ValueError, match="already exists"):
+            any_backend.create_topic("t", ["y"], DdsTopicQos())
+
+    def test_history_depth_trim(self, any_backend):
+        any_backend.connect()
+        any_backend.create_topic("t", ["v"], DdsTopicQos(history_depth=3))
+        for i in range(5):
+            any_backend.publish("t", {"v": str(i)})
+        result = any_backend.read("t", 10)
+        assert result.sample_count == 3
+        assert result.samples[0].data["v"] == "2"
+
+    def test_read_consumes_buffer(self, any_backend):
+        any_backend.connect()
+        any_backend.create_topic("t", ["v"], DdsTopicQos())
+        any_backend.publish("t", {"v": "1"})
+        first = any_backend.read("t", 10)
+        assert first.sample_count == 1
+        second = any_backend.read("t", 10)
+        assert second.sample_count == 0
+
+    def test_operations_before_connect_raise_runtimeerror(self, any_backend):
+        with pytest.raises(RuntimeError, match="Not connected"):
+            any_backend.create_topic("t", ["f"], DdsTopicQos())
+
+    def test_double_connect_raises_runtimeerror(self, any_backend):
+        any_backend.connect()
+        with pytest.raises(RuntimeError, match="Already connected"):
+            any_backend.connect()
+
+
+# =============================================================================
+# 2. Driver interface parity: Dds and MockDds must expose the same surface
+# =============================================================================
+
+
+class TestDriverInterfaceParity:
+    def test_export_methods_match(self):
+        def _exported(cls):
+            return {
+                name
+                for name in dir(cls)
+                if not name.startswith("_")
+                and callable(getattr(cls, name, None))
+                and hasattr(getattr(cls, name), "__wrapped__")
+            }
+
+        dds_methods = {
+            name for name in vars(Dds) if not name.startswith("_") and hasattr(getattr(Dds, name, None), "__wrapped__")
+        }
+        mock_methods = {
+            name
+            for name in vars(MockDds)
+            if not name.startswith("_") and hasattr(getattr(MockDds, name, None), "__wrapped__")
+        }
+        assert dds_methods == mock_methods, (
+            f"Export mismatch: Dds has {dds_methods - mock_methods}, MockDds has {mock_methods - dds_methods}"
+        )
+
+    def test_shared_config_fields_present(self):
+        shared = {"domain_id", "default_reliability", "default_durability", "default_history_depth"}
+        dds_fields = {f.name for f in dc.fields(Dds) if not f.name.startswith("_")}
+        mock_fields = {f.name for f in dc.fields(MockDds) if not f.name.startswith("_")}
+        assert shared.issubset(dds_fields), f"Dds missing: {shared - dds_fields}"
+        assert shared.issubset(mock_fields), f"MockDds missing: {shared - mock_fields}"
+
+    def test_both_override_close(self):
+        assert "close" in vars(Dds), "Dds must override close()"
+        assert "close" in vars(MockDds), "MockDds must override close()"
+
+    def test_both_have_default_qos(self):
+        assert hasattr(Dds, "_default_qos")
+        assert hasattr(MockDds, "_default_qos")
+
+
+# =============================================================================
+# 3. CLI completeness: every public API method has a CLI command
+# =============================================================================
+
+
+class TestCliCompleteness:
+    def test_all_expected_commands_registered(self):
+        with serve(MockDds()) as client:
+            cli = client.cli()
+            expected = {
+                "connect",
+                "disconnect",
+                "topics",
+                "info",
+                "create-topic",
+                "publish",
+                "read",
+                "monitor",
+            }
+            assert expected.issubset(set(cli.commands)), f"Missing CLI commands: {expected - set(cli.commands)}"
+
+
+# =============================================================================
+# 4. Model invariants
+# =============================================================================
+
+
+class TestModelInvariants:
+    def test_read_result_rejects_count_mismatch(self):
+        with pytest.raises(ValueError, match="sample_count"):
+            DdsReadResult(
+                topic_name="t",
+                samples=[DdsSample(topic_name="t", data={"k": "v"})],
+                sample_count=0,
+            )
+
+    def test_read_result_accepts_consistent_count(self):
+        r = DdsReadResult(
+            topic_name="t",
+            samples=[DdsSample(topic_name="t", data={"k": "v"})],
+            sample_count=1,
+        )
+        assert r.sample_count == 1
+
+    def test_publish_result_has_no_success_field(self):
+        assert "success" not in DdsPublishResult.model_fields, (
+            "DdsPublishResult should not have a 'success' field; failures are signalled via exceptions"
+        )
+
+
+# =============================================================================
+# 5. _make_idl_type name collision guard
+# =============================================================================
+
+
+class TestIdlTypeCollisions:
+    def test_similar_names_produce_distinct_types(self):
+        t1 = _make_idl_type("sensor/temp", ["v"])
+        t2 = _make_idl_type("sensor-temp", ["v"])
+        assert t1.__name__ != t2.__name__
+
+    def test_numeric_prefix_produces_valid_identifier(self):
+        t = _make_idl_type("123-topic", ["v"])
+        assert t.__name__.isidentifier()
+
+    def test_slash_dot_dash_all_handled(self):
+        for name in ["a/b", "a.b", "a-b", "a/b.c-d"]:
+            t = _make_idl_type(name, ["f"])
+            assert t.__name__.isidentifier(), f"Invalid identifier for topic '{name}'"
+
+
+# =============================================================================
+# 6. Project convention: no asyncio in production code
+# =============================================================================
+
+
+class TestProjectConventions:
+    def test_no_asyncio_imports_in_production_code(self):
+        pkg = pathlib.Path(__file__).parent
+        for py_file in pkg.glob("*.py"):
+            if py_file.name.endswith("_test.py"):
+                continue
+            content = py_file.read_text()
+            assert "import asyncio" not in content, (
+                f"{py_file.name} imports asyncio; use anyio instead (project convention)"
+            )

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/regression_test.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/regression_test.py
@@ -17,8 +17,13 @@ from .common import (
     DdsSample,
     DdsTopicQos,
 )
-from .driver import Dds, MockDds, _make_idl_type
+from .driver import Dds, MockDds, _make_idl_type, _validate_field_names
 from jumpstarter.common.utils import serve
+from jumpstarter.driver.decorators import (
+    MARKER_DRIVERCALL,
+    MARKER_MAGIC,
+    MARKER_STREAMING_DRIVERCALL,
+)
 
 # =============================================================================
 # 1. Backend parity: identical operations must produce identical results
@@ -100,22 +105,23 @@ class TestBackendParity:
 class TestDriverInterfaceParity:
     def test_export_methods_match(self):
         def _exported(cls):
-            return {
-                name
-                for name in dir(cls)
-                if not name.startswith("_")
-                and callable(getattr(cls, name, None))
-                and hasattr(getattr(cls, name), "__wrapped__")
-            }
+            """Detect exported methods using the official jumpstarter markers."""
+            result: set[str] = set()
+            for name in vars(cls):
+                if name.startswith("_"):
+                    continue
+                method = getattr(cls, name, None)
+                if not callable(method):
+                    continue
+                if (
+                    getattr(method, MARKER_DRIVERCALL, None) == MARKER_MAGIC
+                    or getattr(method, MARKER_STREAMING_DRIVERCALL, None) == MARKER_MAGIC
+                ):
+                    result.add(name)
+            return result
 
-        dds_methods = {
-            name for name in vars(Dds) if not name.startswith("_") and hasattr(getattr(Dds, name, None), "__wrapped__")
-        }
-        mock_methods = {
-            name
-            for name in vars(MockDds)
-            if not name.startswith("_") and hasattr(getattr(MockDds, name, None), "__wrapped__")
-        }
+        dds_methods = _exported(Dds)
+        mock_methods = _exported(MockDds)
         assert dds_methods == mock_methods, (
             f"Export mismatch: Dds has {dds_methods - mock_methods}, MockDds has {mock_methods - dds_methods}"
         )
@@ -208,7 +214,58 @@ class TestIdlTypeCollisions:
 
 
 # =============================================================================
-# 6. Project convention: no asyncio in production code
+# 6. Field name validation
+# =============================================================================
+
+
+class TestFieldNameValidation:
+    def test_invalid_identifier_rejected(self):
+        with pytest.raises(ValueError, match="not a valid Python identifier"):
+            _validate_field_names(["123bad"])
+
+    def test_keyword_rejected(self):
+        with pytest.raises(ValueError, match="Python keyword"):
+            _validate_field_names(["class"])
+
+    def test_duplicate_rejected(self):
+        with pytest.raises(ValueError, match="Duplicate"):
+            _validate_field_names(["x", "x"])
+
+    def test_valid_fields_pass(self):
+        _validate_field_names(["speed", "heading", "timestamp"])
+
+    def test_backend_rejects_invalid_fields(self, any_backend):
+        any_backend.connect()
+        with pytest.raises(ValueError):
+            any_backend.create_topic("t", ["123bad"], DdsTopicQos())
+
+    def test_backend_rejects_duplicate_fields(self, any_backend):
+        any_backend.connect()
+        with pytest.raises(ValueError, match="Duplicate"):
+            any_backend.create_topic("t", ["x", "x"], DdsTopicQos())
+
+
+# =============================================================================
+# 7. history_depth validation
+# =============================================================================
+
+
+class TestHistoryDepthValidation:
+    def test_zero_depth_rejected(self):
+        with pytest.raises(ValueError):
+            DdsTopicQos(history_depth=0)
+
+    def test_negative_depth_rejected(self):
+        with pytest.raises(ValueError):
+            DdsTopicQos(history_depth=-1)
+
+    def test_depth_one_accepted(self):
+        qos = DdsTopicQos(history_depth=1)
+        assert qos.history_depth == 1
+
+
+# =============================================================================
+# 8. Project conventions
 # =============================================================================
 
 

--- a/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/regression_test.py
+++ b/python/packages/jumpstarter-driver-dds/jumpstarter_driver_dds/regression_test.py
@@ -17,13 +17,20 @@ from .common import (
     DdsSample,
     DdsTopicQos,
 )
-from .driver import Dds, MockDds, _make_idl_type, _validate_field_names
+from .driver import Dds, MockDds, _validate_field_names
 from jumpstarter.common.utils import serve
 from jumpstarter.driver.decorators import (
     MARKER_DRIVERCALL,
     MARKER_MAGIC,
     MARKER_STREAMING_DRIVERCALL,
 )
+
+try:
+    import cyclonedds as _cyclonedds  # noqa: F401
+
+    _has_cyclonedds = True
+except ImportError:
+    _has_cyclonedds = False
 
 # =============================================================================
 # 1. Backend parity: identical operations must produce identical results
@@ -193,21 +200,28 @@ class TestModelInvariants:
 
 
 # =============================================================================
-# 5. _make_idl_type name collision guard
+# 5. _make_idl_type name collision guard (requires cyclonedds native lib)
 # =============================================================================
 
 
+@pytest.mark.skipif(not _has_cyclonedds, reason="CycloneDDS native library not available")
 class TestIdlTypeCollisions:
     def test_similar_names_produce_distinct_types(self):
+        from .driver import _make_idl_type
+
         t1 = _make_idl_type("sensor/temp", ["v"])
         t2 = _make_idl_type("sensor-temp", ["v"])
         assert t1.__name__ != t2.__name__
 
     def test_numeric_prefix_produces_valid_identifier(self):
+        from .driver import _make_idl_type
+
         t = _make_idl_type("123-topic", ["v"])
         assert t.__name__.isidentifier()
 
     def test_slash_dot_dash_all_handled(self):
+        from .driver import _make_idl_type
+
         for name in ["a/b", "a.b", "a-b", "a/b.c-d"]:
             t = _make_idl_type(name, ["f"])
             assert t.__name__.isidentifier(), f"Invalid identifier for topic '{name}'"

--- a/python/packages/jumpstarter-driver-dds/pyproject.toml
+++ b/python/packages/jumpstarter-driver-dds/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "jumpstarter-driver-dds"
+dynamic = ["version", "urls"]
+description = "DDS (Data Distribution Service) pub/sub driver for Jumpstarter using Eclipse CycloneDDS"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "Vinicius Zein", email = "vtzein@gmail.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "jumpstarter",
+    "cyclonedds>=0.10.0",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+Dds = "jumpstarter_driver_dds.driver:Dds"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../'}
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=html --cov-report=xml"
+log_cli = true
+log_cli_level = "INFO"
+testpaths = ["jumpstarter_driver_dds"]
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+]

--- a/python/packages/jumpstarter-driver-dds/pyproject.toml
+++ b/python/packages/jumpstarter-driver-dds/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "jumpstarter",
-    "cyclonedds>=0.10.0",
+    "cyclonedds>=0.10.0,<1.0",
 ]
 
 [project.entry-points."jumpstarter.drivers"]
@@ -22,7 +22,7 @@ raw-options = { 'root' = '../../../'}
 
 [tool.hatch.metadata.hooks.vcs.urls]
 Homepage = "https://jumpstarter.dev"
-source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+source_archive = "https://github.com/jumpstarter-dev/jumpstarter/archive/{commit_hash}.zip"
 
 [tool.pytest.ini_options]
 addopts = "--cov --cov-report=html --cov-report=xml"

--- a/python/packages/jumpstarter-driver-dds/pyproject.toml
+++ b/python/packages/jumpstarter-driver-dds/pyproject.toml
@@ -10,8 +10,11 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "jumpstarter",
-    "cyclonedds>=0.10.0,<1.0",
+    "click>=8.1.7.2",
 ]
+
+[project.optional-dependencies]
+cyclonedds = ["cyclonedds>=0.10.0,<1.0"]
 
 [project.entry-points."jumpstarter.drivers"]
 Dds = "jumpstarter_driver_dds.driver:Dds"

--- a/python/packages/jumpstarter-driver-dds/pyproject.toml
+++ b/python/packages/jumpstarter-driver-dds/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "jumpstarter",
+    "anyio>=4.0",
     "click>=8.1.7.2",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,6 +12,7 @@ jumpstarter-driver-androidemulator = { workspace = true }
 jumpstarter-driver-ble = { workspace = true }
 jumpstarter-driver-can = { workspace = true }
 jumpstarter-driver-composite = { workspace = true }
+jumpstarter-driver-dds = { workspace = true }
 jumpstarter-driver-doip = { workspace = true }
 jumpstarter-driver-corellium = { workspace = true }
 jumpstarter-driver-dutlink = { workspace = true }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,6 +12,7 @@ jumpstarter-driver-androidemulator = { workspace = true }
 jumpstarter-driver-ble = { workspace = true }
 jumpstarter-driver-can = { workspace = true }
 jumpstarter-driver-composite = { workspace = true }
+jumpstarter-driver-dds = { workspace = true }
 jumpstarter-driver-doip = { workspace = true }
 jumpstarter-driver-corellium = { workspace = true }
 jumpstarter-driver-dut-network = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -34,6 +34,7 @@ members = [
     "jumpstarter-driver-iscsi",
     "jumpstarter-driver-mitmproxy",
     "jumpstarter-driver-network",
+    "jumpstarter-driver-noyito-relay",
     "jumpstarter-driver-opendal",
     "jumpstarter-driver-pi-pico",
     "jumpstarter-driver-power",
@@ -1690,6 +1691,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hid"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/f8/0357a8aa8874a243e96d08a8568efaf7478293e1a3441ddca18039b690c1/hid-1.0.9.tar.gz", hash = "sha256:f4471f11f0e176d1b0cb1b243e55498cc90347a3aede735655304395694ac182", size = 4973, upload-time = "2026-02-05T15:35:20.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/c7/f0e1ad95179f44a6fc7a9140be025812cc7a62cf7390442b685a57ee1417/hid-1.0.9-py3-none-any.whl", hash = "sha256:6b9289e00bbc1e1589bec0c7f376a63fe03a4a4a1875575d0ad60e3e11a349f4", size = 4959, upload-time = "2026-02-05T15:35:19.269Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2394,8 +2404,13 @@ dev = [
 name = "jumpstarter-driver-dds"
 source = { editable = "packages/jumpstarter-driver-dds" }
 dependencies = [
-    { name = "cyclonedds" },
+    { name = "click" },
     { name = "jumpstarter" },
+]
+
+[package.optional-dependencies]
+cyclonedds = [
+    { name = "cyclonedds" },
 ]
 
 [package.dev-dependencies]
@@ -2406,9 +2421,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cyclonedds", specifier = ">=0.10.0,<1.0" },
+    { name = "click", specifier = ">=8.1.7.2" },
+    { name = "cyclonedds", marker = "extra == 'cyclonedds'", specifier = ">=0.10.0,<1.0" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
 ]
+provides-extras = ["cyclonedds"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2786,6 +2803,38 @@ dev = [
     { name = "types-paramiko", specifier = ">=3.5.0.20240928" },
     { name = "types-pexpect", specifier = ">=4.9.0.20241208" },
     { name = "websocket-client", specifier = ">=1.8.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-noyito-relay"
+source = { editable = "packages/jumpstarter-driver-noyito-relay" }
+dependencies = [
+    { name = "hid" },
+    { name = "jumpstarter" },
+    { name = "jumpstarter-driver-power" },
+    { name = "pyserial" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hid", specifier = ">=1.0.4" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
+    { name = "pyserial", specifier = ">=3.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
 
 [[package]]
@@ -5236,6 +5285,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1181,26 +1181,12 @@ wheels = [
 
 [[package]]
 name = "cyclonedds"
-version = "11.0.1"
+version = "0.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-click" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/52/f501db026eff5aed63598c51b58a09ee45cf90306791cbf7c05f1a30ebf9/cyclonedds-11.0.1.tar.gz", hash = "sha256:487cdd9e3dbe3bc6f66c3318c45979f4015bb9d32d5dfcb9bb4a67376176a526", size = 191643, upload-time = "2026-03-20T12:47:30.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/1f/f4d2e1ac127f841d24f4b494b15e8133ce2b7b54126519a1ab605b546468/cyclonedds-11.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f883d834d8cf62416e83d878716d7d80d26b8356cc0678aaf1363f65102a99d", size = 925585, upload-time = "2026-03-20T12:47:40.315Z" },
-    { url = "https://files.pythonhosted.org/packages/69/58/90bed244b4a20619dafeda12091e3020537296a1536776d58d3ba8bd0b9b/cyclonedds-11.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a0a3a3db3245749a1e4934bfca21ebaa3fd79d62dcbd5961a42011ce74affcd1", size = 855722, upload-time = "2026-03-20T12:47:42.041Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/0295bc331924c147a5f13deb30dff21b1d006059eac6828cf74377c716bd/cyclonedds-11.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce635041d42e954a5fec187dabf99d4b36c9daa54cc97d6d2238985e3ef6101", size = 7703243, upload-time = "2026-03-20T12:47:44.138Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0b/e697fa5d3a7c8f43696e76a3f82cefef2fa13452f840bb506128cf5be167/cyclonedds-11.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:6079bf42cfe1f201356b18e093a3c6a57983b96a7c70c359723457df399b7ed5", size = 1348125, upload-time = "2026-03-20T12:47:46.294Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/bf/b779a39d4415e630ca5af5eb2143ff13b396c8d35cfd5ef8b36aa51f9579/cyclonedds-11.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:60d86cfbb06dcbac1167ad1dd6eea7fa62e1adcc09132c7e27d1641fe8e2790d", size = 924927, upload-time = "2026-03-20T12:47:47.825Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/19/d6d7a3ff4738ecbd74d6c634776ac665f7a41d68230f01a11d4756490608/cyclonedds-11.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e74b7daf503a63b37765e5d8e2808db641d1fc53637004a04636cf564864ba16", size = 855612, upload-time = "2026-03-20T12:47:49.496Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/27/26dafd6cde19a440497c26d3fd39560db2e5ec2261fa628801000a0cd8b6/cyclonedds-11.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e96507088c57165f7c189c3a85be866f74c7449fb0cbc6316ad306e5f599be1", size = 7704807, upload-time = "2026-03-20T12:47:51.365Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9e/966e6f25650b65726361eac161e71cca998c653ae39a0118bc5f94356d0e/cyclonedds-11.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:db977a7306f85e5b83cacfa0137a26955c9fe1d6ad03621407e00005adc01ede", size = 1348220, upload-time = "2026-03-20T12:47:53.119Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/40/56f1dd62cf7272e78c3c3f5885e7eec1a99f923dea9522208c0849a816bc/cyclonedds-11.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:20b5f2b4c1e42bf3d217f45ba3664dc21a16b74803b8b457e91ea187b11fc7bd", size = 924924, upload-time = "2026-03-20T12:47:54.9Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/28/f6f660f62f459532723c25a69e577694e01a44686aa20a5a2053ec67a402/cyclonedds-11.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c3b899649685fd2606ea65620ea173b28d61e775adf8785861460ff91efbbbb8", size = 855636, upload-time = "2026-03-20T12:47:56.196Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a5/a6c8052dafd16c8c0e02eb6ef0cb2bb086d726d654c56e94ec4cdb1640ab/cyclonedds-11.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fef1f6ce115a579e322f3156842e8b660883e4e8b0aa2f5e2a3df9d7959d1736", size = 7704791, upload-time = "2026-03-20T12:47:58.037Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/fb/df46b2aeff2e07716c0659bae2f5ac67bdd33e7ad4cce1cc35c505a0aa90/cyclonedds-11.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:850d6624dad8c9f3e0e65423225bd8e4c14c85c2d53bd64e16c2569ea3b491db", size = 1348209, upload-time = "2026-03-20T12:48:00.061Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/91/cf/28eb9c823dfc245c540f5286d71b44aeee2a51021fc85b25bb9562be78cc/cyclonedds-0.10.5.tar.gz", hash = "sha256:63fc4d6fdb2fd35181c40f4e90757149f2def5f570ef19fb71edc4f568755f8a", size = 156919, upload-time = "2024-06-05T18:50:42.999Z" }
 
 [[package]]
 name = "dbus-fast"
@@ -2420,7 +2406,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cyclonedds", specifier = ">=0.10.0" },
+    { name = "cyclonedds", specifier = ">=0.10.0,<1.0" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
 ]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -22,6 +22,7 @@ members = [
     "jumpstarter-driver-can",
     "jumpstarter-driver-composite",
     "jumpstarter-driver-corellium",
+    "jumpstarter-driver-dds",
     "jumpstarter-driver-doip",
     "jumpstarter-driver-dutlink",
     "jumpstarter-driver-energenie",
@@ -1176,6 +1177,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/76/f95b83359012ee0e670da3e41c164a0c256aeedd81886f878911581d852f/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:0339a692de47084969500ee455e42c58e449461e0ec845a34a6a9b9bf7df7fb8", size = 4146422, upload-time = "2025-06-10T00:03:41.827Z" },
     { url = "https://files.pythonhosted.org/packages/09/ad/5429fcc4def93e577a5407988f89cf15305e64920203d4ac14601a9dc876/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:0cf13c77d710131d33e63626bd55ae7c0efb701ebdc2b3a7952b9b23a0412862", size = 4388475, upload-time = "2025-06-10T00:03:43.493Z" },
     { url = "https://files.pythonhosted.org/packages/99/49/0ab9774f64555a1b50102757811508f5ace451cf5dc0a2d074a4b9deca6a/cryptography-45.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bbc505d1dc469ac12a0a064214879eac6294038d6b24ae9f71faae1448a9608d", size = 3337594, upload-time = "2025-06-10T00:03:45.523Z" },
+]
+
+[[package]]
+name = "cyclonedds"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich-click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/52/f501db026eff5aed63598c51b58a09ee45cf90306791cbf7c05f1a30ebf9/cyclonedds-11.0.1.tar.gz", hash = "sha256:487cdd9e3dbe3bc6f66c3318c45979f4015bb9d32d5dfcb9bb4a67376176a526", size = 191643, upload-time = "2026-03-20T12:47:30.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/1f/f4d2e1ac127f841d24f4b494b15e8133ce2b7b54126519a1ab605b546468/cyclonedds-11.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f883d834d8cf62416e83d878716d7d80d26b8356cc0678aaf1363f65102a99d", size = 925585, upload-time = "2026-03-20T12:47:40.315Z" },
+    { url = "https://files.pythonhosted.org/packages/69/58/90bed244b4a20619dafeda12091e3020537296a1536776d58d3ba8bd0b9b/cyclonedds-11.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a0a3a3db3245749a1e4934bfca21ebaa3fd79d62dcbd5961a42011ce74affcd1", size = 855722, upload-time = "2026-03-20T12:47:42.041Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/0295bc331924c147a5f13deb30dff21b1d006059eac6828cf74377c716bd/cyclonedds-11.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce635041d42e954a5fec187dabf99d4b36c9daa54cc97d6d2238985e3ef6101", size = 7703243, upload-time = "2026-03-20T12:47:44.138Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0b/e697fa5d3a7c8f43696e76a3f82cefef2fa13452f840bb506128cf5be167/cyclonedds-11.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:6079bf42cfe1f201356b18e093a3c6a57983b96a7c70c359723457df399b7ed5", size = 1348125, upload-time = "2026-03-20T12:47:46.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/bf/b779a39d4415e630ca5af5eb2143ff13b396c8d35cfd5ef8b36aa51f9579/cyclonedds-11.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:60d86cfbb06dcbac1167ad1dd6eea7fa62e1adcc09132c7e27d1641fe8e2790d", size = 924927, upload-time = "2026-03-20T12:47:47.825Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/19/d6d7a3ff4738ecbd74d6c634776ac665f7a41d68230f01a11d4756490608/cyclonedds-11.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e74b7daf503a63b37765e5d8e2808db641d1fc53637004a04636cf564864ba16", size = 855612, upload-time = "2026-03-20T12:47:49.496Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/26dafd6cde19a440497c26d3fd39560db2e5ec2261fa628801000a0cd8b6/cyclonedds-11.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e96507088c57165f7c189c3a85be866f74c7449fb0cbc6316ad306e5f599be1", size = 7704807, upload-time = "2026-03-20T12:47:51.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/966e6f25650b65726361eac161e71cca998c653ae39a0118bc5f94356d0e/cyclonedds-11.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:db977a7306f85e5b83cacfa0137a26955c9fe1d6ad03621407e00005adc01ede", size = 1348220, upload-time = "2026-03-20T12:47:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/40/56f1dd62cf7272e78c3c3f5885e7eec1a99f923dea9522208c0849a816bc/cyclonedds-11.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:20b5f2b4c1e42bf3d217f45ba3664dc21a16b74803b8b457e91ea187b11fc7bd", size = 924924, upload-time = "2026-03-20T12:47:54.9Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/28/f6f660f62f459532723c25a69e577694e01a44686aa20a5a2053ec67a402/cyclonedds-11.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c3b899649685fd2606ea65620ea173b28d61e775adf8785861460ff91efbbbb8", size = 855636, upload-time = "2026-03-20T12:47:56.196Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a5/a6c8052dafd16c8c0e02eb6ef0cb2bb086d726d654c56e94ec4cdb1640ab/cyclonedds-11.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fef1f6ce115a579e322f3156842e8b660883e4e8b0aa2f5e2a3df9d7959d1736", size = 7704791, upload-time = "2026-03-20T12:47:58.037Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/fb/df46b2aeff2e07716c0659bae2f5ac67bdd33e7ad4cce1cc35c505a0aa90/cyclonedds-11.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:850d6624dad8c9f3e0e65423225bd8e4c14c85c2d53bd64e16c2569ea3b491db", size = 1348209, upload-time = "2026-03-20T12:48:00.061Z" },
 ]
 
 [[package]]
@@ -2378,6 +2402,32 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "requests-mock" },
     { name = "trio", specifier = ">=0.28.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-dds"
+source = { editable = "packages/jumpstarter-driver-dds" }
+dependencies = [
+    { name = "cyclonedds" },
+    { name = "jumpstarter" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cyclonedds", specifier = ">=0.10.0" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -22,6 +22,7 @@ members = [
     "jumpstarter-driver-can",
     "jumpstarter-driver-composite",
     "jumpstarter-driver-corellium",
+    "jumpstarter-driver-dds",
     "jumpstarter-driver-doip",
     "jumpstarter-driver-dut-network",
     "jumpstarter-driver-dutlink",
@@ -1182,6 +1183,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/76/f95b83359012ee0e670da3e41c164a0c256aeedd81886f878911581d852f/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:0339a692de47084969500ee455e42c58e449461e0ec845a34a6a9b9bf7df7fb8", size = 4146422, upload-time = "2025-06-10T00:03:41.827Z" },
     { url = "https://files.pythonhosted.org/packages/09/ad/5429fcc4def93e577a5407988f89cf15305e64920203d4ac14601a9dc876/cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:0cf13c77d710131d33e63626bd55ae7c0efb701ebdc2b3a7952b9b23a0412862", size = 4388475, upload-time = "2025-06-10T00:03:43.493Z" },
     { url = "https://files.pythonhosted.org/packages/99/49/0ab9774f64555a1b50102757811508f5ace451cf5dc0a2d074a4b9deca6a/cryptography-45.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bbc505d1dc469ac12a0a064214879eac6294038d6b24ae9f71faae1448a9608d", size = 3337594, upload-time = "2025-06-10T00:03:45.523Z" },
+]
+
+[[package]]
+name = "cyclonedds"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich-click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/52/f501db026eff5aed63598c51b58a09ee45cf90306791cbf7c05f1a30ebf9/cyclonedds-11.0.1.tar.gz", hash = "sha256:487cdd9e3dbe3bc6f66c3318c45979f4015bb9d32d5dfcb9bb4a67376176a526", size = 191643, upload-time = "2026-03-20T12:47:30.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/1f/f4d2e1ac127f841d24f4b494b15e8133ce2b7b54126519a1ab605b546468/cyclonedds-11.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f883d834d8cf62416e83d878716d7d80d26b8356cc0678aaf1363f65102a99d", size = 925585, upload-time = "2026-03-20T12:47:40.315Z" },
+    { url = "https://files.pythonhosted.org/packages/69/58/90bed244b4a20619dafeda12091e3020537296a1536776d58d3ba8bd0b9b/cyclonedds-11.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a0a3a3db3245749a1e4934bfca21ebaa3fd79d62dcbd5961a42011ce74affcd1", size = 855722, upload-time = "2026-03-20T12:47:42.041Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/0295bc331924c147a5f13deb30dff21b1d006059eac6828cf74377c716bd/cyclonedds-11.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce635041d42e954a5fec187dabf99d4b36c9daa54cc97d6d2238985e3ef6101", size = 7703243, upload-time = "2026-03-20T12:47:44.138Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0b/e697fa5d3a7c8f43696e76a3f82cefef2fa13452f840bb506128cf5be167/cyclonedds-11.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:6079bf42cfe1f201356b18e093a3c6a57983b96a7c70c359723457df399b7ed5", size = 1348125, upload-time = "2026-03-20T12:47:46.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/bf/b779a39d4415e630ca5af5eb2143ff13b396c8d35cfd5ef8b36aa51f9579/cyclonedds-11.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:60d86cfbb06dcbac1167ad1dd6eea7fa62e1adcc09132c7e27d1641fe8e2790d", size = 924927, upload-time = "2026-03-20T12:47:47.825Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/19/d6d7a3ff4738ecbd74d6c634776ac665f7a41d68230f01a11d4756490608/cyclonedds-11.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e74b7daf503a63b37765e5d8e2808db641d1fc53637004a04636cf564864ba16", size = 855612, upload-time = "2026-03-20T12:47:49.496Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/26dafd6cde19a440497c26d3fd39560db2e5ec2261fa628801000a0cd8b6/cyclonedds-11.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e96507088c57165f7c189c3a85be866f74c7449fb0cbc6316ad306e5f599be1", size = 7704807, upload-time = "2026-03-20T12:47:51.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/966e6f25650b65726361eac161e71cca998c653ae39a0118bc5f94356d0e/cyclonedds-11.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:db977a7306f85e5b83cacfa0137a26955c9fe1d6ad03621407e00005adc01ede", size = 1348220, upload-time = "2026-03-20T12:47:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/40/56f1dd62cf7272e78c3c3f5885e7eec1a99f923dea9522208c0849a816bc/cyclonedds-11.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:20b5f2b4c1e42bf3d217f45ba3664dc21a16b74803b8b457e91ea187b11fc7bd", size = 924924, upload-time = "2026-03-20T12:47:54.9Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/28/f6f660f62f459532723c25a69e577694e01a44686aa20a5a2053ec67a402/cyclonedds-11.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c3b899649685fd2606ea65620ea173b28d61e775adf8785861460ff91efbbbb8", size = 855636, upload-time = "2026-03-20T12:47:56.196Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a5/a6c8052dafd16c8c0e02eb6ef0cb2bb086d726d654c56e94ec4cdb1640ab/cyclonedds-11.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fef1f6ce115a579e322f3156842e8b660883e4e8b0aa2f5e2a3df9d7959d1736", size = 7704791, upload-time = "2026-03-20T12:47:58.037Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/fb/df46b2aeff2e07716c0659bae2f5ac67bdd33e7ad4cce1cc35c505a0aa90/cyclonedds-11.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:850d6624dad8c9f3e0e65423225bd8e4c14c85c2d53bd64e16c2569ea3b491db", size = 1348209, upload-time = "2026-03-20T12:48:00.061Z" },
 ]
 
 [[package]]
@@ -2422,6 +2446,32 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "requests-mock" },
     { name = "trio", specifier = ">=0.28.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-dds"
+source = { editable = "packages/jumpstarter-driver-dds" }
+dependencies = [
+    { name = "cyclonedds" },
+    { name = "jumpstarter" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cyclonedds", specifier = ">=0.10.0" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2438,8 +2438,13 @@ dev = [
 name = "jumpstarter-driver-dds"
 source = { editable = "packages/jumpstarter-driver-dds" }
 dependencies = [
-    { name = "cyclonedds" },
+    { name = "click" },
     { name = "jumpstarter" },
+]
+
+[package.optional-dependencies]
+cyclonedds = [
+    { name = "cyclonedds" },
 ]
 
 [package.dev-dependencies]
@@ -2450,9 +2455,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cyclonedds", specifier = ">=0.10.0,<1.0" },
+    { name = "click", specifier = ">=8.1.7.2" },
+    { name = "cyclonedds", marker = "extra == 'cyclonedds'", specifier = ">=0.10.0,<1.0" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
 ]
+provides-extras = ["cyclonedds"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1187,26 +1187,12 @@ wheels = [
 
 [[package]]
 name = "cyclonedds"
-version = "11.0.1"
+version = "0.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-click" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/52/f501db026eff5aed63598c51b58a09ee45cf90306791cbf7c05f1a30ebf9/cyclonedds-11.0.1.tar.gz", hash = "sha256:487cdd9e3dbe3bc6f66c3318c45979f4015bb9d32d5dfcb9bb4a67376176a526", size = 191643, upload-time = "2026-03-20T12:47:30.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/1f/f4d2e1ac127f841d24f4b494b15e8133ce2b7b54126519a1ab605b546468/cyclonedds-11.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f883d834d8cf62416e83d878716d7d80d26b8356cc0678aaf1363f65102a99d", size = 925585, upload-time = "2026-03-20T12:47:40.315Z" },
-    { url = "https://files.pythonhosted.org/packages/69/58/90bed244b4a20619dafeda12091e3020537296a1536776d58d3ba8bd0b9b/cyclonedds-11.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a0a3a3db3245749a1e4934bfca21ebaa3fd79d62dcbd5961a42011ce74affcd1", size = 855722, upload-time = "2026-03-20T12:47:42.041Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/0295bc331924c147a5f13deb30dff21b1d006059eac6828cf74377c716bd/cyclonedds-11.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce635041d42e954a5fec187dabf99d4b36c9daa54cc97d6d2238985e3ef6101", size = 7703243, upload-time = "2026-03-20T12:47:44.138Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0b/e697fa5d3a7c8f43696e76a3f82cefef2fa13452f840bb506128cf5be167/cyclonedds-11.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:6079bf42cfe1f201356b18e093a3c6a57983b96a7c70c359723457df399b7ed5", size = 1348125, upload-time = "2026-03-20T12:47:46.294Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/bf/b779a39d4415e630ca5af5eb2143ff13b396c8d35cfd5ef8b36aa51f9579/cyclonedds-11.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:60d86cfbb06dcbac1167ad1dd6eea7fa62e1adcc09132c7e27d1641fe8e2790d", size = 924927, upload-time = "2026-03-20T12:47:47.825Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/19/d6d7a3ff4738ecbd74d6c634776ac665f7a41d68230f01a11d4756490608/cyclonedds-11.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e74b7daf503a63b37765e5d8e2808db641d1fc53637004a04636cf564864ba16", size = 855612, upload-time = "2026-03-20T12:47:49.496Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/27/26dafd6cde19a440497c26d3fd39560db2e5ec2261fa628801000a0cd8b6/cyclonedds-11.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e96507088c57165f7c189c3a85be866f74c7449fb0cbc6316ad306e5f599be1", size = 7704807, upload-time = "2026-03-20T12:47:51.365Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9e/966e6f25650b65726361eac161e71cca998c653ae39a0118bc5f94356d0e/cyclonedds-11.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:db977a7306f85e5b83cacfa0137a26955c9fe1d6ad03621407e00005adc01ede", size = 1348220, upload-time = "2026-03-20T12:47:53.119Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/40/56f1dd62cf7272e78c3c3f5885e7eec1a99f923dea9522208c0849a816bc/cyclonedds-11.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:20b5f2b4c1e42bf3d217f45ba3664dc21a16b74803b8b457e91ea187b11fc7bd", size = 924924, upload-time = "2026-03-20T12:47:54.9Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/28/f6f660f62f459532723c25a69e577694e01a44686aa20a5a2053ec67a402/cyclonedds-11.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c3b899649685fd2606ea65620ea173b28d61e775adf8785861460ff91efbbbb8", size = 855636, upload-time = "2026-03-20T12:47:56.196Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a5/a6c8052dafd16c8c0e02eb6ef0cb2bb086d726d654c56e94ec4cdb1640ab/cyclonedds-11.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fef1f6ce115a579e322f3156842e8b660883e4e8b0aa2f5e2a3df9d7959d1736", size = 7704791, upload-time = "2026-03-20T12:47:58.037Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/fb/df46b2aeff2e07716c0659bae2f5ac67bdd33e7ad4cce1cc35c505a0aa90/cyclonedds-11.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:850d6624dad8c9f3e0e65423225bd8e4c14c85c2d53bd64e16c2569ea3b491db", size = 1348209, upload-time = "2026-03-20T12:48:00.061Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/91/cf/28eb9c823dfc245c540f5286d71b44aeee2a51021fc85b25bb9562be78cc/cyclonedds-0.10.5.tar.gz", hash = "sha256:63fc4d6fdb2fd35181c40f4e90757149f2def5f570ef19fb71edc4f568755f8a", size = 156919, upload-time = "2024-06-05T18:50:42.999Z" }
 
 [[package]]
 name = "dbus-fast"
@@ -2464,7 +2450,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cyclonedds", specifier = ">=0.10.0" },
+    { name = "cyclonedds", specifier = ">=0.10.0,<1.0" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
 ]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -50,6 +50,7 @@ members = [
     "jumpstarter-driver-someip",
     "jumpstarter-driver-ssh",
     "jumpstarter-driver-ssh-mitm",
+    "jumpstarter-driver-ssh-mount",
     "jumpstarter-driver-stlink-msd",
     "jumpstarter-driver-tasmota",
     "jumpstarter-driver-tftp",
@@ -86,6 +87,7 @@ docs = [
     { name = "esbonio", specifier = ">=0.16.4" },
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "myst-parser", specifier = ">=5.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "sphinx", specifier = "<8.1.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.4.16" },
@@ -2032,6 +2034,7 @@ dependencies = [
     { name = "jumpstarter-driver-snmp" },
     { name = "jumpstarter-driver-someip" },
     { name = "jumpstarter-driver-ssh" },
+    { name = "jumpstarter-driver-ssh-mount" },
     { name = "jumpstarter-driver-tftp" },
     { name = "jumpstarter-driver-tmt" },
     { name = "jumpstarter-driver-uboot" },
@@ -2079,6 +2082,7 @@ requires-dist = [
     { name = "jumpstarter-driver-snmp", editable = "packages/jumpstarter-driver-snmp" },
     { name = "jumpstarter-driver-someip", editable = "packages/jumpstarter-driver-someip" },
     { name = "jumpstarter-driver-ssh", editable = "packages/jumpstarter-driver-ssh" },
+    { name = "jumpstarter-driver-ssh-mount", editable = "packages/jumpstarter-driver-ssh-mount" },
     { name = "jumpstarter-driver-tftp", editable = "packages/jumpstarter-driver-tftp" },
     { name = "jumpstarter-driver-tmt", editable = "packages/jumpstarter-driver-tmt" },
     { name = "jumpstarter-driver-uboot", editable = "packages/jumpstarter-driver-uboot" },
@@ -2438,6 +2442,7 @@ dev = [
 name = "jumpstarter-driver-dds"
 source = { editable = "packages/jumpstarter-driver-dds" }
 dependencies = [
+    { name = "anyio" },
     { name = "click" },
     { name = "jumpstarter" },
 ]
@@ -2455,6 +2460,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0" },
     { name = "click", specifier = ">=8.1.7.2" },
     { name = "cyclonedds", marker = "extra == 'cyclonedds'", specifier = ">=0.10.0,<1.0" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
@@ -3347,6 +3353,38 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "trio", specifier = ">=0.28.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-ssh-mount"
+source = { editable = "packages/jumpstarter-driver-ssh-mount" }
+dependencies = [
+    { name = "click" },
+    { name = "jumpstarter" },
+    { name = "jumpstarter-driver-composite" },
+    { name = "jumpstarter-driver-network" },
+    { name = "jumpstarter-driver-ssh" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-composite", editable = "packages/jumpstarter-driver-composite" },
+    { name = "jumpstarter-driver-network", editable = "packages/jumpstarter-driver-network" },
+    { name = "jumpstarter-driver-ssh", editable = "packages/jumpstarter-driver-ssh" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `jumpstarter-driver-dds` package providing DDS (Data Distribution Service) pub/sub messaging via Eclipse CycloneDDS
- Supports domain participation, topic management with configurable QoS (reliability, durability, history depth), publish/subscribe, streaming monitor, and a Click CLI interface
- Includes both a real `Dds` driver (using CycloneDDS) and a `MockDds` driver with `MockDdsBackend` for testing without native DDS dependencies
- Comprehensive test suite with **58 tests** covering unit, e2e (gRPC boundary), error paths, and stateful lifecycle tests (connection, topic schema enforcement, pub/sub, reconnect, call log/audit trail)
- Full documentation with README, exporter YAML example, and docs index update

## Implementation Details

**Architecture** follows the same patterns as existing automotive drivers (XCP, gPTP, DoIP):
- `common.py`: Pydantic models for RPC-safe types (`DdsTopicQos`, `DdsParticipantInfo`, `DdsSample`, etc.)
- `driver.py`: `DdsBackend` (real CycloneDDS) + `MockDdsBackend` (in-memory) + `Dds` driver + `MockDds` driver
- `client.py`: `DdsClient` with `model_validate` deserialization and Click CLI
- `conftest.py`: `StatefulDdsBackend` with lifecycle rule enforcement + pytest fixtures
- `driver_test.py`: 6 test levels (models, backend unit, e2e mock, error paths, stateful, full workflows)

**QoS support**: Reliability (RELIABLE/BEST_EFFORT), Durability (VOLATILE/TRANSIENT_LOCAL/TRANSIENT/PERSISTENT), History depth

**Dependency**: `cyclonedds>=0.10.0` (EPL-2.0 licensed, used as a runtime dependency)

## Test plan

- [x] All 58 tests pass (`make pkg-test-jumpstarter-driver-dds`)
- [x] Lint passes (`make lint-fix` -- All checks passed)
- [ ] CI pipeline passes on GitHub Actions
- [ ] Verify CycloneDDS wheel installs on Linux CI runners


Made with [Cursor](https://cursor.com)