### PR TITLE
fix(ci): point devcontainers Dependabot entry to correct directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
 
   # Devcontainers
   - package-ecosystem: "devcontainers"
-    directory: "/"
+    directory: "/python"
     schedule:
       interval: weekly
 


### PR DESCRIPTION
## Summary

- Fix Dependabot `devcontainers` ecosystem entry pointing at `/` instead of `/python`, where `.devcontainer/` actually lives
- This mismatch caused Dependabot to silently fail to find the devcontainer configuration

Closes #562

## Test plan

- [ ] Verify Dependabot no longer reports errors for the devcontainers ecosystem
- [ ] Confirm devcontainer dependency update PRs start appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)