### PR TITLE
docs/ci: Renode driver listing and conditional macOS Renode install

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.python }}
+      renode_driver: ${{ steps.filter.outputs.renode_driver }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,6 +32,8 @@ jobs:
             python:
               - 'python/**'
               - '.github/workflows/python-tests.yaml'
+            renode_driver:
+              - 'python/packages/jumpstarter-driver-renode/**'
 
   pytest-matrix:
     needs: changes
@@ -84,8 +87,14 @@ jobs:
         run: |
           brew install qemu
 
+      # Homebrew Renode is slow (~5+ minutes per job). Install on macOS only when this run
+      # touches the Renode driver, or on workflow_dispatch (full manual run). Linux still
+      # installs Renode from the .deb in all jobs (fast).
       - name: Install Renode (macOS)
-        if: runner.os == 'macOS'
+        if: >-
+          runner.os == 'macOS'
+          && (needs.changes.outputs.renode_driver == 'true'
+          || github.event_name == 'workflow_dispatch')
         run: |
           brew install renode/tap/renode
 

--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -98,6 +98,7 @@ Drivers for debugging and programming devices:
 * **[Android Emulator](androidemulator.md)** (`jumpstarter-driver-androidemulator`) -
   Android emulator lifecycle management with ADB tunneling
 * **[QEMU](qemu.md)** (`jumpstarter-driver-qemu`) - QEMU virtualization platform
+* **[Renode](renode.md)** (`jumpstarter-driver-renode`) - Renode embedded systems emulation
 * **[Corellium](corellium.md)** (`jumpstarter-driver-corellium`) - Corellium
   virtualization platform
 * **[U-Boot](uboot.md)** (`jumpstarter-driver-uboot`) - Universal Bootloader
@@ -136,6 +137,7 @@ power.md
 probe-rs.md
 pyserial.md
 qemu.md
+renode.md
 gpiod.md
 ridesx.md
 sdwire.md

--- a/python/packages/jumpstarter-driver-renode/README.md
+++ b/python/packages/jumpstarter-driver-renode/README.md
@@ -112,9 +112,6 @@ The `monitor` CLI subcommand is also available inside a `jmp shell` session.
 
 ## Design Decisions
 
-The architectural choices for this driver are documented in
-[ADR-0001: Renode Integration Approach](../../docs/source/contributing/adr/0001-renode-integration.md).
-
 Key decisions:
 
 - **Control interface**: Telnet monitor via `anyio.connect_tcp` (no


### PR DESCRIPTION
## Summary

### Documentation

- Register **Renode** (`jumpstarter-driver-renode`) in the drivers reference index and the hidden `toctree`, so `renode.md` (symlinked from the package README) is part of the Sphinx tree and the “document isn’t included in any toctree” warning goes away.
- Remove the **Design Decisions** paragraph that pointed at the old ADR path (`contributing/adr/0001-renode-integration.md`), which no longer exists and caused MyST xref failures under `make docs` (`-W`).

No change to the in-repo JEP under `docs/internal/jeps/`; we can add a link again once the team agrees on how to reference it from published docs.

### CI (Python Tests workflow)

- **macOS:** `brew install renode/tap/renode` is slow (~5+ minutes per job). It now runs only when the change set touches `python/packages/jumpstarter-driver-renode/**` (via `paths-filter`), or on **`workflow_dispatch`** so manual runs still get full coverage.
- **Linux:** unchanged; the `.deb` install remains for every matrix job (fast).

## Testing

- `make docs` (from `python/`)