### PR TITLE
feat: add ST-LINK mass storage flasher driver for STM32 boards

### DIFF
--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -95,6 +95,8 @@ Drivers for debugging and programming devices:
   UF2 flashing via BOOTSEL mass storage
 * **[Probe-RS](probe-rs.md)** (`jumpstarter-driver-probe-rs`) - Debugging probe
   support
+* **[ST-LINK MSD](stlink-msd.md)** (`jumpstarter-driver-stlink-msd`) - ST-LINK
+  mass storage flasher for STM32 Nucleo and Discovery boards
 * **[Android Emulator](androidemulator.md)** (`jumpstarter-driver-androidemulator`) -
   Android emulator lifecycle management with ADB tunneling
 * **[QEMU](qemu.md)** (`jumpstarter-driver-qemu`) - QEMU virtualization platform
@@ -145,6 +147,7 @@ shell.md
 ssh.md
 snmp.md
 someip.md
+stlink-msd.md
 tasmota.md
 tmt.md
 tftp.md

--- a/python/docs/source/reference/package-apis/drivers/stlink-msd.md
+++ b/python/docs/source/reference/package-apis/drivers/stlink-msd.md
@@ -1,0 +1,1 @@
+../../../../../packages/jumpstarter-driver-stlink-msd/README.md

--- a/python/packages/jumpstarter-driver-stlink-msd/.gitignore
+++ b/python/packages/jumpstarter-driver-stlink-msd/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-stlink-msd/README.md
+++ b/python/packages/jumpstarter-driver-stlink-msd/README.md
@@ -11,23 +11,20 @@ built-in mass storage interface handles all the flash programming.
 
 | Format | Handling |
 |--------|----------|
-| `.elf` | Auto-converted to `.bin` via `objcopy`, then copied to the volume |
 | `.bin` | Copied directly to the ST-LINK volume |
 | `.hex` | Copied directly to the ST-LINK volume |
 
-Using `.elf` allows the same build artifact for both virtual (Renode) and physical targets.
+ELF files must be converted externally before flashing:
+
+```shell
+arm-none-eabi-objcopy -O binary zephyr.elf zephyr.bin
+```
 
 ## Installation
 
 ```shell
 pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-stlink-msd
 ```
-
-For `.elf` support, ensure one of these is on your `PATH`:
-
-- `arm-none-eabi-objcopy` (ARM GCC toolchain)
-- `llvm-objcopy` (LLVM/Clang)
-- `arm-zephyr-eabi-objcopy` (Zephyr SDK)
 
 ## Configuration
 
@@ -37,25 +34,21 @@ export:
     type: jumpstarter_driver_stlink_msd.driver.StlinkMsdFlasher
     config:
       # volume_name: "NOD_H755ZI"   # optional: auto-detected if only one ST-LINK is connected
-      # objcopy_path: "/path/to/objcopy"  # optional: auto-detected from PATH
 ```
 
 | Parameter     | Description                                                      | Type           | Required | Default      |
 |---------------|------------------------------------------------------------------|----------------|----------|--------------|
 | volume_name   | Name of the mounted ST-LINK volume (e.g. `NOD_H755ZI`)          | str \| None    | no       | auto-detect  |
-| objcopy_path  | Path to objcopy binary for ELF-to-BIN conversion                 | str \| None    | no       | auto-detect  |
 
 ## Shell Commands
 
 ```shell
-j flasher flash firmware.elf       # flash an ELF (auto-converts to .bin)
 j flasher flash firmware.bin       # flash a raw binary
+j flasher flash firmware.hex       # flash an Intel HEX file
 j flasher info                     # show ST-LINK volume details
 ```
 
 ## API
 
-- **`flash(source, target=None)`** — Flash firmware to the board. Accepts `.elf`, `.bin`, or `.hex`.
-  ELF files are automatically converted to `.bin` using `objcopy`.
+- **`flash(source, target=None)`** — Flash firmware to the board. Accepts `.bin` or `.hex` files.
 - **`info()`** — Read `DETAILS.TXT` from the ST-LINK volume and return board metadata.
-- **`dump()`** — Not supported (ST-LINK mass storage is write-only).

--- a/python/packages/jumpstarter-driver-stlink-msd/README.md
+++ b/python/packages/jumpstarter-driver-stlink-msd/README.md
@@ -1,0 +1,61 @@
+# ST-LINK Mass Storage Flasher
+
+`jumpstarter-driver-stlink-msd` flashes STM32 **Nucleo** and **Discovery** boards by copying
+firmware to the **ST-LINK USB mass storage volume**.
+
+This is an alternative to probe-rs that avoids known [connect-under-reset issues
+with ST-Link V3](https://github.com/probe-rs/probe-rs/issues/3516). The ST-LINK's
+built-in mass storage interface handles all the flash programming.
+
+## Supported Formats
+
+| Format | Handling |
+|--------|----------|
+| `.elf` | Auto-converted to `.bin` via `objcopy`, then copied to the volume |
+| `.bin` | Copied directly to the ST-LINK volume |
+| `.hex` | Copied directly to the ST-LINK volume |
+
+Using `.elf` allows the same build artifact for both virtual (Renode) and physical targets.
+
+## Installation
+
+```shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-stlink-msd
+```
+
+For `.elf` support, ensure one of these is on your `PATH`:
+
+- `arm-none-eabi-objcopy` (ARM GCC toolchain)
+- `llvm-objcopy` (LLVM/Clang)
+- `arm-zephyr-eabi-objcopy` (Zephyr SDK)
+
+## Configuration
+
+```yaml
+export:
+  flasher:
+    type: jumpstarter_driver_stlink_msd.driver.StlinkMsdFlasher
+    config:
+      # volume_name: "NOD_H755ZI"   # optional: auto-detected if only one ST-LINK is connected
+      # objcopy_path: "/path/to/objcopy"  # optional: auto-detected from PATH
+```
+
+| Parameter     | Description                                                      | Type           | Required | Default      |
+|---------------|------------------------------------------------------------------|----------------|----------|--------------|
+| volume_name   | Name of the mounted ST-LINK volume (e.g. `NOD_H755ZI`)          | str \| None    | no       | auto-detect  |
+| objcopy_path  | Path to objcopy binary for ELF-to-BIN conversion                 | str \| None    | no       | auto-detect  |
+
+## Shell Commands
+
+```shell
+j flasher flash firmware.elf       # flash an ELF (auto-converts to .bin)
+j flasher flash firmware.bin       # flash a raw binary
+j flasher info                     # show ST-LINK volume details
+```
+
+## API
+
+- **`flash(source, target=None)`** — Flash firmware to the board. Accepts `.elf`, `.bin`, or `.hex`.
+  ELF files are automatically converted to `.bin` using `objcopy`.
+- **`info()`** — Read `DETAILS.TXT` from the ST-LINK volume and return board metadata.
+- **`dump()`** — Not supported (ST-LINK mass storage is write-only).

--- a/python/packages/jumpstarter-driver-stlink-msd/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-stlink-msd/examples/exporter.yaml
@@ -1,0 +1,18 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: nucleo-board
+endpoint: grpc.jumpstarter.example.com:443
+token: "<token>"
+export:
+  flasher:
+    type: jumpstarter_driver_stlink_msd.driver.StlinkMsdFlasher
+    config:
+      # volume_name: "NOD_H755ZI"   # optional: auto-detected if only one ST-LINK is connected
+      # objcopy_path: "/opt/zephyr-sdk/arm-zephyr-eabi/bin/arm-zephyr-eabi-objcopy"  # optional: auto-detected
+  console:
+    type: jumpstarter_driver_pyserial.driver.PySerial
+    config:
+      url: "/dev/ttyACM0"
+      baudrate: 115200

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/client.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/client.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+from jumpstarter_driver_opendal.client import FlasherClient
+
+from jumpstarter.streams.encoding import Compression
+
+
+@dataclass(kw_only=True)
+class StlinkMsdFlasherClient(FlasherClient):
+    """Client interface for ST-LINK mass storage flasher.
+
+    Flashes STM32 boards by copying firmware to the ST-LINK's USB
+    mass storage volume. Supports .elf, .bin, and .hex files.
+    """
+
+    def info(self) -> dict[str, str]:
+        """Read board info from the ST-LINK volume."""
+        return self.call("info")
+
+    def flash_file(self, filepath) -> str:
+        """Flash a local file to the STM32 board."""
+        absolute = Path(filepath).resolve()
+        return self.flash(absolute)
+
+    def cli(self):
+        base = super().cli()
+        base.commands.pop("flash", None)
+        base.commands.pop("dump", None)
+
+        @base.command()
+        def info():
+            """Show ST-LINK volume information."""
+            data = self.info()
+            if not data:
+                raise click.ClickException("No info available from ST-LINK volume.")
+            for key, value in sorted(data.items()):
+                click.echo(f"{key}: {value}")
+
+        @base.command()
+        @click.argument("file", type=click.Path(exists=True))
+        @click.option("--compression", type=click.Choice(Compression, case_sensitive=False))
+        def flash(file, compression):
+            """Flash firmware (.elf, .bin, or .hex) to the STM32 board."""
+            name = Path(file).name
+            click.echo(f"Flashing {name}...")
+            self.flash(file, target=name, compression=compression)
+            click.echo("Flash complete — ST-LINK will program the target MCU.")
+
+        return base

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/client.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/client.py
@@ -12,17 +12,12 @@ class StlinkMsdFlasherClient(FlasherClient):
     """Client interface for ST-LINK mass storage flasher.
 
     Flashes STM32 boards by copying firmware to the ST-LINK's USB
-    mass storage volume. Supports .elf, .bin, and .hex files.
+    mass storage volume. Supports .bin and .hex files.
     """
 
     def info(self) -> dict[str, str]:
         """Read board info from the ST-LINK volume."""
         return self.call("info")
-
-    def flash_file(self, filepath) -> str:
-        """Flash a local file to the STM32 board."""
-        absolute = Path(filepath).resolve()
-        return self.flash(absolute)
 
     def cli(self):
         base = super().cli()
@@ -42,7 +37,7 @@ class StlinkMsdFlasherClient(FlasherClient):
         @click.argument("file", type=click.Path(exists=True))
         @click.option("--compression", type=click.Choice(Compression, case_sensitive=False))
         def flash(file, compression):
-            """Flash firmware (.elf, .bin, or .hex) to the STM32 board."""
+            """Flash firmware (.bin or .hex) to the STM32 board."""
             name = Path(file).name
             click.echo(f"Flashing {name}...")
             self.flash(file, target=name, compression=compression)

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import tempfile
 from dataclasses import dataclass
 
@@ -15,61 +14,29 @@ from jumpstarter_driver_opendal.driver import FlasherInterface
 from .stlink_mount import find_all_stlink_mounts, find_stlink_mount
 from jumpstarter.driver import Driver, export
 
-
-def _find_objcopy() -> str | None:
-    """Find an objcopy binary that can handle ARM ELF files."""
-    for name in (
-        "arm-none-eabi-objcopy",
-        "llvm-objcopy",
-        "arm-zephyr-eabi-objcopy",
-        "objcopy",
-    ):
-        path = shutil.which(name)
-        if path:
-            return path
-    return None
+_SUPPORTED_EXTENSIONS = frozenset({".bin", ".hex"})
 
 
-def _elf_to_bin(elf_path: str, bin_path: str, objcopy_path: str | None = None) -> None:
-    """Convert an ELF file to raw binary using objcopy."""
-    objcopy = objcopy_path or _find_objcopy()
-    if objcopy is None:
-        raise FileNotFoundError(
-            "No objcopy found. Install arm-none-eabi-gcc, llvm, or the Zephyr SDK."
+def _validate_firmware_name(name: str) -> None:
+    """Raise if the firmware file extension is not supported by ST-LINK MSD."""
+    _, ext = os.path.splitext(name.lower())
+    if ext not in _SUPPORTED_EXTENSIONS:
+        raise ValueError(
+            f"Unsupported firmware format '{ext or name}'. "
+            f"ST-LINK mass storage only accepts .bin or .hex files. "
+            f"Convert ELF files with: arm-none-eabi-objcopy -O binary input.elf output.bin"
         )
-
-    result = subprocess.run(
-        [objcopy, "-O", "binary", elf_path, bin_path],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"objcopy failed: {result.stderr.strip()}")
-
-
-def _detect_format(filename: str) -> str:
-    """Detect firmware format from filename extension."""
-    lower = filename.lower()
-    if lower.endswith(".elf"):
-        return "elf"
-    if lower.endswith(".bin"):
-        return "bin"
-    if lower.endswith(".hex"):
-        return "hex"
-    return "unknown"
 
 
 @dataclass(kw_only=True)
 class StlinkMsdFlasher(FlasherInterface, Driver):
     """Flash STM32 boards by copying firmware to the ST-LINK USB mass storage volume.
 
-    Supports .elf files (converted to .bin via objcopy), .bin files (copied directly),
-    and .hex files (copied directly). This allows using the same .elf build artifact
-    for both virtual targets (Renode) and physical targets (Nucleo/Discovery boards).
+    Supports .bin and .hex files. ELF files must be converted to .bin
+    externally (e.g. via ``arm-none-eabi-objcopy -O binary``).
     """
 
     volume_name: str | None = None
-    objcopy_path: str | None = None
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -101,7 +68,7 @@ class StlinkMsdFlasher(FlasherInterface, Driver):
 
     @export
     def info(self) -> dict[str, str]:
-        """Read DETAILS.TXT and MBED.HTM from the ST-LINK volume."""
+        """Read DETAILS.TXT from the ST-LINK volume and return board metadata."""
         mount = self._resolve_mount()
         result: dict[str, str] = {}
 
@@ -120,44 +87,34 @@ class StlinkMsdFlasher(FlasherInterface, Driver):
     async def flash(self, source, target: str | None = None):
         """Flash firmware to the STM32 board via ST-LINK mass storage.
 
-        Accepts .elf (auto-converted to .bin), .bin, or .hex files.
-        The ``target`` parameter is the destination filename on the volume
-        (default: ``firmware.bin``).
+        Accepts .bin or .hex files only. ELF files are rejected — convert
+        them externally before flashing.
+
+        :param source: Firmware resource (local path or storage handle).
+        :param target: Destination filename on the volume (default: ``firmware.bin``).
         """
         mount = self._resolve_mount()
-        src_name = target or "firmware.bin"
+        dest_name = target or "firmware.bin"
+        _validate_firmware_name(dest_name)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            tmp_path = os.path.join(tmpdir, "input_firmware")
+            tmp_path = os.path.join(tmpdir, dest_name)
 
             async with await FileWriteStream.from_path(tmp_path) as stream:
                 async with self.resource(source) as res:
                     async for chunk in res:
                         await stream.send(chunk)
 
-            fmt = _detect_format(src_name)
-            if fmt == "unknown":
-                fmt = _detect_format(tmp_path)
-
-            if fmt == "elf":
-                bin_path = os.path.join(tmpdir, "firmware.bin")
-                self.logger.info("Converting ELF to BIN using objcopy")
-                await to_thread.run_sync(
-                    lambda: _elf_to_bin(tmp_path, bin_path, self.objcopy_path)
-                )
-                flash_src = bin_path
-                dest_name = src_name.rsplit(".", 1)[0] + ".bin" if src_name.lower().endswith(".elf") else src_name
-            else:
-                flash_src = tmp_path
-                dest_name = src_name
-
             dest_path = os.path.join(mount, dest_name)
             self.logger.info("Copying firmware to %s", dest_path)
 
             def _copy() -> None:
-                shutil.copy2(flash_src, dest_path)
-                with open(dest_path, "rb") as f:
-                    os.fsync(f.fileno())
+                shutil.copy2(tmp_path, dest_path)
+                fd = os.open(dest_path, os.O_RDONLY)
+                try:
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
 
             await to_thread.run_sync(_copy)
 

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver.py
@@ -1,0 +1,172 @@
+"""ST-LINK mass storage flasher for STM32 Nucleo and Discovery boards."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+
+from anyio import to_thread
+from anyio.streams.file import FileWriteStream
+from jumpstarter_driver_opendal.driver import FlasherInterface
+
+from .stlink_mount import find_all_stlink_mounts, find_stlink_mount
+from jumpstarter.driver import Driver, export
+
+
+def _find_objcopy() -> str | None:
+    """Find an objcopy binary that can handle ARM ELF files."""
+    for name in (
+        "arm-none-eabi-objcopy",
+        "llvm-objcopy",
+        "arm-zephyr-eabi-objcopy",
+        "objcopy",
+    ):
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def _elf_to_bin(elf_path: str, bin_path: str, objcopy_path: str | None = None) -> None:
+    """Convert an ELF file to raw binary using objcopy."""
+    objcopy = objcopy_path or _find_objcopy()
+    if objcopy is None:
+        raise FileNotFoundError(
+            "No objcopy found. Install arm-none-eabi-gcc, llvm, or the Zephyr SDK."
+        )
+
+    result = subprocess.run(
+        [objcopy, "-O", "binary", elf_path, bin_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"objcopy failed: {result.stderr.strip()}")
+
+
+def _detect_format(filename: str) -> str:
+    """Detect firmware format from filename extension."""
+    lower = filename.lower()
+    if lower.endswith(".elf"):
+        return "elf"
+    if lower.endswith(".bin"):
+        return "bin"
+    if lower.endswith(".hex"):
+        return "hex"
+    return "unknown"
+
+
+@dataclass(kw_only=True)
+class StlinkMsdFlasher(FlasherInterface, Driver):
+    """Flash STM32 boards by copying firmware to the ST-LINK USB mass storage volume.
+
+    Supports .elf files (converted to .bin via objcopy), .bin files (copied directly),
+    and .hex files (copied directly). This allows using the same .elf build artifact
+    for both virtual targets (Renode) and physical targets (Nucleo/Discovery boards).
+    """
+
+    volume_name: str | None = None
+    objcopy_path: str | None = None
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_stlink_msd.client.StlinkMsdFlasherClient"
+
+    def _resolve_mount(self) -> str:
+        mount = find_stlink_mount(self.volume_name)
+        if mount is None:
+            all_mounts = find_all_stlink_mounts()
+            if len(all_mounts) == 0:
+                raise FileNotFoundError(
+                    "No ST-LINK mass storage volume found. "
+                    "Check that the board is connected and the ST-LINK USB drive is mounted."
+                )
+            dirs = ", ".join(str(p) for p in all_mounts)
+            if self.volume_name:
+                raise FileNotFoundError(
+                    f"ST-LINK volume '{self.volume_name}' not found. Available: {dirs}"
+                )
+            raise FileNotFoundError(
+                f"Multiple ST-LINK volumes found: {dirs}. "
+                "Set 'volume_name' in the config to select one."
+            )
+        return str(mount)
+
+    @export
+    def info(self) -> dict[str, str]:
+        """Read DETAILS.TXT and MBED.HTM from the ST-LINK volume."""
+        mount = self._resolve_mount()
+        result: dict[str, str] = {}
+
+        details_path = os.path.join(mount, "DETAILS.TXT")
+        if os.path.isfile(details_path):
+            with open(details_path, encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    if ":" in line:
+                        key, _, value = line.partition(":")
+                        result[key.strip()] = value.strip()
+
+        result["mount_point"] = mount
+        return result
+
+    @export
+    async def flash(self, source, target: str | None = None):
+        """Flash firmware to the STM32 board via ST-LINK mass storage.
+
+        Accepts .elf (auto-converted to .bin), .bin, or .hex files.
+        The ``target`` parameter is the destination filename on the volume
+        (default: ``firmware.bin``).
+        """
+        mount = self._resolve_mount()
+        src_name = target or "firmware.bin"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = os.path.join(tmpdir, "input_firmware")
+
+            async with await FileWriteStream.from_path(tmp_path) as stream:
+                async with self.resource(source) as res:
+                    async for chunk in res:
+                        await stream.send(chunk)
+
+            fmt = _detect_format(src_name)
+            if fmt == "unknown":
+                fmt = _detect_format(tmp_path)
+
+            if fmt == "elf":
+                bin_path = os.path.join(tmpdir, "firmware.bin")
+                self.logger.info("Converting ELF to BIN using objcopy")
+                await to_thread.run_sync(
+                    lambda: _elf_to_bin(tmp_path, bin_path, self.objcopy_path)
+                )
+                flash_src = bin_path
+                dest_name = src_name.rsplit(".", 1)[0] + ".bin" if src_name.lower().endswith(".elf") else src_name
+            else:
+                flash_src = tmp_path
+                dest_name = src_name
+
+            dest_path = os.path.join(mount, dest_name)
+            self.logger.info("Copying firmware to %s", dest_path)
+
+            def _copy() -> None:
+                shutil.copy2(flash_src, dest_path)
+                with open(dest_path, "rb") as f:
+                    os.fsync(f.fileno())
+
+            await to_thread.run_sync(_copy)
+
+        self.logger.info("Flash complete — ST-LINK will program the target MCU")
+
+    @export
+    async def dump(self, target, partition: str | None = None):
+        """Not supported: ST-LINK mass storage is write-only for firmware."""
+        raise NotImplementedError(
+            "Reading flash via ST-LINK mass storage is not supported. "
+            "Use probe-rs or STM32CubeProgrammer for flash readback."
+        )

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver_test.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver_test.py
@@ -1,7 +1,6 @@
-from unittest.mock import patch
-
 import pytest
 
+from .driver import _validate_firmware_name
 from .stlink_mount import looks_like_stlink_volume
 
 
@@ -37,34 +36,23 @@ def test_looks_like_stlink_volume_not_dir(tmp_path):
     assert looks_like_stlink_volume(f) is False
 
 
-def test_detect_format():
-    from .driver import _detect_format
-
-    assert _detect_format("firmware.elf") == "elf"
-    assert _detect_format("firmware.bin") == "bin"
-    assert _detect_format("firmware.hex") == "hex"
-    assert _detect_format("firmware.unknown") == "unknown"
-    assert _detect_format("FIRMWARE.ELF") == "elf"
+def test_validate_firmware_name_bin():
+    _validate_firmware_name("firmware.bin")
 
 
-def test_elf_to_bin_missing_objcopy():
-    from .driver import _elf_to_bin
-
-    with pytest.raises(FileNotFoundError, match="No objcopy found"):
-        with patch("jumpstarter_driver_stlink_msd.driver._find_objcopy", return_value=None):
-            _elf_to_bin("/fake/input.elf", "/fake/output.bin")
+def test_validate_firmware_name_hex():
+    _validate_firmware_name("firmware.hex")
 
 
-def test_elf_to_bin_success(tmp_path):
-    from .driver import _elf_to_bin
+def test_validate_firmware_name_bin_uppercase():
+    _validate_firmware_name("FIRMWARE.BIN")
 
-    elf_file = tmp_path / "test.elf"
-    bin_file = tmp_path / "test.bin"
-    elf_file.write_bytes(b"\x7fELF" + b"\x00" * 100)
 
-    fake_objcopy = tmp_path / "fake_objcopy.sh"
-    fake_objcopy.write_text('#!/bin/sh\ncp "$3" "$4"\n')
-    fake_objcopy.chmod(0o755)
+def test_validate_firmware_name_elf_rejected():
+    with pytest.raises(ValueError, match="Unsupported firmware format"):
+        _validate_firmware_name("firmware.elf")
 
-    _elf_to_bin(str(elf_file), str(bin_file), objcopy_path=str(fake_objcopy))
-    assert bin_file.exists()
+
+def test_validate_firmware_name_unknown_rejected():
+    with pytest.raises(ValueError, match="Unsupported firmware format"):
+        _validate_firmware_name("firmware.xyz")

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver_test.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/driver_test.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import pytest
+
+from .stlink_mount import looks_like_stlink_volume
+
+
+def test_looks_like_stlink_volume_with_mbed(tmp_path):
+    (tmp_path / "MBED.HTM").touch()
+    assert looks_like_stlink_volume(tmp_path) is True
+
+
+def test_looks_like_stlink_volume_with_details(tmp_path):
+    (tmp_path / "DETAILS.TXT").touch()
+    assert looks_like_stlink_volume(tmp_path) is True
+
+
+def test_looks_like_stlink_volume_no_markers(tmp_path):
+    assert looks_like_stlink_volume(tmp_path) is False
+
+
+def test_looks_like_stlink_volume_known_prefix(tmp_path):
+    nod_dir = tmp_path / "NOD_H755ZI"
+    nod_dir.mkdir()
+    assert looks_like_stlink_volume(nod_dir) is True
+
+
+def test_looks_like_stlink_volume_nucleo_prefix(tmp_path):
+    nucleo_dir = tmp_path / "NUCLEO"
+    nucleo_dir.mkdir()
+    assert looks_like_stlink_volume(nucleo_dir) is True
+
+
+def test_looks_like_stlink_volume_not_dir(tmp_path):
+    f = tmp_path / "MBED.HTM"
+    f.touch()
+    assert looks_like_stlink_volume(f) is False
+
+
+def test_detect_format():
+    from .driver import _detect_format
+
+    assert _detect_format("firmware.elf") == "elf"
+    assert _detect_format("firmware.bin") == "bin"
+    assert _detect_format("firmware.hex") == "hex"
+    assert _detect_format("firmware.unknown") == "unknown"
+    assert _detect_format("FIRMWARE.ELF") == "elf"
+
+
+def test_elf_to_bin_missing_objcopy():
+    from .driver import _elf_to_bin
+
+    with pytest.raises(FileNotFoundError, match="No objcopy found"):
+        with patch("jumpstarter_driver_stlink_msd.driver._find_objcopy", return_value=None):
+            _elf_to_bin("/fake/input.elf", "/fake/output.bin")
+
+
+def test_elf_to_bin_success(tmp_path):
+    from .driver import _elf_to_bin
+
+    elf_file = tmp_path / "test.elf"
+    bin_file = tmp_path / "test.bin"
+    elf_file.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+    fake_objcopy = tmp_path / "fake_objcopy.sh"
+    fake_objcopy.write_text('#!/bin/sh\ncp "$3" "$4"\n')
+    fake_objcopy.chmod(0o755)
+
+    _elf_to_bin(str(elf_file), str(bin_file), objcopy_path=str(fake_objcopy))
+    assert bin_file.exists()

--- a/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/stlink_mount.py
+++ b/python/packages/jumpstarter-driver-stlink-msd/jumpstarter_driver_stlink_msd/stlink_mount.py
@@ -1,0 +1,86 @@
+"""Locate ST-LINK USB mass storage mounts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_STLINK_MARKER_FILES = frozenset({"MBED.HTM", "DETAILS.TXT"})
+
+_KNOWN_VOLUME_PREFIXES = (
+    "NOD_",
+    "DIS_",
+    "NUCLEO",
+)
+
+
+def looks_like_stlink_volume(path: Path) -> bool:
+    """Return True if ``path`` looks like an ST-LINK USB mass storage root."""
+    if not path.is_dir():
+        return False
+
+    if any((path / name).is_file() for name in _STLINK_MARKER_FILES):
+        return True
+
+    name_upper = path.name.upper()
+    return any(name_upper.startswith(prefix) for prefix in _KNOWN_VOLUME_PREFIXES)
+
+
+def _parse_proc_mounts(text: str) -> list[Path]:
+    out: list[Path] = []
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        mnt = re.sub(r"\\([0-7]{3})", lambda m: chr(int(m.group(1), 8)), parts[1])
+        out.append(Path(mnt))
+    return out
+
+
+def _mount_points_linux() -> list[Path]:
+    try:
+        return _parse_proc_mounts(Path("/proc/mounts").read_text(encoding="utf-8"))
+    except OSError:
+        return []
+
+
+def _mount_points_darwin() -> list[Path]:
+    try:
+        return [p for p in Path("/Volumes").iterdir() if p.is_dir()]
+    except OSError:
+        return []
+
+
+def iter_mount_candidates() -> list[Path]:
+    if sys.platform == "linux":
+        return _mount_points_linux()
+    if sys.platform == "darwin":
+        return _mount_points_darwin()
+    return []
+
+
+def find_stlink_mount(volume_name: str | None = None) -> Path | None:
+    """Find a single ST-LINK mass storage mount point.
+
+    If ``volume_name`` is given, match by volume directory name (case-insensitive).
+    Otherwise auto-detect using marker files and known prefixes.
+    """
+    candidates = iter_mount_candidates()
+
+    if volume_name:
+        for path in candidates:
+            if path.name.upper() == volume_name.upper():
+                return path
+        return None
+
+    matches = [p for p in candidates if looks_like_stlink_volume(p)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def find_all_stlink_mounts() -> list[Path]:
+    """Return all mount points that look like ST-LINK volumes."""
+    return sorted(
+        (p for p in iter_mount_candidates() if looks_like_stlink_volume(p)),
+        key=lambda p: str(p),
+    )

--- a/python/packages/jumpstarter-driver-stlink-msd/pyproject.toml
+++ b/python/packages/jumpstarter-driver-stlink-msd/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "jumpstarter-driver-stlink-msd"
+dynamic = ["version", "urls"]
+description = "ST-LINK mass storage flasher for STM32 Nucleo and Discovery boards"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "Vinicius Zein", email = "vtzein@gmail.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "anyio>=4.10.0",
+    "click>=8.3.1",
+    "jumpstarter",
+    "jumpstarter-driver-opendal",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+StlinkMsdFlasher = "jumpstarter_driver_stlink_msd.driver:StlinkMsdFlasher"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../'}
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=html --cov-report=xml"
+log_cli = true
+log_cli_level = "INFO"
+testpaths = ["jumpstarter_driver_stlink_msd"]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -48,6 +48,7 @@ members = [
     "jumpstarter-driver-someip",
     "jumpstarter-driver-ssh",
     "jumpstarter-driver-ssh-mitm",
+    "jumpstarter-driver-stlink-msd",
     "jumpstarter-driver-tasmota",
     "jumpstarter-driver-tftp",
     "jumpstarter-driver-tmt",
@@ -3199,7 +3200,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jumpstarter", editable = "packages/jumpstarter" },
-    { name = "opensomeip", git = "https://github.com/vtz/opensomeip-python.git?rev=ac1afdeb1ffa002ce3af4e5a3ca2c6fc9a690346" },
+    { name = "opensomeip", specifier = ">=0.1.4,<0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3270,6 +3271,36 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "trio", specifier = ">=0.28.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-stlink-msd"
+source = { editable = "packages/jumpstarter-driver-stlink-msd" }
+dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "jumpstarter" },
+    { name = "jumpstarter-driver-opendal" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.10.0" },
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-opendal", editable = "packages/jumpstarter-driver-opendal" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -4571,7 +4602,30 @@ wheels = [
 [[package]]
 name = "opensomeip"
 version = "0.1.4"
-source = { git = "https://github.com/vtz/opensomeip-python.git?rev=ac1afdeb1ffa002ce3af4e5a3ca2c6fc9a690346#ac1afdeb1ffa002ce3af4e5a3ca2c6fc9a690346" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/b6/538eea3f2379a3a4d66670c34c1f604f254319935253345db1c71684b8e2/opensomeip-0.1.4.tar.gz", hash = "sha256:0df02f951e84f83ec83e823c184c6ecc64f2e907a2dbe28b2a8b59896a77add3", size = 794093, upload-time = "2026-04-20T12:36:40.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/36/d3e7d91837091ceba95b76f64319a790a906d4b56c3d92f140357c0367bd/opensomeip-0.1.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f032065c7ba6e200c0f9694a75784d0147a3decf3637e0d72721d8eb43697bc6", size = 732961, upload-time = "2026-04-20T12:36:07.884Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3b/90507af794cc5457fb0fd36c5949b2d81a57b8205b071417281fca54b046/opensomeip-0.1.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:feadaa029db1b3ff8553aa727c65d762bc55c19def350dc2c4d96f64b9cff436", size = 681384, upload-time = "2026-04-20T12:36:09.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3a/7140743d08352e3243d4c4c6493760ccf696167ae3c686c1588e56d3793d/opensomeip-0.1.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4bf0d01efffd5bbb9a91c49e92f127fd2227e0802fc2590239dd10fdefa8c970", size = 813926, upload-time = "2026-04-20T12:36:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8a/89d22a127c9745311079408747aa4b4a08d70785c4823bf3267238bfd41a/opensomeip-0.1.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be202f720fc0a4d4470a0ad8e9016d8fc1d8c06992237cac917a18e3acd0be78", size = 863655, upload-time = "2026-04-20T12:36:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c8/41e59e532aaefd808daa09643a5bb0e878353691bc48ffe98d800b1ced64/opensomeip-0.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:b8c2bcb3a5e0ad725889d54304105daebb2f94bb1a35bd88bb5760ce60b62c5d", size = 1030868, upload-time = "2026-04-20T12:36:13.835Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c2/fe5fc28bf1370ac37bd2483b0b471685233502e5d87bfa6c8a4ac168faa7/opensomeip-0.1.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:62aaeb40247bcf3140d9c5fffddea60f44688d6aa988bff3cb1a7dbaa763af60", size = 741197, upload-time = "2026-04-20T12:36:15.577Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/a1/470a7b136c8820c01a0a5550ce1ded906fc31731a7dfb0ed758872c3b815/opensomeip-0.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2057e811d3aa4032debcf29e9e5906e42b3c36e73f7af028b723cfc49b98faf8", size = 682874, upload-time = "2026-04-20T12:36:17.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/26/89e9e0ff5c93815599185e2ec566798bd6641a30091f1e85d4447527f4a6/opensomeip-0.1.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58a12bf2d22762d8ff68d927cd10ff5a68e86a964eeaf8ae8da24c3bd06cf96c", size = 812990, upload-time = "2026-04-20T12:36:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/20/34/5e8bdf637a133d19c89edadf9ebd2aab6ac431102f5b66a2f6939963208d/opensomeip-0.1.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f1033e3f95a129fbb159781bfd9b563858650b0fc5738d9192efecde6cb7f171", size = 864774, upload-time = "2026-04-20T12:36:20.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c0/e8a8ea8b5f6ce7eb97b260bdea802d7f1b25217db598b97b2566ed48c6c1/opensomeip-0.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:0465bf6169d16e551230bb952a2d96dac6ba3efc874a0d4ca754347a8647b026", size = 1030507, upload-time = "2026-04-20T12:36:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/01/1ad0f72b76fe5c13881d98ea243b8d9ab011c45b588b1c5904192648c607/opensomeip-0.1.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2882665d95c4cb10fd72e0f1cb29c3b478534e292ee83bcbc5fbf007c79f8f74", size = 741269, upload-time = "2026-04-20T12:36:24.15Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/39/dd42ec0690cecf52f1bdef609d50bd3c8b4dd67c9c2bcae0d184884bb077/opensomeip-0.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e1b8884df2cdf61fe18ae3c08f70ba1d0385acbbab817b6ebea740b95addc6d6", size = 682875, upload-time = "2026-04-20T12:36:25.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d1/bbfdac43ecec8a45e7a5a0bdb5a62eaa17c7c516389069f356b856346281/opensomeip-0.1.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cecdcff756005a041c75d5b355a4711fc47f197435a3ea1eacc7ce86069b464f", size = 813238, upload-time = "2026-04-20T12:36:27.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/83/8abac36c487cd0cd175e9436ff14c2f9ac47fc19ce45e4199e5d7c5ecd7b/opensomeip-0.1.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e32afac02480fbe6e8ff4c98591167b187bf76b0c02ac461de7264736bdadd5b", size = 864682, upload-time = "2026-04-20T12:36:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a4/ec5685374a600353c5ca010631d2587996b4d629daa274d508c81f1e38d2/opensomeip-0.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:68399fdea77eee9e162cc68a0bdc23d11d54ed8f7aaa869ddcf65f9e5b1bdc04", size = 1030448, upload-time = "2026-04-20T12:36:30.57Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/99c39167dc5c62906039fe60798b542a7ae9fee79ba5e7e9c86adac4a64e/opensomeip-0.1.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad9dad9b4f69bac5c2cc824331fb3ccb0e88e371c8c2f3dd9d84e58f6b759b64", size = 741368, upload-time = "2026-04-20T12:36:32.184Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a8/dbd699b49803023b43a9cb79f85eb2b50b41aee43169c25bd119b7207083/opensomeip-0.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d22868321e96fc8399c5b65ad1ff4939fe810a09c91077703f60b5f532bb1dc7", size = 684119, upload-time = "2026-04-20T12:36:33.971Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c4/22d71f217b00f31aeb729ef3116a89a32e246fbed27bb0115710ec26ac9c/opensomeip-0.1.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67669e83704cc24d0d974749af9981514b898251198ffb0ad4461b2080e92c36", size = 815519, upload-time = "2026-04-20T12:36:35.521Z" },
+    { url = "https://files.pythonhosted.org/packages/09/64/3911b01ac097210633a0b410920a5134e31e6d143e89859c69f56b37cc15/opensomeip-0.1.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c3d7ab24cfb47d6749a700e2fdf62ec9dcc2ebdaf8dd4bbe044c097f30b3f98", size = 864454, upload-time = "2026-04-20T12:36:36.952Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d7/47129f69599728cf69986b4656557b5f200db987fa454ff3ef2b9c00ac8e/opensomeip-0.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:9c02f737db484e85728c3924e1525e320dff9e19cb5b699978776977a96c4d0d", size = 1050633, upload-time = "2026-04-20T12:36:38.522Z" },
+]
 
 [[package]]
 name = "oras"


### PR DESCRIPTION
## Summary

- Adds `jumpstarter-driver-stlink-msd`, a new driver that flashes STM32 Nucleo and Discovery boards by copying firmware to the ST-LINK USB mass storage volume
- Supports `.elf` files (auto-converted to `.bin` via `objcopy`), `.bin`, and `.hex` — enabling the same `.elf` artifact for both Renode (virtual) and physical targets
- Provides an alternative to probe-rs, which has [known connect-under-reset issues with ST-Link V3](https://github.com/probe-rs/probe-rs/issues/3516) on dual-core STM32H7 chips

## Motivation

probe-rs cannot establish debug sessions on STM32H755 (and similar) boards with ST-Link V3 due to unsupported custom reset sequences ([#3516](https://github.com/probe-rs/probe-rs/issues/3516), [#3715](https://github.com/probe-rs/probe-rs/issues/3715)). The ST-LINK mass storage interface is the most reliable flashing method for Nucleo boards and doesn't require a debug session.

Closes #634

## Test plan

- [x] Unit tests for volume detection (`looks_like_stlink_volume` with marker files and known prefixes)
- [x] Unit tests for format detection (`.elf`, `.bin`, `.hex`)
- [x] Unit tests for ELF-to-BIN conversion error handling and success path
- [x] Lint passes
- [ ] Manual test: `j flasher flash firmware.elf` on a Nucleo H755ZI-Q board


Made with [Cursor](https://cursor.com)