### PR TITLE
ci: add quality gates for coverage and type checking

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -100,6 +100,23 @@ jobs:
           src: './python'
           version-file: python/pyproject.toml
 
+  type-check-python:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+        with:
+          version: latest
+
+      - name: Run ty
+        working-directory: python
+        run: make ty
+
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -97,6 +97,8 @@ jobs:
 
       - name: Run pytest
         working-directory: python
+        env:
+          PYTEST_ADDOPTS: "--cov --cov-report=xml"
         run: |
             make test
 
@@ -106,21 +108,9 @@ jobs:
         run: |
             coverage_files=$(find packages -name coverage.xml 2>/dev/null | sort)
             if [ -z "$coverage_files" ]; then
-              echo "::warning::No coverage.xml files found, skipping diff-cover"
-              exit 0
+              echo "::error::No coverage.xml files found"
+              exit 1
             fi
-
-            changed_packages=$(
-              git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
-              | sed -nE 's#^python/packages/([^/]+)/.*#\1#p' \
-              | sort -u
-            )
-            for pkg in $changed_packages; do
-              if [ ! -f "packages/${pkg}/coverage.xml" ]; then
-                echo "::warning::No coverage.xml for changed package: ${pkg}"
-              fi
-            done
-
             uv run diff-cover $coverage_files --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
   # https://github.com/orgs/community/discussions/26822

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -42,6 +42,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
@@ -98,6 +100,11 @@ jobs:
         run: |
             make test
 
+      - name: Check coverage on changed lines
+        if: github.event_name == 'pull_request'
+        working-directory: python
+        run: |
+            uv run diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
   # https://github.com/orgs/community/discussions/26822
   pytest:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -104,7 +104,7 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: python
         run: |
-            uv run diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
+            uv run diff-cover packages/*/coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
   # https://github.com/orgs/community/discussions/26822
   pytest:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -104,7 +104,24 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: python
         run: |
-            uv run diff-cover packages/*/coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
+            coverage_files=$(find packages -name coverage.xml 2>/dev/null | sort)
+            if [ -z "$coverage_files" ]; then
+              echo "::warning::No coverage.xml files found, skipping diff-cover"
+              exit 0
+            fi
+
+            changed_packages=$(
+              git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
+              | sed -nE 's#^python/packages/([^/]+)/.*#\1#p' \
+              | sort -u
+            )
+            for pkg in $changed_packages; do
+              if [ ! -f "packages/${pkg}/coverage.xml" ]; then
+                echo "::warning::No coverage.xml for changed package: ${pkg}"
+              fi
+            done
+
+            uv run diff-cover $coverage_files --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
   # https://github.com/orgs/community/discussions/26822
   pytest:

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
@@ -75,7 +75,7 @@ def _extract_grpc_code_and_details(exc: BaseException) -> tuple[str | None, str]
     code = None
     details = ""
     try:
-        code_member = exc.code
+        code_member = exc.code  # ty: ignore[unresolved-attribute]
         if callable(code_member):
             grpc_code = code_member()
             code = grpc_code.name if hasattr(grpc_code, "name") else str(grpc_code)
@@ -83,7 +83,7 @@ def _extract_grpc_code_and_details(exc: BaseException) -> tuple[str | None, str]
         code = None
 
     try:
-        details_member = exc.details
+        details_member = exc.details  # ty: ignore[unresolved-attribute]
         if callable(details_member):
             details = str(details_member() or "")
     except Exception:

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -188,8 +188,8 @@ def _validate_tokens(tokens: list[str], allowed_values: set[str], ctx, param) ->
 
 
 def parse_comma_separated(
-    ctx: click.Context,
-    param: click.Parameter,
+    ctx: click.Context | None,
+    param: click.Parameter | None,
     value: str | tuple[str, ...] | None,
     allowed_values: set[str] | None = None,
     normalize_case: bool = True

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/print.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/print.py
@@ -37,7 +37,7 @@ def model_print(  # noqa: C901
             names = []
 
             try:
-                model.rich_add_names(names)
+                model.rich_add_names(names)  # ty: ignore[unresolved-attribute]
             except AttributeError as err:
                 raise NotImplementedError from err
 
@@ -47,7 +47,7 @@ def model_print(  # noqa: C901
             paths = []
 
             try:
-                model.rich_add_paths(paths)
+                model.rich_add_paths(paths)  # ty: ignore[unresolved-attribute]
             except AttributeError as err:
                 raise NotImplementedError from err
 
@@ -57,12 +57,12 @@ def model_print(  # noqa: C901
             table = Table(
                 box=None,
                 header_style=None,
-                pad_edge=None,
+                pad_edge=False,
             )
 
             try:
-                model.rich_add_columns(table, **kwargs)
-                model.rich_add_rows(table, **kwargs)
+                model.rich_add_columns(table, **kwargs)  # ty: ignore[unresolved-attribute]
+                model.rich_add_rows(table, **kwargs)  # ty: ignore[unresolved-attribute]
             except AttributeError as err:
                 raise NotImplementedError from err
 

--- a/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver.py
+++ b/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver.py
@@ -14,7 +14,7 @@ def list_drivers():
         table = Table(
             box=None,
             header_style=None,
-            pad_edge=None,
+            pad_edge=False,
         )
 
         table.add_column("NAME", no_wrap=True)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -52,7 +52,7 @@ class DurationParamType(click.ParamType):
                 td = None
                 try:
                     seconds = parse_duration(value)
-                    if seconds is not None:
+                    if seconds is not None and isinstance(seconds, (int, float)):
                         td = timedelta(seconds=seconds)
                 except (ValueError, TypeError):
                     pass

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/completion.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/completion.py
@@ -9,5 +9,7 @@ def completion(shell: str):
     from jumpstarter_cli.jmp import jmp
 
     comp_cls = get_completion_class(shell)
+    if comp_cls is None:
+        raise click.ClickException(f"Unsupported shell: {shell}")
     comp = comp_cls(jmp, {}, "jmp", "_JMP_COMPLETE")
     click.echo(comp.source())

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/j.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/j.py
@@ -6,6 +6,7 @@ from typing import cast
 import click
 from anyio import create_task_group, get_cancelled_exc_class, run, to_thread
 from anyio.from_thread import BlockingPortal
+from click.exceptions import Exit as ClickExit
 from jumpstarter_cli_common.exceptions import (
     ClickExceptionRed,
     async_handle_exceptions,
@@ -28,7 +29,7 @@ async def j_async():
                     async with env_async(portal, stack) as client:
                         result = await to_thread.run_sync(lambda: client.cli()(standalone_mode=False))
                         if isinstance(result, int) and result != 0:
-                            raise BaseExceptionGroup("CLI exit", [click.exceptions.Exit(result)])
+                            raise BaseExceptionGroup("CLI exit", [ClickExit(result)])
         except BaseExceptionGroup as eg:
             # Handle exceptions wrapped in ExceptionGroup (e.g., from task groups)
             if exc := find_exception_in_group(eg, EnvironmentVariableNotSetError):
@@ -42,9 +43,10 @@ async def j_async():
                 await cli()
             finally:
                 tg.cancel_scope.cancel()
-    except* click.exceptions.Exit as excgroup:
+    except* ClickExit as excgroup:
         for exc in leaf_exceptions(excgroup):
-            sys.exit(exc.exit_code)
+            if isinstance(exc, ClickExit):
+                sys.exit(exc.exit_code)
     except* click.ClickException as excgroup:
         for exc in leaf_exceptions(excgroup):
             cast(click.ClickException, exc).show()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/j.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/j.py
@@ -45,8 +45,7 @@ async def j_async():
                 tg.cancel_scope.cancel()
     except* ClickExit as excgroup:
         for exc in leaf_exceptions(excgroup):
-            if isinstance(exc, ClickExit):
-                sys.exit(exc.exit_code)
+            sys.exit(cast(ClickExit, exc).exit_code)
     except* click.ClickException as excgroup:
         for exc in leaf_exceptions(excgroup):
             cast(click.ClickException, exc).show()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/login.py
@@ -228,9 +228,11 @@ async def login(  # noqa: C901
     match config:
         # we are updating an existing config
         case ClientConfigV1Alpha1():
+            assert config.token is not None
             issuer = decode_jwt_issuer(config.token)
             config_kind = "client"
         case ExporterConfigV1Alpha1():
+            assert config.token is not None
             issuer = decode_jwt_issuer(config.token)
             config_kind = "exporter"
         # we are creating a new config
@@ -313,7 +315,7 @@ async def login(  # noqa: C901
     if stored_refresh_token and token is None and username is None and password is None:
         try:
             tokens = await oidc.refresh_token_grant(stored_refresh_token)
-            config.token = tokens["access_token"]
+            config.token = tokens["access_token"]  # ty: ignore[invalid-assignment]
             refresh_token = tokens.get("refresh_token")
             if refresh_token is not None and isinstance(config, ClientConfigV1Alpha1):
                 config.refresh_token = refresh_token
@@ -333,7 +335,7 @@ async def login(  # noqa: C901
     else:
         tokens = await oidc.authorization_code_grant(callback_port=callback_port)
 
-    config.token = tokens["access_token"]
+    config.token = tokens["access_token"]  # ty: ignore[invalid-assignment]
     refresh_token = tokens.get("refresh_token")
 
     # only client configs support refresh_token
@@ -352,6 +354,8 @@ async def login(  # noqa: C901
 async def relogin_client(config: ClientConfigV1Alpha1):
     """Relogin into a jumpstarter instance"""
     client_id = "jumpstarter-cli"  # TODO: store this metadata in the config
+    if config.token is None:
+        raise ReauthenticationFailed("No token set in client config")
     try:
         issuer = decode_jwt_issuer(config.token)
     except Exception as e:

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/run.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/run.py
@@ -81,7 +81,7 @@ def _handle_child(config, parsed_bind=None, tls_insecure=False, tls_cert=None, t
 
             with open_signal_receiver(signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT) as signals:
                 async for sig in signals:
-                    if signal_handled:
+                    if signal_handled:  # ty: ignore[unresolved-reference]
                         continue  # Ignore duplicate signals
                     received_signal = sig
                     logger.info("CHILD: Received %d (%s)", received_signal, signal.Signals(received_signal).name)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -6,8 +6,11 @@ from datetime import timedelta
 from types import SimpleNamespace
 
 import anyio
+import anyio.from_thread
+import anyio.to_thread
 import click
 import grpc
+import grpc.aio
 from anyio import create_task_group, get_cancelled_exc_class
 from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.exceptions import find_exception_in_group, handle_exceptions_with_reauthentication

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -703,7 +703,7 @@ class TestMonitorTokenExpiry:
 
         def check_cancelled():
             nonlocal call_count
-            call_count += 1
+            call_count += 1  # ty: ignore[unresolved-reference]
             return call_count > 1
 
         config = _make_config()

--- a/python/packages/jumpstarter-driver-androidemulator/jumpstarter_driver_androidemulator/client.py
+++ b/python/packages/jumpstarter-driver-androidemulator/jumpstarter_driver_androidemulator/client.py
@@ -28,7 +28,7 @@ class AndroidEmulatorClient(CompositeClient):
         Yields:
             An ``adbutils.AdbDevice`` connected through the tunnel.
         """
-        import adbutils
+        import adbutils  # ty: ignore[unresolved-import]
 
         with self.adb.forward_adb(port=0) as (host, port):
             adb = adbutils.AdbClient(host=host, port=port)

--- a/python/packages/jumpstarter-driver-androidemulator/jumpstarter_driver_androidemulator/driver_test.py
+++ b/python/packages/jumpstarter-driver-androidemulator/jumpstarter_driver_androidemulator/driver_test.py
@@ -1,10 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from jumpstarter_driver_adb.driver import AdbServer
 
 from .driver import AndroidEmulator, AndroidEmulatorPower
 from jumpstarter.common.exceptions import ConfigurationError
-from jumpstarter_driver_adb.driver import AdbServer
 
 
 def _mock_adb_ok():

--- a/python/packages/jumpstarter-driver-androidemulator/jumpstarter_driver_androidemulator/driver_test.py
+++ b/python/packages/jumpstarter-driver-androidemulator/jumpstarter_driver_androidemulator/driver_test.py
@@ -2,8 +2,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from .driver import AndroidEmulator
+from .driver import AndroidEmulator, AndroidEmulatorPower
 from jumpstarter.common.exceptions import ConfigurationError
+from jumpstarter_driver_adb.driver import AdbServer
 
 
 def _mock_adb_ok():
@@ -42,7 +43,7 @@ def test_init_invalid_port(mock_run, mock_adb_which, mock_emu_which):
 @patch("subprocess.run", return_value=_mock_adb_ok())
 def test_power_on_builds_cmdline(mock_run, mock_adb_which, mock_emu_which):
     emu = AndroidEmulator(avd_name="test_avd", console_port=5556)
-    power = emu.children["power"]
+    power: AndroidEmulatorPower = emu.children["power"]  # ty: ignore[invalid-assignment]
 
     with patch("subprocess.Popen") as mock_popen:
         mock_proc = MagicMock()
@@ -73,7 +74,7 @@ def test_power_on_builds_cmdline(mock_run, mock_adb_which, mock_emu_which):
 @patch("subprocess.run", return_value=_mock_adb_ok())
 def test_power_on_not_headless(mock_run, mock_adb_which, mock_emu_which):
     emu = AndroidEmulator(avd_name="test_avd", headless=False)
-    power = emu.children["power"]
+    power: AndroidEmulatorPower = emu.children["power"]  # ty: ignore[invalid-assignment]
 
     with patch("subprocess.Popen") as mock_popen:
         mock_proc = MagicMock()
@@ -93,7 +94,7 @@ def test_power_on_not_headless(mock_run, mock_adb_which, mock_emu_which):
 @patch("subprocess.run", return_value=_mock_adb_ok())
 def test_power_off_graceful(mock_run, mock_adb_which, mock_emu_which):
     emu = AndroidEmulator(avd_name="test_avd")
-    power = emu.children["power"]
+    power: AndroidEmulatorPower = emu.children["power"]  # ty: ignore[invalid-assignment]
 
     mock_proc = MagicMock()
     mock_proc.returncode = None
@@ -115,7 +116,7 @@ def test_power_off_force_kill(mock_run, mock_adb_which, mock_emu_which):
     from subprocess import TimeoutExpired
 
     emu = AndroidEmulator(avd_name="test_avd")
-    power = emu.children["power"]
+    power: AndroidEmulatorPower = emu.children["power"]  # ty: ignore[invalid-assignment]
 
     mock_proc = MagicMock()
     mock_proc.returncode = None
@@ -137,5 +138,5 @@ def test_custom_ports(mock_run, mock_adb_which, mock_emu_which):
     emu = AndroidEmulator(avd_name="test_avd", console_port=5556, adb_server_port=15038)
     assert emu.console_port == 5556
     assert emu.adb_server_port == 15038
-    adb_child = emu.children["adb"]
+    adb_child: AdbServer = emu.children["adb"]  # ty: ignore[invalid-assignment]
     assert adb_child.port == 15038

--- a/python/packages/jumpstarter-driver-ble/jumpstarter_driver_ble/driver.py
+++ b/python/packages/jumpstarter-driver-ble/jumpstarter_driver_ble/driver.py
@@ -3,8 +3,9 @@ from dataclasses import dataclass
 from functools import partial
 
 import anyio
+import anyio.streams.memory
 from anyio.abc import ObjectStream
-from anyio.streams.memory import MemoryObjectSendStream
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from bleak import BleakClient, BleakGATTCharacteristic
 from bleak.exc import BleakError
 
@@ -38,7 +39,7 @@ class AsyncBleConfig():
 class AsyncBleWrapper(ObjectStream):
     client: BleakClient
     config: AsyncBleConfig
-    receive_stream: anyio.streams.memory.MemoryObjectReceiveStream
+    receive_stream: MemoryObjectReceiveStream
 
     async def send(self, data: bytes):
         await self.client.write_gatt_char(self.config.write_char_uuid, data)
@@ -109,7 +110,7 @@ class BleWriteNotifyStream(Driver):
         async with BleakClient(self.address) as client:
             try:
                 if client.is_connected:
-                    send_stream, receive_stream = anyio.create_memory_object_stream[bytearray](
+                    send_stream, receive_stream = anyio.create_memory_object_stream[bytearray](  # ty: ignore[call-non-callable]
                         max_buffer_size=1000)
                     self.logger.info(
                         "Connected to BLE device at Address: %s", self.address)

--- a/python/packages/jumpstarter-driver-ble/jumpstarter_driver_ble/driver_test.py
+++ b/python/packages/jumpstarter-driver-ble/jumpstarter_driver_ble/driver_test.py
@@ -86,7 +86,7 @@ def test_ble_driver_connect_stream():
 
 def test_ble_notify_handler():
     """Test the notification handler puts data into the stream."""
-    send_stream, receive_stream = anyio.create_memory_object_stream[bytearray](max_buffer_size=10)
+    send_stream, receive_stream = anyio.create_memory_object_stream[bytearray](max_buffer_size=10)  # ty: ignore[call-non-callable]
     sender = MagicMock()
     test_data = bytearray(b"test_notification")
 
@@ -98,7 +98,7 @@ def test_ble_notify_handler():
 
 def test_ble_notify_handler_queue_full(capsys):
     """Test the notification handler handles a full buffer gracefully."""
-    send_stream, receive_stream = anyio.create_memory_object_stream[bytearray](max_buffer_size=1)
+    send_stream, receive_stream = anyio.create_memory_object_stream[bytearray](max_buffer_size=1)  # ty: ignore[call-non-callable]
     sender = MagicMock()
 
     # Fill the buffer

--- a/python/packages/jumpstarter-driver-doip/jumpstarter_driver_doip/driver_test.py
+++ b/python/packages/jumpstarter-driver-doip/jumpstarter_driver_doip/driver_test.py
@@ -208,22 +208,22 @@ def test_doip_reconnect_failure(mock_doip_cls):
 
 def test_doip_missing_required_ecu_ip():
     with pytest.raises(ValidationError, match="ecu_ip"):
-        DoIP(ecu_logical_address=0x00E0)
+        DoIP(ecu_logical_address=0x00E0)  # ty: ignore[missing-argument]
 
 
 def test_doip_missing_required_ecu_logical_address():
     with pytest.raises(ValidationError, match="ecu_logical_address"):
-        DoIP(ecu_ip="192.168.1.100")
+        DoIP(ecu_ip="192.168.1.100")  # ty: ignore[missing-argument]
 
 
 def test_doip_invalid_ecu_ip_type():
     with pytest.raises(ValidationError):
-        DoIP(ecu_ip=12345, ecu_logical_address=0x00E0)
+        DoIP(ecu_ip=12345, ecu_logical_address=0x00E0)  # ty: ignore[invalid-argument-type]
 
 
 def test_doip_invalid_tcp_port_type():
     with pytest.raises(ValidationError):
-        DoIP(ecu_ip="192.168.1.100", ecu_logical_address=0x00E0, tcp_port="not_a_port")
+        DoIP(ecu_ip="192.168.1.100", ecu_logical_address=0x00E0, tcp_port="not_a_port")  # ty: ignore[invalid-argument-type]
 
 
 def test_doip_invalid_auto_reconnect_tcp_type():
@@ -231,7 +231,7 @@ def test_doip_invalid_auto_reconnect_tcp_type():
         DoIP(
             ecu_ip="192.168.1.100",
             ecu_logical_address=0x00E0,
-            auto_reconnect_tcp="not_bool",
+            auto_reconnect_tcp="not_bool",  # ty: ignore[invalid-argument-type]
         )
 
 

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -314,7 +314,7 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         """
         # Check if this is an ExceptionGroup and look through its exceptions
         if hasattr(exception, "exceptions"):
-            for sub_exc in exception.exceptions:
+            for sub_exc in exception.exceptions:  # ty: ignore[not-iterable]
                 result = self._find_exception_in_chain(sub_exc, target_type)
                 if result is not None:
                     return result

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client_test.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client_test.py
@@ -242,9 +242,9 @@ def test_flash_http_url_with_oci_credentials_still_uses_direct_http_path():
         def get_url(self):
             return "http://exporter"
 
-    client.http = DummyService()
-    client.tftp = DummyService()
-    client.call = lambda *args, **kwargs: None
+    client.http = DummyService()  # ty: ignore[unresolved-attribute]
+    client.tftp = DummyService()  # ty: ignore[unresolved-attribute]
+    client.call = lambda *args, **kwargs: None  # ty: ignore[invalid-assignment]
 
     captured = {}
 
@@ -254,7 +254,7 @@ def test_flash_http_url_with_oci_credentials_still_uses_direct_http_path():
         captured["oci_username"] = args[14]
         captured["oci_password"] = args[15]
 
-    client._perform_flash_operation = capture_perform
+    client._perform_flash_operation = capture_perform  # ty: ignore[invalid-assignment]
 
     client.flash(
         "https://example.com/image.raw.xz",

--- a/python/packages/jumpstarter-driver-gpiod/jumpstarter_driver_gpiod/driver.py
+++ b/python/packages/jumpstarter-driver-gpiod/jumpstarter_driver_gpiod/driver.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 try:
     import gpiod
 except ImportError:
-    gpiod = None
+    gpiod = None  # ty: ignore[invalid-assignment]
 
 from jumpstarter_driver_power.driver import PowerInterface
 

--- a/python/packages/jumpstarter-driver-gpiod/jumpstarter_driver_gpiod/driver_test.py
+++ b/python/packages/jumpstarter-driver-gpiod/jumpstarter_driver_gpiod/driver_test.py
@@ -47,7 +47,7 @@ def digital_output_client():
     """Create a DigitalOutputClient instance with mocked dependencies"""
     # Mock the required attributes
     client = DigitalOutputClient(stub=MagicMock(), portal=MagicMock(), stack=MagicMock())
-    client.uuid = "test-uuid"
+    client.uuid = "test-uuid"  # ty: ignore[invalid-assignment]
     return client
 
 
@@ -56,7 +56,7 @@ def digital_input_client():
     """Create a DigitalInputClient instance with mocked dependencies"""
     # Mock the required attributes
     client = DigitalInputClient(stub=MagicMock(), portal=MagicMock(), stack=MagicMock())
-    client.uuid = "test-uuid"
+    client.uuid = "test-uuid"  # ty: ignore[invalid-assignment]
     return client
 
 
@@ -155,7 +155,7 @@ class TestDriverMethods:
         mock_gpiod.LineSettings.assert_called()
 
         # Verify line was requested
-        driver._chip.request_lines.assert_called_once()
+        driver._chip.request_lines.assert_called_once()  # ty: ignore[unresolved-attribute]
 
         # Verify pin was processed correctly
         assert driver.line == 18
@@ -178,7 +178,7 @@ class TestDriverMethods:
         mock_gpiod.LineSettings.assert_called()
 
         # Verify line was requested
-        driver._chip.request_lines.assert_called_once()
+        driver._chip.request_lines.assert_called_once()  # ty: ignore[unresolved-attribute]
 
         # Verify line was processed correctly
         assert driver.line == 17
@@ -203,12 +203,12 @@ class TestDriverMethods:
         driver._line.set_value.assert_called_with(18, mock_gpiod.line.Value.INACTIVE)
 
         # Test read_pin() method
-        driver._line.get_value.return_value = mock_gpiod.line.Value.ACTIVE
+        driver._line.get_value.return_value = mock_gpiod.line.Value.ACTIVE  # ty: ignore[invalid-assignment]
         result = driver.read_pin()
         assert result.value == 1
         assert str(result) == "active"
 
-        driver._line.get_value.return_value = mock_gpiod.line.Value.INACTIVE
+        driver._line.get_value.return_value = mock_gpiod.line.Value.INACTIVE  # ty: ignore[invalid-assignment]
         result = driver.read_pin()
         assert result.value == 0
         assert str(result) == "inactive"
@@ -225,24 +225,24 @@ class TestDriverMethods:
         driver = DigitalInput(line=17)
 
         # Test read_pin() method
-        driver._line.get_value.return_value = mock_gpiod.line.Value.ACTIVE
+        driver._line.get_value.return_value = mock_gpiod.line.Value.ACTIVE  # ty: ignore[invalid-assignment]
         result = driver.read_pin()
         assert result.value == 1
         assert str(result) == "active"
 
-        driver._line.get_value.return_value = mock_gpiod.line.Value.INACTIVE
+        driver._line.get_value.return_value = mock_gpiod.line.Value.INACTIVE  # ty: ignore[invalid-assignment]
         result = driver.read_pin()
         assert result.value == 0
         assert str(result) == "inactive"
 
         # Test wait_for_active() when already active
-        driver._line.get_value.return_value = mock_gpiod.line.Value.ACTIVE
+        driver._line.get_value.return_value = mock_gpiod.line.Value.ACTIVE  # ty: ignore[invalid-assignment]
         driver.wait_for_active()
         driver._line.wait_edge_events.assert_not_called()
 
         # Test wait_for_active() with timeout
-        driver._line.get_value.return_value = mock_gpiod.line.Value.INACTIVE
-        driver._line.wait_edge_events.return_value = False  # Timeout
+        driver._line.get_value.return_value = mock_gpiod.line.Value.INACTIVE  # ty: ignore[invalid-assignment]
+        driver._line.wait_edge_events.return_value = False  # ty: ignore[invalid-assignment]
 
         with pytest.raises(TimeoutError, match="Timed out waiting for line 17 edge event"):
             driver.wait_for_active(timeout=1.0)
@@ -252,8 +252,8 @@ class TestDriverMethods:
         mock_event.line_offset = 17
         mock_event.event_type = mock_gpiod.EdgeEvent.Type.RISING_EDGE
 
-        driver._line.wait_edge_events.return_value = True
-        driver._line.read_edge_events.return_value = [mock_event]
+        driver._line.wait_edge_events.return_value = True  # ty: ignore[invalid-assignment]
+        driver._line.read_edge_events.return_value = [mock_event]  # ty: ignore[invalid-assignment]
 
         driver.wait_for_edge("rising")
         driver._line.wait_edge_events.assert_called()

--- a/python/packages/jumpstarter-driver-http-power/jumpstarter_driver_http_power/driver.py
+++ b/python/packages/jumpstarter-driver-http-power/jumpstarter_driver_http_power/driver.py
@@ -63,16 +63,16 @@ class HttpPower(PowerInterface, Driver):
         if self.auth and self.auth.basic:
             auth = (self.auth.basic.user, self.auth.basic.password)
         method = endpoint_config.method.upper()
+        url = endpoint_config.url
         kwargs = {
-            'url': endpoint_config.url,
             'auth': auth,
         }
         if endpoint_config.data and method in ['POST', 'PUT', 'PATCH']:
             kwargs['data'] = endpoint_config.data
 
-        self.logger.debug(f"Making {method} request to {endpoint_config.url}")
+        self.logger.debug(f"Making {method} request to {url}")
 
-        response = requests.request(method, **kwargs)
+        response = requests.request(method, url, **kwargs)
         response.raise_for_status()
         return response.text
 

--- a/python/packages/jumpstarter-driver-http-power/jumpstarter_driver_http_power/driver_test.py
+++ b/python/packages/jumpstarter-driver-http-power/jumpstarter_driver_http_power/driver_test.py
@@ -51,6 +51,7 @@ class MockHTTPHandler(BaseHTTPRequestHandler):
 def test_drivers_http_power():
     # Start a mock HTTP server
     server = HTTPServer(('localhost', 0), MockHTTPHandler)
+    server.requests = []  # ty: ignore[unresolved-attribute]
     server_port = server.server_address[1]
     server_thread = threading.Thread(target=server.serve_forever)
     server_thread.daemon = True
@@ -82,22 +83,22 @@ def test_drivers_http_power():
             assert readings[0].current == 0.0
 
             # Verify HTTP requests were made
-            assert len(server.requests) == 3
+            assert len(server.requests) == 3  # ty: ignore[unresolved-attribute]
 
             # Check on request
-            on_request = server.requests[0]
+            on_request = server.requests[0]  # ty: ignore[unresolved-attribute]
             assert on_request['method'] == 'POST'
             assert on_request['path'] == '/on'
             assert on_request['body'] == 'power=on'
 
             # Check off request
-            off_request = server.requests[1]
+            off_request = server.requests[1]  # ty: ignore[unresolved-attribute]
             assert off_request['method'] == 'POST'
             assert off_request['path'] == '/off'
             assert off_request['body'] == 'power=off'
 
             # Check read request
-            read_request = server.requests[2]
+            read_request = server.requests[2]  # ty: ignore[unresolved-attribute]
             assert read_request['method'] == 'GET'
             assert read_request['path'] == '/read'
             assert read_request['body'] is None

--- a/python/packages/jumpstarter-driver-mitmproxy/demo/conftest.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/demo/conftest.py
@@ -15,7 +15,7 @@ from http.server import HTTPServer
 
 import pytest
 import requests
-from backend import DemoBackendHandler
+from backend import DemoBackendHandler  # ty: ignore[unresolved-import]
 
 BACKEND_PORT = 9000
 PROXY_PORT = 8080

--- a/python/packages/jumpstarter-driver-mitmproxy/demo/dut_simulator.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/demo/dut_simulator.py
@@ -21,6 +21,7 @@ import time
 from urllib.parse import urlsplit
 
 import requests
+import requests.exceptions
 
 # ── ANSI colours ──────────────────────────────────────────────
 _GREEN = "\033[92m"
@@ -49,7 +50,7 @@ def _source_colour(source: str) -> str:
 
 def _print_response(method: str, path: str, resp: requests.Response):
     ts = time.strftime("%H:%M:%S")
-    sc = _status_colour(resp.status_code)
+    sc = _status_colour(resp.status_code)  # ty: ignore[invalid-argument-type]
 
     print(f"  {_DIM}{ts}{_RESET}  {sc}{resp.status_code}{_RESET}  {method:4s} {path}")
 

--- a/python/packages/jumpstarter-driver-mitmproxy/examples/addons/mjpeg_stream.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/examples/addons/mjpeg_stream.py
@@ -86,7 +86,7 @@ def _generate_test_pattern_jpeg(
     frame number overlay. Otherwise, returns the minimal JPEG.
     """
     try:
-        from PIL import Image, ImageDraw, ImageFont
+        from PIL import Image, ImageDraw, ImageFont  # ty: ignore[unresolved-import]
 
         img = Image.new("RGB", (width, height), color=(40, 40, 40))
         draw = ImageDraw.Draw(img)

--- a/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/bundled_addon.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/bundled_addon.py
@@ -419,7 +419,7 @@ class AddonRegistry:
             spec.loader.exec_module(module)
 
             if hasattr(module, "Handler"):
-                handler = module.Handler()
+                handler = module.Handler()  # ty: ignore[call-non-callable]
                 self._handlers[name] = handler
                 ctx.log.info(f"Loaded addon: {name}")
                 return handler

--- a/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/client.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/client.py
@@ -1447,11 +1447,12 @@ def _mock_summary(defn: dict) -> str:
 
 def _human_size(nbytes: int) -> str:
     """Format a byte count as a human-readable string."""
+    nbytes_float = float(nbytes)
     for unit in ("B", "KB", "MB", "GB"):
-        if nbytes < 1024:
-            return f"{nbytes:.0f} {unit}" if unit == "B" else f"{nbytes:.1f} {unit}"
-        nbytes /= 1024
-    return f"{nbytes:.1f} TB"
+        if nbytes_float < 1024:
+            return f"{nbytes_float:.0f} {unit}" if unit == "B" else f"{nbytes_float:.1f} {unit}"
+        nbytes_float /= 1024
+    return f"{nbytes_float:.1f} TB"
 
 
 def _collect_entries_from_item(item: dict) -> list[dict]:

--- a/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/driver_test.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/driver_test.py
@@ -655,7 +655,7 @@ def deep_merge_patch():
             return
         return original_mkdir(self, *args, **kwargs)
 
-    Path.mkdir = safe_mkdir
+    Path.mkdir = safe_mkdir  # ty: ignore[invalid-assignment]
     try:
         if "jumpstarter_driver_mitmproxy.bundled_addon" in sys.modules:
             mod = sys.modules["jumpstarter_driver_mitmproxy.bundled_addon"]
@@ -663,7 +663,7 @@ def deep_merge_patch():
             mod = importlib.import_module(
                 "jumpstarter_driver_mitmproxy.bundled_addon"
             )
-        return mod._deep_merge_patch
+        return mod._deep_merge_patch  # ty: ignore[unresolved-attribute]
     finally:
         Path.mkdir = original_mkdir
 
@@ -673,7 +673,7 @@ def apply_patches(deep_merge_patch):
     """Import _apply_patches lazily."""
     import sys
     mod = sys.modules["jumpstarter_driver_mitmproxy.bundled_addon"]
-    return mod._apply_patches
+    return mod._apply_patches  # ty: ignore[unresolved-attribute]
 
 
 class TestDeepMergePatch:

--- a/python/packages/jumpstarter-driver-pi-pico/jumpstarter_driver_pi_pico/driver_test.py
+++ b/python/packages/jumpstarter-driver-pi-pico/jumpstarter_driver_pi_pico/driver_test.py
@@ -183,7 +183,7 @@ def test_drivers_pi_pico_enter_bootloader_via_gpio(monkeypatch, tmp_path):
 
     def _fake_mounts():
         nonlocal call_count
-        call_count += 1
+        call_count += 1  # ty: ignore[unresolved-reference]
         if call_count <= 1:
             return []
         return [boot]
@@ -213,7 +213,7 @@ def test_drivers_pi_pico_gpio_preferred_over_serial(monkeypatch, tmp_path):
 
     def _fake_mounts():
         nonlocal call_count
-        call_count += 1
+        call_count += 1  # ty: ignore[unresolved-reference]
         if call_count <= 1:
             return []
         return [boot]
@@ -242,7 +242,7 @@ def test_drivers_pi_pico_flash_via_gpio(monkeypatch, tmp_path):
 
     def _fake_mounts():
         nonlocal call_count
-        call_count += 1
+        call_count += 1  # ty: ignore[unresolved-reference]
         if call_count <= 2:
             return []
         return [boot]

--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver.py
@@ -18,7 +18,7 @@ from jumpstarter.driver import Driver, export, exportstream
 try:
     import termios
 except ImportError:  # pragma: no cover - non-POSIX platforms
-    termios = None
+    termios = None  # ty: ignore[invalid-assignment]
 
 LOOP = "loop://"
 

--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/driver_test.py
@@ -122,7 +122,7 @@ def test_throttled_stream_async():
         expected_min_time = (len(test_data) - 1) / cps  # Should take at least 11/5 = 2.2 seconds
 
         # Create a memory stream for testing
-        tx, rx = create_memory_object_stream[bytes](32)
+        tx, rx = create_memory_object_stream[bytes](32)  # ty: ignore[call-non-callable]
         stapled_stream = StapledObjectStream(tx, rx)
         # Wrap it with throttling and ensure proper closure
         async with ThrottledStream(stream=stapled_stream, cps=cps) as throttled_stream:

--- a/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/nvdemux/manager.py
+++ b/python/packages/jumpstarter-driver-pyserial/jumpstarter_driver_pyserial/nvdemux/manager.py
@@ -155,7 +155,7 @@ class DemuxerManager:
         if cls._signal_handlers_installed:
             return
 
-        def make_handler(sig: signal.Signals) -> Callable[[int, any], None]:
+        def make_handler(sig: signal.Signals) -> Callable[[int, any], None]:  # ty: ignore[invalid-type-form]
             """Create a signal handler that cleans up and re-raises the signal."""
 
             def handler(signum: int, frame):

--- a/python/packages/jumpstarter-driver-shell/jumpstarter_driver_shell/client.py
+++ b/python/packages/jumpstarter-driver-shell/jumpstarter_driver_shell/client.py
@@ -2,6 +2,7 @@ import sys
 from dataclasses import dataclass
 
 import click
+import click.exceptions
 
 from jumpstarter.client import DriverClient
 from jumpstarter.client.decorators import driver_click_group

--- a/python/packages/jumpstarter-driver-shell/jumpstarter_driver_shell/driver.py
+++ b/python/packages/jumpstarter-driver-shell/jumpstarter_driver_shell/driver.py
@@ -1,4 +1,5 @@
 import asyncio
+import asyncio.subprocess
 import os
 import signal
 import subprocess
@@ -187,7 +188,7 @@ class Shell(Driver):
 
         # Start the process with pipes for streaming and new process group
         self.logger.debug( f"running {method} with cmd: {cmd} and env: {combined_env} " f"and args: {args}")
-        process = await asyncio.create_subprocess_exec(
+        process = await asyncio.create_subprocess_exec(  # ty: ignore[missing-argument]
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/python/packages/jumpstarter-driver-someip/jumpstarter_driver_someip/driver_test.py
+++ b/python/packages/jumpstarter-driver-someip/jumpstarter_driver_someip/driver_test.py
@@ -283,12 +283,12 @@ def test_someip_connection_error(mock_osip_cls):
 
 def test_someip_missing_required_host():
     with pytest.raises(ValidationError, match="host"):
-        SomeIp(port=30490)
+        SomeIp(port=30490)  # ty: ignore[missing-argument]
 
 
 def test_someip_invalid_port_type():
     with pytest.raises(ValidationError):
-        SomeIp(host="127.0.0.1", port="not_a_port")
+        SomeIp(host="127.0.0.1", port="not_a_port")  # ty: ignore[invalid-argument-type]
 
 
 @patch("jumpstarter_driver_someip.driver.OsipClient")

--- a/python/packages/jumpstarter-driver-ssh-mitm/jumpstarter_driver_ssh_mitm/driver_test.py
+++ b/python/packages/jumpstarter-driver-ssh-mitm/jumpstarter_driver_ssh_mitm/driver_test.py
@@ -244,7 +244,7 @@ class TestSSHMITMStream:
         def fake_handle_session(self, transport):
             started.set()
 
-        instance._handle_session = fake_handle_session.__get__(instance, SSHMITM)
+        instance._handle_session = fake_handle_session.__get__(instance, SSHMITM)  # ty: ignore[invalid-assignment]
 
         class DummyTransport:
             def __init__(self, sock):

--- a/python/packages/jumpstarter-driver-ssh/jumpstarter_driver_ssh/driver_test.py
+++ b/python/packages/jumpstarter-driver-ssh/jumpstarter_driver_ssh/driver_test.py
@@ -647,7 +647,7 @@ def test_ssh_identity_temp_file_creation_error():
                     client.run(SSHCommandRunOptions(direct=False), ["hostname"])
 
                 # Check that the original OSError is in the exception group
-                assert any(isinstance(e, OSError) and "Permission denied" in str(e) for e in exc_info.value.exceptions)
+                assert any(isinstance(e, OSError) and "Permission denied" in str(e) for e in exc_info.value.exceptions)  # ty: ignore[unresolved-attribute]
 
 
 def test_ssh_identity_temp_file_cleanup_error():

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/test_path_traversal.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/test_path_traversal.py
@@ -11,7 +11,7 @@ def server():
     return TftpServer(
         host="127.0.0.1",
         port=0,
-        operator=operator,
+        operator=operator,  # ty: ignore[invalid-argument-type]
     )
 
 

--- a/python/packages/jumpstarter-driver-uds-can/jumpstarter_driver_uds_can/driver.py
+++ b/python/packages/jumpstarter-driver-uds-can/jumpstarter_driver_uds_can/driver.py
@@ -58,7 +58,7 @@ class UdsCan(UdsInterface, Driver):
 
             self._uds_conn = PythonIsoTpConnection(self._stack)
             config = make_uds_client_config(request_timeout=self.request_timeout)
-            self._uds_client = UdsoncanClient(self._uds_conn, config=config)
+            self._uds_client = UdsoncanClient(self._uds_conn, config=config)  # ty: ignore[invalid-argument-type]
             self._uds_client.open()
         except Exception:
             self.close()

--- a/python/packages/jumpstarter-driver-uds-can/jumpstarter_driver_uds_can/driver_test.py
+++ b/python/packages/jumpstarter-driver-uds-can/jumpstarter_driver_uds_can/driver_test.py
@@ -326,27 +326,27 @@ def test_uds_can_close_resources(mock_bus_cls, mock_notifier_cls, mock_stack_cls
 
 def test_uds_can_missing_required_channel():
     with pytest.raises(ValidationError, match="channel"):
-        UdsCan(rxid=0x641, txid=0x642)
+        UdsCan(rxid=0x641, txid=0x642)  # ty: ignore[missing-argument]
 
 
 def test_uds_can_missing_required_rxid():
     with pytest.raises(ValidationError, match="rxid"):
-        UdsCan(channel="vcan0", txid=0x642)
+        UdsCan(channel="vcan0", txid=0x642)  # ty: ignore[missing-argument]
 
 
 def test_uds_can_missing_required_txid():
     with pytest.raises(ValidationError, match="txid"):
-        UdsCan(channel="vcan0", rxid=0x641)
+        UdsCan(channel="vcan0", rxid=0x641)  # ty: ignore[missing-argument]
 
 
 def test_uds_can_invalid_channel_type():
     with pytest.raises(ValidationError):
-        UdsCan(channel=12345, rxid=0x641, txid=0x642)
+        UdsCan(channel=12345, rxid=0x641, txid=0x642)  # ty: ignore[invalid-argument-type]
 
 
 def test_uds_can_invalid_timeout_type():
     with pytest.raises(ValidationError):
-        UdsCan(channel="vcan0", rxid=0x641, txid=0x642, request_timeout="not_a_float")
+        UdsCan(channel="vcan0", rxid=0x641, txid=0x642, request_timeout="not_a_float")  # ty: ignore[invalid-argument-type]
 
 
 @patch("jumpstarter_driver_uds_can.driver.UdsoncanClient")

--- a/python/packages/jumpstarter-driver-uds-doip/jumpstarter_driver_uds_doip/driver.py
+++ b/python/packages/jumpstarter-driver-uds-doip/jumpstarter_driver_uds_doip/driver.py
@@ -50,7 +50,7 @@ class UdsDoip(UdsInterface, Driver):
         try:
             conn = DoIPClientUDSConnector(self._doip_client)
             config = make_uds_client_config(request_timeout=self.request_timeout)
-            self._uds_client = UdsoncanClient(conn, config=config)
+            self._uds_client = UdsoncanClient(conn, config=config)  # ty: ignore[invalid-argument-type]
             self._uds_client.open()
         except Exception:
             self.close()

--- a/python/packages/jumpstarter-driver-uds-doip/jumpstarter_driver_uds_doip/driver_test.py
+++ b/python/packages/jumpstarter-driver-uds-doip/jumpstarter_driver_uds_doip/driver_test.py
@@ -272,17 +272,17 @@ def test_uds_doip_close_resources(mock_doip_cls, mock_conn_cls, mock_uds_cls):
 
 def test_uds_doip_missing_required_ecu_ip():
     with pytest.raises(ValidationError, match="ecu_ip"):
-        UdsDoip(ecu_logical_address=0x00E0)
+        UdsDoip(ecu_logical_address=0x00E0)  # ty: ignore[missing-argument]
 
 
 def test_uds_doip_missing_required_ecu_logical_address():
     with pytest.raises(ValidationError, match="ecu_logical_address"):
-        UdsDoip(ecu_ip="192.168.1.100")
+        UdsDoip(ecu_ip="192.168.1.100")  # ty: ignore[missing-argument]
 
 
 def test_uds_doip_invalid_ecu_ip_type():
     with pytest.raises(ValidationError):
-        UdsDoip(ecu_ip=12345, ecu_logical_address=0x00E0)
+        UdsDoip(ecu_ip=12345, ecu_logical_address=0x00E0)  # ty: ignore[invalid-argument-type]
 
 
 def test_uds_doip_invalid_timeout_type():
@@ -290,7 +290,7 @@ def test_uds_doip_invalid_timeout_type():
         UdsDoip(
             ecu_ip="192.168.1.100",
             ecu_logical_address=0x00E0,
-            request_timeout="not_a_float",
+            request_timeout="not_a_float",  # ty: ignore[invalid-argument-type]
         )
 
 

--- a/python/packages/jumpstarter-driver-vnc/jumpstarter_driver_vnc/client.py
+++ b/python/packages/jumpstarter-driver-vnc/jumpstarter_driver_vnc/client.py
@@ -12,21 +12,21 @@ from jumpstarter_driver_network.adapters.novnc import NovncAdapter
 from jumpstarter.client.decorators import driver_click_group
 
 if typing.TYPE_CHECKING:
-    from jumpstarter_driver_network.client import TCPClient
+    from jumpstarter_driver_network.client import NetworkClient
 
 
 class VNClient(CompositeClient):
     """Client for interacting with a VNC server."""
 
     @property
-    def tcp(self) -> TCPClient:
+    def tcp(self) -> NetworkClient:
         """
         Access the underlying TCP client.
 
         Returns:
-            TCPClient: The TCP client instance stored in this composite client's children mapping.
+            NetworkClient: The TCP client instance stored in this composite client's children mapping.
         """
-        return typing.cast("TCPClient", self.children["tcp"])
+        return typing.cast("NetworkClient", self.children["tcp"])
 
     def stream(self, method="connect"):
         """Create a new stream, proxied to the underlying TCP driver."""

--- a/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
+++ b/python/packages/jumpstarter-driver-xcp/jumpstarter_driver_xcp/driver_test.py
@@ -57,10 +57,10 @@ def mock_master():
 @pytest.fixture
 def client(mock_master):
     instance = Xcp(
-        transport="ETH",
+        transport="ETH",  # ty: ignore[invalid-argument-type]
         host="127.0.0.1",
         port=5555,
-        protocol="TCP",
+        protocol="TCP",  # ty: ignore[invalid-argument-type]
     )
 
     with patch(
@@ -279,7 +279,7 @@ def test_unlock_with_resources(client, mock_master):
 def test_connect_timeout(mock_master):
     mock_master.connect.side_effect = TimeoutError("No response from ECU")
 
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=mock_master,
@@ -292,7 +292,7 @@ def test_connect_timeout(mock_master):
 def test_upload_error(mock_master):
     mock_master.shortUpload.side_effect = RuntimeError("XCP ERR_ACCESS_DENIED")
 
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=mock_master,
@@ -306,7 +306,7 @@ def test_upload_error(mock_master):
 def test_download_error(mock_master):
     mock_master.download.side_effect = RuntimeError("XCP ERR_OUT_OF_RANGE")
 
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=mock_master,
@@ -320,7 +320,7 @@ def test_download_error(mock_master):
 def test_program_clear_error(mock_master):
     mock_master.programClear.side_effect = RuntimeError("Erase failed")
 
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=mock_master,
@@ -334,7 +334,7 @@ def test_program_clear_error(mock_master):
 def test_unlock_error(mock_master):
     mock_master.cond_unlock.side_effect = RuntimeError("Seed & key failed")
 
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=mock_master,
@@ -348,7 +348,7 @@ def test_unlock_error(mock_master):
 def test_get_daq_info_error(mock_master):
     mock_master.getDaqInfo.side_effect = RuntimeError("DAQ not supported")
 
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=mock_master,
@@ -366,17 +366,17 @@ def test_get_daq_info_error(mock_master):
 
 def test_invalid_transport_type():
     with pytest.raises(ValidationError):
-        Xcp(transport="INVALID", host="127.0.0.1", port=5555)
+        Xcp(transport="INVALID", host="127.0.0.1", port=5555)  # ty: ignore[invalid-argument-type]
 
 
 def test_invalid_protocol_type():
     with pytest.raises(ValidationError):
-        Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="INVALID")
+        Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="INVALID")  # ty: ignore[invalid-argument-type]
 
 
 def test_invalid_port_type():
     with pytest.raises(ValidationError):
-        Xcp(transport="ETH", host="127.0.0.1", port="not_a_port")
+        Xcp(transport="ETH", host="127.0.0.1", port="not_a_port")  # ty: ignore[invalid-argument-type]
 
 
 def test_default_config_values():
@@ -397,7 +397,7 @@ def test_custom_config_forwarded(mock_create):
     mock_create.return_value = _make_mock_master()
 
     instance = Xcp(
-        transport="CAN",
+        transport="CAN",  # ty: ignore[invalid-argument-type]
         can_interface="vector",
         channel=0,
         bitrate=500000,
@@ -428,7 +428,7 @@ def test_custom_config_forwarded(mock_create):
 
 def _stateful_client_ctx(stateful_master):
     """Context manager helper: serve() an Xcp driver backed by the stateful mock."""
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=stateful_master,
@@ -608,7 +608,7 @@ def test_stateful_full_programming_flow(stateful_client, stateful_master):
 
 def test_stateful_program_clear_before_start_raises(stateful_master):
     """programClear without programStart should fail."""
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=stateful_master,
@@ -621,7 +621,7 @@ def test_stateful_program_clear_before_start_raises(stateful_master):
 
 def test_stateful_program_before_clear_raises(stateful_master):
     """program without programClear should fail."""
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=stateful_master,
@@ -668,7 +668,7 @@ def test_stateful_calibration_workflow(stateful_client):
 
 def test_stateful_operations_before_connect_raise(stateful_master):
     """Methods called before connect() should fail."""
-    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")
+    instance = Xcp(transport="ETH", host="127.0.0.1", port=5555, protocol="TCP")  # ty: ignore[invalid-argument-type]  # noqa: E501
     with patch(
         "jumpstarter_driver_xcp.driver._create_xcp_master",
         return_value=stateful_master,

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/connections.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/connections.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import anyio
+import anyio.abc
+import anyio.from_thread
 from anyio.from_thread import BlockingPortal
 
 from jumpstarter.client.client import client_from_path
@@ -198,7 +200,7 @@ class ConnectionManager:
         task_status,
     ) -> Connection:
         """Wire up the Unix socket, client, and notification watchers for a lease."""
-        notify_send, notify_recv = anyio.create_memory_object_stream[tuple[str, str, timedelta]](16)
+        notify_send, notify_recv = anyio.create_memory_object_stream[tuple[str, str, timedelta]](16)  # ty: ignore[call-non-callable]
 
         def _on_lease_ending(lease_obj, remaining):
             try:

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/introspect.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/introspect.py
@@ -7,11 +7,12 @@ import logging
 from typing import Any
 
 import click
+import click.core
 
 logger = logging.getLogger(__name__)
 
 
-def walk_click_tree(cmd: click.BaseCommand, path: list[str] | None = None) -> dict[str, Any]:
+def walk_click_tree(cmd: click.core.BaseCommand, path: list[str] | None = None) -> dict[str, Any]:  # ty: ignore[unresolved-attribute]
     """Recursively walk a Click command tree and return structured JSON.
 
     Returns command names, help text, parameters (with types and defaults),

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/server_test.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/server_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.subprocess
 import logging
 import time
 from dataclasses import dataclass
@@ -353,7 +354,7 @@ class TestRunCommand:
 
         async def fake_communicate():
             nonlocal call_count
-            call_count += 1
+            call_count += 1  # ty: ignore[unresolved-reference]
             if call_count == 1:
                 await asyncio.sleep(999)
             return (b"partial", b"err")

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/tools/commands.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/tools/commands.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.subprocess
 import logging
 import shutil
 
 import anyio
+import anyio.to_thread
 import click
 
 from jumpstarter_mcp.connections import ConnectionManager
@@ -99,7 +101,7 @@ async def explore(
     if not hasattr(client, "cli"):
         return {"error": "Client does not have a CLI interface"}
 
-    cli_cmd = await anyio.to_thread.run_sync(client.cli)
+    cli_cmd = await anyio.to_thread.run_sync(client.cli)  # ty: ignore[invalid-argument-type]
 
     if command_path:
         for name in command_path:

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/tools/connections.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/tools/connections.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
-import anyio.to_thread
+import anyio.to_thread  # noqa: F401
 
 from jumpstarter_mcp.connections import ConnectionManager
 from jumpstarter_mcp.introspect import list_drivers, walk_click_tree

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/tools/connections.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/tools/connections.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
+import anyio.to_thread
+
 from jumpstarter_mcp.connections import ConnectionManager
 from jumpstarter_mcp.introspect import list_drivers, walk_click_tree
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "pre-commit>=3.8.0",
     "esbonio>=0.16.5",
     "ty>=0.0.1a8",
+    "diff-cover>=9.2.0",
 ]
 
 [tool.ruff]
@@ -98,6 +99,7 @@ Pn = "Pn"
 mosquitto = "mosquitto"
 
 [tool.coverage.run]
+branch = true
 omit = ["conftest.py", "test_*.py", "*_test.py", "*_pb2.py", "*_pb2_grpc.py"]
 skip_empty = true
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -33,6 +33,7 @@ members = [
     "jumpstarter-driver-iscsi",
     "jumpstarter-driver-mitmproxy",
     "jumpstarter-driver-network",
+    "jumpstarter-driver-noyito-relay",
     "jumpstarter-driver-opendal",
     "jumpstarter-driver-pi-pico",
     "jumpstarter-driver-power",
@@ -70,6 +71,7 @@ members = [
 
 [manifest.dependency-groups]
 dev = [
+    { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "esbonio", specifier = ">=0.16.5" },
     { name = "pre-commit", specifier = ">=3.8.0" },
     { name = "ruff", specifier = "==0.15.8" },
@@ -1242,6 +1244,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2c/61eeb887055a37150db824b6bf830e821a736580769ac2fea4eadb0d613f/diff_cover-10.2.0-py3-none-any.whl", hash = "sha256:59c328595e0b8948617cc5269af9e484c86462e2844bfcafa3fb37f8fca0af87", size = 56748, upload-time = "2026-01-09T01:59:06.028Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1678,6 +1695,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
+]
+
+[[package]]
+name = "hid"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/f8/0357a8aa8874a243e96d08a8568efaf7478293e1a3441ddca18039b690c1/hid-1.0.9.tar.gz", hash = "sha256:f4471f11f0e176d1b0cb1b243e55498cc90347a3aede735655304395694ac182", size = 4973, upload-time = "2026-02-05T15:35:20.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/c7/f0e1ad95179f44a6fc7a9140be025812cc7a62cf7390442b685a57ee1417/hid-1.0.9-py3-none-any.whl", hash = "sha256:6b9289e00bbc1e1589bec0c7f376a63fe03a4a4a1875575d0ad60e3e11a349f4", size = 4959, upload-time = "2026-02-05T15:35:19.269Z" },
 ]
 
 [[package]]
@@ -2263,12 +2289,15 @@ source = { editable = "packages/jumpstarter-driver-ble" }
 dependencies = [
     { name = "anyio" },
     { name = "bleak" },
+    { name = "click" },
     { name = "jumpstarter" },
+    { name = "jumpstarter-driver-network" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-anyio" },
     { name = "pytest-cov" },
 ]
 
@@ -2276,12 +2305,15 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.10.0" },
     { name = "bleak", specifier = ">=1.1.1" },
+    { name = "click", specifier = ">=8.1.8" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-network", editable = "packages/jumpstarter-driver-network" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-anyio", specifier = ">=0.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
@@ -2754,6 +2786,38 @@ dev = [
 ]
 
 [[package]]
+name = "jumpstarter-driver-noyito-relay"
+source = { editable = "packages/jumpstarter-driver-noyito-relay" }
+dependencies = [
+    { name = "hid" },
+    { name = "jumpstarter" },
+    { name = "jumpstarter-driver-power" },
+    { name = "pyserial" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hid", specifier = ">=1.0.4" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
+    { name = "pyserial", specifier = ">=3.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+]
+
+[[package]]
 name = "jumpstarter-driver-opendal"
 source = { editable = "packages/jumpstarter-driver-opendal" }
 dependencies = [
@@ -3094,7 +3158,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "opensomeip", specifier = ">=0.1.2" },
+    { name = "opensomeip", specifier = ">=0.1.2,<0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -5255,6 +5319,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Enable **branch coverage** measurement (`branch = true` in `[tool.coverage.run]`) to catch untested `if/else` paths
- Add **diff-cover** step to Python Tests workflow that enforces >=80% coverage on new/changed lines in PRs, preventing coverage regression without demanding an arbitrary threshold
- Add **ty type checking** to the Linters workflow as a non-blocking job (`continue-on-error: true`) to surface type errors before merge -- can be made blocking once the 49 existing diagnostics are resolved
- Add `diff-cover` to dev dependencies

## Rationale

As AI-generated code contributions increase, automated quality gates that prevent regression are essential for maintaining confidence when accepting changes. These three changes are the highest-impact, lowest-effort improvements:

1. **Coverage ratchet via diff-cover**: New/changed lines must be >=80% covered. This prevents coverage erosion without penalizing existing uncovered code.
2. **Branch coverage**: Catches cases where only one side of an `if/else` is tested -- common in AI-generated error handling paths.
3. **Type checking visibility**: Makes type errors visible on PRs even though they don't block merge yet.

## Test plan

- [ ] Python Tests workflow runs successfully with the `fetch-depth: 0` and `diff-cover` step
- [ ] diff-cover step only runs on pull_request events (skipped on push/merge_group)
- [ ] diff-cover correctly reports coverage on changed lines
- [ ] ty type-check job runs and reports results without blocking the workflow
- [ ] Branch coverage data appears in coverage reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)