### PR TITLE
fix: use crypto/rand instead of math/rand for ECDSA key generation

### DIFF
--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -209,8 +209,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	oidcSigner, err := oidc.NewSignerFromSeed(
-		[]byte(os.Getenv("CONTROLLER_KEY")),
+	oidcSigner, err := oidc.NewSignerWithRandomKey(
 		"https://localhost:8085",
 		"jumpstarter",
 	)

--- a/controller/go.mod
+++ b/controller/go.mod
@@ -3,7 +3,6 @@ module github.com/jumpstarter-dev/jumpstarter-controller
 go 1.24.0
 
 require (
-	filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-jose/go-jose/v4 v4.0.4
 	github.com/go-logr/logr v1.4.2
@@ -30,7 +29,6 @@ require (
 
 require (
 	cel.dev/expr v0.19.1 // indirect
-	filippo.io/bigmod v0.0.3 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/controller/go.sum
+++ b/controller/go.sum
@@ -1,9 +1,5 @@
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
 cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
-filippo.io/bigmod v0.0.3 h1:qmdCFHmEMS+PRwzrW6eUrgA4Q3T8D6bRcjsypDMtWHM=
-filippo.io/bigmod v0.0.3/go.mod h1:WxGvOYE0OUaBC2N112Dflb3CjOnMBuNRA2UWZc2UbPE=
-filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87 h1:HlcHAMbI9Xvw3aWnhPngghMl5AKE2GOvjmvSGOKzCcI=
-filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87/go.mod h1:nAs0+DyACEQGudhkTwlPC9atyqDYC7ZotgZR7D8OwXM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -16,8 +12,6 @@ github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
-github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
@@ -279,7 +273,6 @@ golang.org/x/tools v0.28.0/go.mod h1:dcIOrVd3mfQKTgrDVQHqCPMWy6lnhfhtX3hLXYVLfRw
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=

--- a/controller/internal/controller/client_controller_test.go
+++ b/controller/internal/controller/client_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Identity Controller", func() {
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+			signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 			Expect(err).NotTo(HaveOccurred())
 
 			controllerReconciler := &ClientReconciler{
@@ -98,7 +98,7 @@ var _ = Describe("Identity Controller", func() {
 
 		It("should reconcile a missing token secret", func() {
 			By("recreating the secret")
-			signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+			signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 			Expect(err).NotTo(HaveOccurred())
 
 			controllerReconciler := &ClientReconciler{
@@ -129,7 +129,7 @@ var _ = Describe("Identity Controller", func() {
 
 		It("should reconcile an invalid token secret", func() {
 			By("recreating the secret")
-			signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+			signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 			Expect(err).NotTo(HaveOccurred())
 
 			controllerReconciler := &ClientReconciler{

--- a/controller/internal/controller/exporter_controller_test.go
+++ b/controller/internal/controller/exporter_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Exporter Controller", func() {
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+			signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 			Expect(err).NotTo(HaveOccurred())
 
 			controllerReconciler := &ExporterReconciler{
@@ -97,7 +97,7 @@ var _ = Describe("Exporter Controller", func() {
 		})
 		It("should reconcile a missing token secret", func() {
 			By("recreating the secret")
-			signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+			signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 			Expect(err).NotTo(HaveOccurred())
 
 			controllerReconciler := &ExporterReconciler{

--- a/controller/internal/controller/lease_controller_test.go
+++ b/controller/internal/controller/lease_controller_test.go
@@ -567,7 +567,7 @@ func reconcileLease(ctx context.Context, lease *jumpstarterdevv1alpha1.Lease) re
 		Scheme: k8sClient.Scheme(),
 	}
 
-	signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+	signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 	Expect(err).NotTo(HaveOccurred())
 
 	exporterReconciler := &ExporterReconciler{

--- a/controller/internal/controller/suite_test.go
+++ b/controller/internal/controller/suite_test.go
@@ -125,7 +125,7 @@ func createExporters(ctx context.Context, exporters ...*jumpstarterdevv1alpha1.E
 			Namespace: "default", // TODO(user):Modify as needed
 		}
 
-		signer, err := oidc.NewSignerFromSeed([]byte{}, "https://example.com", "dummy")
+		signer, err := oidc.NewSignerWithRandomKey("https://example.com", "dummy")
 		Expect(err).NotTo(HaveOccurred())
 
 		controllerReconciler := &ExporterReconciler{

--- a/controller/internal/oidc/op.go
+++ b/controller/internal/oidc/op.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/sha256"
-	"encoding/binary"
-	"math/rand"
+	"crypto/rand"
 	"time"
 
-	"filippo.io/keygen"
 	"github.com/gin-gonic/gin"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
@@ -31,11 +28,8 @@ func NewSigner(privateKey *ecdsa.PrivateKey, issuer, audience string) *Signer {
 	}
 }
 
-func NewSignerFromSeed(seed []byte, issuer, audience string) (*Signer, error) {
-	hash := sha256.Sum256(seed)
-	source := rand.NewSource(int64(binary.BigEndian.Uint64(hash[:8])))
-	reader := rand.New(source)
-	key, err := keygen.ECDSALegacy(elliptic.P256(), reader)
+func NewSignerWithRandomKey(issuer, audience string) (*Signer, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/internal/oidc/op_test.go
+++ b/controller/internal/oidc/op_test.go
@@ -1,0 +1,42 @@
+package oidc
+
+import (
+	"testing"
+)
+
+func TestNewSignerWithRandomKeySignsAndValidatesTokens(t *testing.T) {
+	signer, err := NewSignerWithRandomKey("https://example.com", "test-audience")
+	if err != nil {
+		t.Fatalf("NewSignerWithRandomKey returned error: %v", err)
+	}
+
+	token, err := signer.Token("test-subject")
+	if err != nil {
+		t.Fatalf("Token returned error: %v", err)
+	}
+
+	if token == "" {
+		t.Fatal("Token returned empty string")
+	}
+
+	err = signer.Validate(token)
+	if err != nil {
+		t.Fatalf("Validate returned error for valid token: %v", err)
+	}
+}
+
+func TestNewSignerWithRandomKeyProducesDifferentKeys(t *testing.T) {
+	signer1, err := NewSignerWithRandomKey("https://example.com", "test-audience")
+	if err != nil {
+		t.Fatalf("first NewSignerWithRandomKey returned error: %v", err)
+	}
+
+	signer2, err := NewSignerWithRandomKey("https://example.com", "test-audience")
+	if err != nil {
+		t.Fatalf("second NewSignerWithRandomKey returned error: %v", err)
+	}
+
+	if signer1.privatekey.Equal(signer2.privatekey) {
+		t.Fatal("two calls to NewSignerWithRandomKey produced identical private keys")
+	}
+}


### PR DESCRIPTION
The OIDC signing key was derived from math/rand seeded with a SHA-256 hash of an environment variable, making it cryptographically insecure and deterministic. Replaced with crypto/rand.Reader via ecdsa.GenerateKey for proper cryptographic randomness.

Also removes the unused filippo.io/keygen dependency.

Closes #350