### PR TITLE
fix: wire keepalive configuration fields into gRPC server options

### DIFF
--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -281,7 +281,7 @@ func main() {
 			ResourceKey:  "jumpstarter-kind",
 			NameKey:      "jumpstarter-name",
 		}),
-		Router:       router,
+		Router:        router,
 		ServerOptions: option,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create service", "service", "Controller")

--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -282,7 +282,7 @@ func main() {
 			NameKey:      "jumpstarter-name",
 		}),
 		Router:       router,
-		ServerOption: option,
+		ServerOptions: option,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create service", "service", "Controller")
 		os.Exit(1)

--- a/controller/cmd/router/main.go
+++ b/controller/cmd/router/main.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	svc := service.RouterService{
-		ServerOption: serverOption,
+		ServerOptions: serverOption,
 	}
 
 	err = svc.Start(ctx)

--- a/controller/internal/config/grpc.go
+++ b/controller/internal/config/grpc.go
@@ -7,25 +7,62 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// LoadGrpcConfiguration loads the gRPC server configuration from the parsed Config struct.
-// It creates a gRPC server option with keepalive enforcement policy configured.
-func LoadGrpcConfiguration(config Grpc) (grpc.ServerOption, error) {
+func LoadGrpcConfiguration(config Grpc) ([]grpc.ServerOption, error) {
 	ka := config.Keepalive
 
-	// Parse MinTime with default of 1s
 	minTime, err := ParseDuration(ka.MinTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse keepalive minTime: %w", err)
 	}
 	if minTime == 0 {
-		minTime = 1e9 // 1 second default
+		minTime = 1e9
 	}
 
-	// Create the keepalive enforcement policy
 	policy := keepalive.EnforcementPolicy{
 		MinTime:             minTime,
 		PermitWithoutStream: ka.PermitWithoutStream,
 	}
 
-	return grpc.KeepaliveEnforcementPolicy(policy), nil
+	options := []grpc.ServerOption{
+		grpc.KeepaliveEnforcementPolicy(policy),
+	}
+
+	timeout, err := ParseDuration(ka.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse keepalive timeout: %w", err)
+	}
+
+	intervalTime, err := ParseDuration(ka.IntervalTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse keepalive intervalTime: %w", err)
+	}
+
+	maxConnectionIdle, err := ParseDuration(ka.MaxConnectionIdle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse keepalive maxConnectionIdle: %w", err)
+	}
+
+	maxConnectionAge, err := ParseDuration(ka.MaxConnectionAge)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse keepalive maxConnectionAge: %w", err)
+	}
+
+	maxConnectionAgeGrace, err := ParseDuration(ka.MaxConnectionAgeGrace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse keepalive maxConnectionAgeGrace: %w", err)
+	}
+
+	params := keepalive.ServerParameters{
+		Timeout:               timeout,
+		Time:                  intervalTime,
+		MaxConnectionIdle:     maxConnectionIdle,
+		MaxConnectionAge:      maxConnectionAge,
+		MaxConnectionAgeGrace: maxConnectionAgeGrace,
+	}
+
+	if params != (keepalive.ServerParameters{}) {
+		options = append(options, grpc.KeepaliveParams(params))
+	}
+
+	return options, nil
 }

--- a/controller/internal/config/grpc_test.go
+++ b/controller/internal/config/grpc_test.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadGrpcConfigurationMinimalConfigReturnsSlice(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{
+			MinTime:             "5s",
+			PermitWithoutStream: true,
+		},
+	}
+
+	options, err := LoadGrpcConfiguration(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(options) < 1 {
+		t.Fatalf("expected at least 1 server option, got %d", len(options))
+	}
+}
+
+func TestLoadGrpcConfigurationWithTimeoutAndIntervalTime(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{
+			MinTime:             "1s",
+			PermitWithoutStream: true,
+			Timeout:             "30s",
+			IntervalTime:        "5s",
+		},
+	}
+
+	options, err := LoadGrpcConfiguration(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(options) != 2 {
+		t.Fatalf("expected 2 server options (enforcement policy + server parameters), got %d", len(options))
+	}
+}
+
+func TestLoadGrpcConfigurationInvalidTimeoutReturnsError(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{
+			MinTime: "1s",
+			Timeout: "abc",
+		},
+	}
+
+	_, err := LoadGrpcConfiguration(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid timeout, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("expected error mentioning 'timeout', got: %v", err)
+	}
+}
+
+func TestLoadGrpcConfigurationInvalidIntervalTimeReturnsError(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{
+			MinTime:      "1s",
+			IntervalTime: "xyz",
+		},
+	}
+
+	_, err := LoadGrpcConfiguration(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid intervalTime, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "intervalTime") {
+		t.Fatalf("expected error mentioning 'intervalTime', got: %v", err)
+	}
+}
+
+func TestLoadGrpcConfigurationWithConnectionLifetimeFields(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{
+			MinTime:               "1s",
+			PermitWithoutStream:   true,
+			MaxConnectionIdle:     "5m",
+			MaxConnectionAge:      "30m",
+			MaxConnectionAgeGrace: "10s",
+		},
+	}
+
+	options, err := LoadGrpcConfiguration(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(options) != 2 {
+		t.Fatalf("expected 2 server options (enforcement policy + server parameters), got %d", len(options))
+	}
+}
+
+func TestLoadGrpcConfigurationInvalidConnectionLifetimeFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       Grpc
+		wantInErr string
+	}{
+		{
+			name: "invalid maxConnectionIdle",
+			cfg: Grpc{
+				Keepalive: Keepalive{
+					MinTime:           "1s",
+					MaxConnectionIdle: "bad",
+				},
+			},
+			wantInErr: "maxConnectionIdle",
+		},
+		{
+			name: "invalid maxConnectionAge",
+			cfg: Grpc{
+				Keepalive: Keepalive{
+					MinTime:          "1s",
+					MaxConnectionAge: "bad",
+				},
+			},
+			wantInErr: "maxConnectionAge",
+		},
+		{
+			name: "invalid maxConnectionAgeGrace",
+			cfg: Grpc{
+				Keepalive: Keepalive{
+					MinTime:               "1s",
+					MaxConnectionAgeGrace: "bad",
+				},
+			},
+			wantInErr: "maxConnectionAgeGrace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadGrpcConfiguration(tt.cfg)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tt.wantInErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Fatalf("expected error mentioning %q, got: %v", tt.wantInErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadGrpcConfigurationEmptyKeepaliveFieldsReturnZeroValueParams(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{
+			MinTime:               "1s",
+			PermitWithoutStream:   true,
+			Timeout:               "",
+			IntervalTime:          "",
+			MaxConnectionIdle:     "",
+			MaxConnectionAge:      "",
+			MaxConnectionAgeGrace: "",
+		},
+	}
+
+	options, err := LoadGrpcConfiguration(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(options) != 1 {
+		t.Fatalf("expected 1 server option (enforcement policy only, no server parameters for zero values), got %d", len(options))
+	}
+}
+
+func TestLoadGrpcConfigurationEmptyKeepaliveStructUsesDefaults(t *testing.T) {
+	cfg := Grpc{
+		Keepalive: Keepalive{},
+	}
+
+	options, err := LoadGrpcConfiguration(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(options) != 1 {
+		t.Fatalf("expected 1 server option (enforcement policy with default 1s MinTime), got %d", len(options))
+	}
+}

--- a/controller/internal/service/controller_service.go
+++ b/controller/internal/service/controller_service.go
@@ -77,7 +77,7 @@ type ControllerService struct {
 	Authn        authentication.ContextAuthenticator
 	Authz        authorizer.Authorizer
 	Attr         authorization.ContextAttributesGetter
-	ServerOption grpc.ServerOption
+	ServerOptions []grpc.ServerOption
 	Router       config.Router
 	listenQueues sync.Map
 }
@@ -938,8 +938,7 @@ func (s *ControllerService) Start(ctx context.Context) error {
 		}
 	}
 
-	server := grpc.NewServer(
-		s.ServerOption,
+	opts := append(s.ServerOptions,
 		grpc.ChainUnaryInterceptor(func(
 			gctx context.Context,
 			req any,
@@ -957,6 +956,7 @@ func (s *ControllerService) Start(ctx context.Context) error {
 			return handler(srv, &wrappedStream{ServerStream: ss})
 		}, recovery.StreamServerInterceptor()),
 	)
+	server := grpc.NewServer(opts...)
 
 	pb.RegisterControllerServiceServer(server, s)
 	cpb.RegisterClientServiceServer(

--- a/controller/internal/service/controller_service.go
+++ b/controller/internal/service/controller_service.go
@@ -72,14 +72,14 @@ import (
 // ControllerService exposes a gRPC service
 type ControllerService struct {
 	pb.UnimplementedControllerServiceServer
-	Client       client.WithWatch
-	Scheme       *runtime.Scheme
-	Authn        authentication.ContextAuthenticator
-	Authz        authorizer.Authorizer
-	Attr         authorization.ContextAttributesGetter
+	Client        client.WithWatch
+	Scheme        *runtime.Scheme
+	Authn         authentication.ContextAuthenticator
+	Authz         authorizer.Authorizer
+	Attr          authorization.ContextAttributesGetter
 	ServerOptions []grpc.ServerOption
-	Router       config.Router
-	listenQueues sync.Map
+	Router        config.Router
+	listenQueues  sync.Map
 }
 
 type wrappedStream struct {

--- a/controller/internal/service/router_service.go
+++ b/controller/internal/service/router_service.go
@@ -40,7 +40,7 @@ import (
 // RouterService exposes a gRPC service
 type RouterService struct {
 	pb.UnimplementedRouterServiceServer
-	ServerOption grpc.ServerOption
+	ServerOptions []grpc.ServerOption
 	pending      sync.Map
 }
 
@@ -150,12 +150,13 @@ func (s *RouterService) Start(ctx context.Context) error {
 		}
 	}
 
-	server := grpc.NewServer(
+	opts := []grpc.ServerOption{
 		grpc.Creds(credentials.NewServerTLSFromCert(cert)),
 		grpc.ChainUnaryInterceptor(recovery.UnaryServerInterceptor()),
 		grpc.ChainStreamInterceptor(recovery.StreamServerInterceptor()),
-		s.ServerOption,
-	)
+	}
+	opts = append(opts, s.ServerOptions...)
+	server := grpc.NewServer(opts...)
 
 	pb.RegisterRouterServiceServer(server, s)
 

--- a/controller/internal/service/router_service.go
+++ b/controller/internal/service/router_service.go
@@ -41,7 +41,7 @@ import (
 type RouterService struct {
 	pb.UnimplementedRouterServiceServer
 	ServerOptions []grpc.ServerOption
-	pending      sync.Map
+	pending       sync.Map
 }
 
 type streamContext struct {


### PR DESCRIPTION
## Summary
- The five keepalive config fields (Timeout, IntervalTime, MaxConnectionIdle, MaxConnectionAge, MaxConnectionAgeGrace) were parsed from configuration but never wired into `keepalive.ServerParameters`, making them silently ignored
- `LoadGrpcConfiguration` now returns `[]grpc.ServerOption` and constructs a `ServerParameters` option when any keepalive field is non-zero
- Propagates the slice type change through all callers (controller service, router service, cmd entrypoints)

## Test plan
- 8 new tests covering: timeout/interval wiring, connection lifetime fields, invalid value errors for all 5 fields, empty fields produce zero-value params, backward compatibility
- All existing config tests pass with no regressions
- Full `go build ./...` clean

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)