### PR TITLE
fix: reset retry counter after receiving data in exporter reconnect

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -253,13 +253,18 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         """
         retries_left = retries
         while True:
+            received_data = False
             try:
                 async with self._controller_stub() as controller:
                     logger.debug("%s stream connected to controller", stream_name)
                     async for item in stream_factory(controller):
+                        received_data = True
                         logger.debug("%s stream received item", stream_name)
                         await send_tx.send(item)
             except Exception as e:
+                if received_data:
+                    logger.debug("%s stream retry counter reset after receiving data", stream_name)
+                    retries_left = retries
                 if retries_left > 0:
                     retries_left -= 1
                     # Check for common transient errors that warrant faster retry

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_retry_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_retry_test.py
@@ -1,0 +1,160 @@
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+from anyio import create_memory_object_stream
+
+from jumpstarter.exporter.exporter import Exporter
+
+
+def _make_exporter() -> Exporter:
+    mock_channel = AsyncMock()
+    mock_channel.close = AsyncMock()
+
+    async def channel_factory():
+        return mock_channel
+
+    return Exporter(
+        channel_factory=channel_factory,
+        device_factory=AsyncMock(),
+        labels={},
+    )
+
+
+class TestRetryCounterResetsAfterReceivingData:
+    @pytest.mark.anyio
+    async def test_survives_more_than_retries_cycles_when_data_received(self):
+        retries = 3
+        data_cycles = retries * 3
+        call_count = 0
+
+        async def stream_factory(controller):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= data_cycles:
+                yield f"item-{call_count}"
+            raise Exception("connection lost")
+
+        exporter = _make_exporter()
+        send_tx, send_rx = create_memory_object_stream[str](100)
+
+        with pytest.raises(Exception, match="connection lost"):
+            await exporter._retry_stream(
+                stream_name="test",
+                stream_factory=stream_factory,
+                send_tx=send_tx,
+                retries=retries,
+                backoff=0.0,
+            )
+
+        expected_total = data_cycles + retries
+        assert call_count == expected_total
+
+    @pytest.mark.anyio
+    async def test_does_not_reset_when_error_before_any_data(self):
+        retries = 3
+        call_count = 0
+
+        async def stream_factory(controller):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("UNAVAILABLE")
+            yield  # make it an async generator
+
+        exporter = _make_exporter()
+        send_tx, send_rx = create_memory_object_stream[str](100)
+
+        with pytest.raises(Exception, match="UNAVAILABLE"):
+            await exporter._retry_stream(
+                stream_name="test",
+                stream_factory=stream_factory,
+                send_tx=send_tx,
+                retries=retries,
+                backoff=0.0,
+            )
+
+        assert call_count == retries + 1
+
+
+class TestExporterFailsFastOnPersistentErrors:
+    @pytest.mark.anyio
+    async def test_raises_after_exhausting_retries_without_data(self):
+        retries = 5
+        call_count = 0
+
+        async def stream_factory(controller):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("permanently unreachable")
+            yield
+
+        exporter = _make_exporter()
+        send_tx, send_rx = create_memory_object_stream[str](100)
+
+        with pytest.raises(Exception, match="permanently unreachable"):
+            await exporter._retry_stream(
+                stream_name="test",
+                stream_factory=stream_factory,
+                send_tx=send_tx,
+                retries=retries,
+                backoff=0.0,
+            )
+
+        assert call_count == retries + 1
+
+    @pytest.mark.anyio
+    async def test_retries_left_decrements_on_consecutive_failures(self):
+        retries = 4
+        call_count = 0
+
+        async def stream_factory(controller):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                raise Exception("third failure")
+            raise Exception("failure")
+            yield
+
+        exporter = _make_exporter()
+        send_tx, send_rx = create_memory_object_stream[str](100)
+
+        with pytest.raises(Exception, match="failure"):
+            await exporter._retry_stream(
+                stream_name="test",
+                stream_factory=stream_factory,
+                send_tx=send_tx,
+                retries=retries,
+                backoff=0.0,
+            )
+
+        assert call_count == retries + 1
+
+
+class TestRetryCounterResetLogging:
+    @pytest.mark.anyio
+    async def test_logs_debug_message_when_retry_counter_resets(self, caplog):
+        retries = 2
+        call_count = 0
+
+        async def stream_factory(controller):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                yield f"item-{call_count}"
+            raise Exception("connection lost")
+
+        exporter = _make_exporter()
+        send_tx, send_rx = create_memory_object_stream[str](100)
+
+        with caplog.at_level(logging.DEBUG, logger="jumpstarter.exporter.exporter"):
+            with pytest.raises(Exception, match="connection lost"):
+                await exporter._retry_stream(
+                    stream_name="test",
+                    stream_factory=stream_factory,
+                    send_tx=send_tx,
+                    retries=retries,
+                    backoff=0.0,
+                )
+
+        reset_messages = [r for r in caplog.records if "retry counter reset" in r.message.lower()]
+        assert len(reset_messages) == 1


### PR DESCRIPTION
## Summary
- The exporter's retry counter never actually reset after reconnecting, so after enough transient disconnects it would give up permanently even though the connection was healthy in between
- Root cause: the reset logic sat in a `try/else` block that only runs when the async-for loop exits cleanly -- gRPC streams always end via exception, so it never fired
- Fix: track whether any data was received during a connection attempt, and if so, reset the counter when the exception hits

## Test plan
- 5 new tests covering the core scenarios: counter resets after data, does not reset without data, fail-fast still works when the server is genuinely gone, and the debug log fires on reset
- All 304 existing jumpstarter tests pass with no regressions

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)