### PR TITLE
fix: validate name argument in admin create/delete commands

### DIFF
--- a/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create.py
+++ b/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/create.py
@@ -14,6 +14,7 @@ from jumpstarter_cli_common.opt import (
     opt_namespace,
     opt_nointeractive,
     opt_output_all,
+    validate_name,
 )
 from jumpstarter_cli_common.print import model_print
 from jumpstarter_kubernetes import (
@@ -90,6 +91,7 @@ async def create_client(
     output: OutputType,
 ):
     """Create a client object in the Kubernetes cluster"""
+    validate_name(name)
     try:
         confirm_insecure_tls(insecure_tls_config, nointeractive)
         async with ClientsV1Alpha1Api(namespace, kubeconfig, context) as api:
@@ -165,6 +167,7 @@ async def create_exporter(
     output: OutputType,
 ):
     """Create an exporter object in the Kubernetes cluster"""
+    validate_name(name)
     try:
         confirm_insecure_tls(insecure_tls_config, nointeractive)
         async with ExportersV1Alpha1Api(namespace, kubeconfig, context) as api:

--- a/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete.py
+++ b/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete.py
@@ -11,6 +11,7 @@ from jumpstarter_cli_common.opt import (
     opt_namespace,
     opt_nointeractive,
     opt_output_name_only,
+    validate_name,
 )
 from jumpstarter_kubernetes import ClientsV1Alpha1Api, ExportersV1Alpha1Api, delete_cluster_by_name
 from jumpstarter_kubernetes.exceptions import JumpstarterKubernetesError
@@ -56,6 +57,7 @@ async def delete_client(
     nointeractive: bool,
 ):
     """Delete a client object in the Kubernetes cluster"""
+    validate_name(name)
     try:
         async with ClientsV1Alpha1Api(namespace, kubeconfig, context) as api:
             await api.delete_client(name)
@@ -107,6 +109,7 @@ async def delete_exporter(
     nointeractive: bool,
 ):
     """Delete an exporter object in the Kubernetes cluster"""
+    validate_name(name)
     try:
         async with ExportersV1Alpha1Api(namespace, kubeconfig, context) as api:
             await api.delete_exporter(name)

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -113,6 +113,11 @@ def confirm_insecure_tls(insecure_tls_config: bool, nointeractive: bool):
             raise click.Abort()
 
 
+def validate_name(name: Optional[str]) -> None:
+    if not name or not name.strip():
+        raise click.UsageError("Missing required argument 'NAME'.")
+
+
 class OutputMode(str):
     JSON = "json"
     YAML = "yaml"

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
@@ -1,8 +1,11 @@
-"""Tests for SourcePrefixFormatter in opt.py."""
+"""Tests for opt.py utilities."""
 
 import logging
 
-from jumpstarter_cli_common.opt import SourcePrefixFormatter
+import click
+import pytest
+
+from jumpstarter_cli_common.opt import SourcePrefixFormatter, validate_name
 
 
 class TestSourcePrefixFormatter:
@@ -76,3 +79,20 @@ class TestSourcePrefixFormatter:
         )
         formatted3 = formatter.format(record3)
         assert "[different.source]" in formatted3
+
+
+class TestValidateName:
+    def test_raises_on_none(self) -> None:
+        with pytest.raises(click.UsageError, match="Missing required argument 'NAME'."):
+            validate_name(None)
+
+    def test_raises_on_empty_string(self) -> None:
+        with pytest.raises(click.UsageError, match="Missing required argument 'NAME'."):
+            validate_name("")
+
+    def test_raises_on_whitespace_only(self) -> None:
+        with pytest.raises(click.UsageError, match="Missing required argument 'NAME'."):
+            validate_name("   ")
+
+    def test_accepts_valid_name(self) -> None:
+        validate_name("my-resource")


### PR DESCRIPTION
## Summary
- `jmp admin delete client/exporter` and `jmp admin create client/exporter` crashed with a raw Python traceback when invoked without a name argument
- Adds a shared `validate_name()` helper in `jumpstarter_cli_common.opt` that raises a clear `UsageError("Missing required argument 'NAME'.")` when name is None, empty, or whitespace-only
- Both `create.py` and `delete.py` import and use the shared helper

## Test plan
- 4 new tests for `validate_name` in cli-common (None, empty, whitespace, valid name)
- All 69 cli-admin and 18 cli-common tests pass with no regressions

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)