### PR TITLE
jumpstarter-driver-gpio: Add read method required by PowerInterface

### DIFF
--- a/python/packages/jumpstarter-driver-gpiod/jumpstarter_driver_gpiod/driver.py
+++ b/python/packages/jumpstarter-driver-gpiod/jumpstarter_driver_gpiod/driver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Generator
 from dataclasses import dataclass, field
 
 try:
@@ -8,6 +9,7 @@ try:
 except ImportError:
     gpiod = None  # ty: ignore[invalid-assignment]
 
+from jumpstarter_driver_power.common import PowerReading
 from jumpstarter_driver_power.driver import PowerInterface
 
 from jumpstarter_driver_gpiod.client import PinState
@@ -236,3 +238,8 @@ class PowerSwitch(PowerInterface, DigitalOutput):
     def off(self) -> None:
         """Switch off the power"""
         DigitalOutput.off(self)
+
+    @export
+    def read(self) -> Generator[PowerReading, None, None]:
+        raise NotImplementedError
+        yield  # makes this a generator function


### PR DESCRIPTION
This addresses the following issue:
TypeError: Can't instantiate abstract class PowerSwitch without an implementation for abstract method 'read'

This adds the read method which return 0 power because we can't get this kind of data from a gpio.