### PR TITLE
fix: preserve percent-encoding in presigned URLs to prevent signature invalidation

### DIFF
--- a/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/adapter.py
+++ b/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/adapter.py
@@ -64,9 +64,19 @@ async def OpendalAdapter(
     path: str,  # file path in storage backend relative to the storage root
     mode: Literal["rb", "wb"] = "rb",  # binary read or binary write mode
     compression: Compression | None = None,  # compression algorithm
+    original_url: str | None = None,  # original HTTP URL, bypasses OpenDAL presign to avoid path re-encoding
 ):
+    if original_url is not None and compression is not None:
+        raise ValueError("compression is not supported with direct HTTP URLs (original_url)")
+    if mode == "wb" and original_url is not None:
+        raise ValueError("original_url is not supported in write mode")
+    if mode == "rb" and compression is None and original_url is not None:
+        yield PresignedRequestResource(
+            headers={}, url=original_url, method="GET"
+        ).model_dump(mode="json")
+        return
     # if the access mode is binary read, and the storage backend supports presigned read requests
-    if mode == "rb" and operator.capability().presign_read and compression is None:
+    elif mode == "rb" and operator.capability().presign_read and compression is None:
         # create presigned url for the specified file with a 60 second expiration
         presigned = await operator.to_async_operator().presign_read(path, expire_second=60)
         yield PresignedRequestResource(

--- a/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/client.py
+++ b/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/client.py
@@ -51,7 +51,7 @@ def operator_for_path(path: PathBuf) -> tuple[PathBuf, Operator, str]:
         - the operator for the given path
         - the scheme of the operator.
     """
-    if type(path) is str and path.startswith(("http://", "https://")):
+    if isinstance(path, str) and path.startswith(("http://", "https://")):
         parsed_url = urlparse(path)
         operator = Operator("http", root="/", endpoint=f"{parsed_url.scheme}://{parsed_url.netloc}")
         return Path(parsed_url.path), operator, "http"
@@ -79,10 +79,13 @@ class OpendalFile:
         """
         Write into remote file with content from local file
         """
+        original_url = None
         if operator is None:
+            if isinstance(path, str) and path.startswith(("http://", "https://")):
+                original_url = path
             path, operator, _ = operator_for_path(path)
 
-        with OpendalAdapter(client=self.client, operator=operator, path=path) as handle:
+        with OpendalAdapter(client=self.client, operator=operator, path=path, original_url=original_url) as handle:
             return self.__write(handle)
 
     @validate_call(validate_return=True, config=ConfigDict(arbitrary_types_allowed=True))
@@ -630,10 +633,15 @@ class FlasherClient(FlasherClientInterface, DriverClient):
         compression: Compression | None,
     ):
         """Flash image to DUT"""
+        original_url = None
         if operator is None:
+            if isinstance(image, str) and image.startswith(("http://", "https://")):
+                original_url = image
             image, operator, _ = operator_for_path(image)
 
-        with OpendalAdapter(client=self, operator=operator, path=image, mode="rb", compression=compression) as handle:
+        with OpendalAdapter(
+            client=self, operator=operator, path=image, mode="rb", compression=compression, original_url=original_url
+        ) as handle:
             return self.call("flash", handle, target)
 
     def flash(
@@ -763,10 +771,15 @@ class StorageMuxFlasherClient(FlasherClient, StorageMuxClient):
 
         self.host()
 
+        original_url = None
         if operator is None:
+            if isinstance(path, str) and path.startswith(("http://", "https://")):
+                original_url = path
             path, operator, _ = operator_for_path(path)
 
-        with OpendalAdapter(client=self, operator=operator, path=path, mode="rb", compression=compression) as handle:
+        with OpendalAdapter(
+            client=self, operator=operator, path=path, mode="rb", compression=compression, original_url=original_url
+        ) as handle:
             try:
                 return self.write(handle)
             finally:

--- a/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/driver_test.py
+++ b/python/packages/jumpstarter-driver-opendal/jumpstarter_driver_opendal/driver_test.py
@@ -12,6 +12,7 @@ from opendal import Operator
 
 from .common import PresignedRequest
 from .driver import MockFlasher, MockStorageMux, MockStorageMuxFlasher, Opendal
+from jumpstarter.client.core import DriverError
 from jumpstarter.common.utils import serve
 
 
@@ -322,3 +323,290 @@ def test_copy_and_rename_tracking(tmp_path):
     assert "copied_dir" in created_paths
     assert "renamed_dir" in created_paths
     assert len(created_paths) == 4
+
+
+def test_flash_http_url_preserves_percent_encoding():
+    """Flashing from HTTP URL with percent-encoded path must preserve encoding.
+
+    Without _make_url(encoded=True), yarl.URL decodes %40 to @ in the path,
+    so the HTTP request hits a different URL than intended. Presigned URL
+    signatures (S3, CloudFront) are computed over the encoded form and would
+    be rejected.
+    """
+    received_paths = []
+
+    class EncodingCheckHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+
+        def do_GET(self):
+            received_paths.append(self.path)
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+            self.wfile.write(b"test")
+
+        def log_message(self, format, *args):
+            pass
+
+    with serve(MockFlasher()) as flasher:
+        server = HTTPServer(("127.0.0.1", 0), EncodingCheckHandler)
+        port = server.server_address[1]
+        server_thread = Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            flasher.flash(f"http://127.0.0.1:{port}/path%40encoded/file.bin")
+
+            assert len(received_paths) >= 1
+            assert "%40" in received_paths[-1], (
+                f"Server received decoded path {received_paths[-1]!r} — "
+                f"_make_url is not preserving percent-encoding"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)
+
+
+def test_flash_http_redirect_preserves_percent_encoding():
+    """When a presigned URL returns a redirect, encoding in Location must be preserved.
+
+    aiohttp's automatic redirect following re-parses Location through yarl.URL(),
+    decoding %40 to @. The fix disables auto-redirect and manually follows with
+    _make_url(encoded=True).
+    """
+    received_paths = []
+
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+
+        def do_GET(self):
+            received_paths.append(self.path)
+            if self.path.startswith("/start"):
+                port = self.server.server_address[1]
+                self.send_response(302)
+                self.send_header(
+                    "Location",
+                    f"http://127.0.0.1:{port}/redirect%40target/file.bin",
+                )
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("content-length", "4")
+                self.end_headers()
+                self.wfile.write(b"test")
+
+        def log_message(self, format, *args):
+            pass
+
+    with serve(MockFlasher()) as flasher:
+        server = HTTPServer(("127.0.0.1", 0), RedirectHandler)
+        port = server.server_address[1]
+        server_thread = Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            flasher.flash(f"http://127.0.0.1:{port}/start")
+
+            assert len(received_paths) == 2, (
+                f"Expected 2 requests (initial + redirect), got {len(received_paths)}"
+            )
+            assert received_paths[0] == "/start"
+            assert "%40" in received_paths[1], (
+                f"Redirect target received decoded path {received_paths[1]!r} — "
+                f"redirect following is not preserving percent-encoding"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)
+
+
+def test_flash_http_chained_redirects_preserve_percent_encoding():
+    """Chained redirects (A->B->C) must all preserve percent-encoding."""
+    received_paths = []
+
+    class ChainedRedirectHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+
+        def do_GET(self):
+            received_paths.append(self.path)
+            port = self.server.server_address[1]
+            if self.path.startswith("/hop1"):
+                self.send_response(302)
+                self.send_header(
+                    "Location",
+                    f"http://127.0.0.1:{port}/hop2%40middle/file.bin",
+                )
+                self.end_headers()
+            elif self.path.startswith("/hop2"):
+                self.send_response(302)
+                self.send_header(
+                    "Location",
+                    f"http://127.0.0.1:{port}/hop3%40final/file.bin",
+                )
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("content-length", "4")
+                self.end_headers()
+                self.wfile.write(b"test")
+
+        def log_message(self, format, *args):
+            pass
+
+    with serve(MockFlasher()) as flasher:
+        server = HTTPServer(("127.0.0.1", 0), ChainedRedirectHandler)
+        port = server.server_address[1]
+        server_thread = Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            flasher.flash(f"http://127.0.0.1:{port}/hop1")
+
+            assert len(received_paths) == 3, (
+                f"Expected 3 requests (hop1 + hop2 + hop3), got {len(received_paths)}"
+            )
+            assert received_paths[0] == "/hop1"
+            assert "%40" in received_paths[1], (
+                f"Hop 2 received decoded path {received_paths[1]!r}"
+            )
+            assert "%40" in received_paths[2], (
+                f"Hop 3 received decoded path {received_paths[2]!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+def test_flash_http_redirect_all_status_codes(status_code):
+    """All redirect status codes (301, 302, 303, 307, 308) must be followed with encoding preserved."""
+    received_paths = []
+
+    class StatusCodeRedirectHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+
+        def do_GET(self):
+            received_paths.append(self.path)
+            if self.path.startswith("/start"):
+                port = self.server.server_address[1]
+                self.send_response(status_code)
+                self.send_header(
+                    "Location",
+                    f"http://127.0.0.1:{port}/target%40encoded/file.bin",
+                )
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("content-length", "4")
+                self.end_headers()
+                self.wfile.write(b"test")
+
+        def log_message(self, format, *args):
+            pass
+
+    with serve(MockFlasher()) as flasher:
+        server = HTTPServer(("127.0.0.1", 0), StatusCodeRedirectHandler)
+        port = server.server_address[1]
+        server_thread = Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            flasher.flash(f"http://127.0.0.1:{port}/start")
+
+            assert len(received_paths) == 2
+            assert received_paths[0] == "/start"
+            assert "%40" in received_paths[1], (
+                f"Status {status_code}: redirect target received decoded path {received_paths[1]!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)
+
+
+def test_flash_http_redirect_loop_raises():
+    """Redirect loop must raise RuntimeError after max_redirects."""
+
+    class LoopRedirectHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+
+        def do_GET(self):
+            port = self.server.server_address[1]
+            self.send_response(302)
+            self.send_header(
+                "Location",
+                f"http://127.0.0.1:{port}/loop",
+            )
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    with serve(MockFlasher()) as flasher:
+        server = HTTPServer(("127.0.0.1", 0), LoopRedirectHandler)
+        port = server.server_address[1]
+        server_thread = Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            with pytest.raises(DriverError, match="Too many redirects"):
+                flasher.flash(f"http://127.0.0.1:{port}/loop")
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)
+
+
+def test_flash_http_redirect_missing_location_raises():
+    """302 without Location header must raise RuntimeError."""
+
+    class NoLocationHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("content-length", "4")
+            self.end_headers()
+
+        def do_GET(self):
+            self.send_response(302)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    with serve(MockFlasher()) as flasher:
+        server = HTTPServer(("127.0.0.1", 0), NoLocationHandler)
+        port = server.server_address[1]
+        server_thread = Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        try:
+            with pytest.raises(DriverError, match="missing Location header"):
+                flasher.flash(f"http://127.0.0.1:{port}/start")
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
@@ -47,7 +47,7 @@ class RideSXClient(FlasherClient, CompositeClient):
                 self.logger.info(f"Uploading {file_path} to storage as {filename}")
 
             try:
-                self.storage.write_from_path(filename, path_buf, operator=operator)
+                self.storage.write_from_path(filename, file_path, operator=operator)
             except Exception as e:
                 raise RideSXFlashError(
                     f"Failed to transfer '{file_path}' to exporter storage as '{filename}' (scheme={operator_scheme})"

--- a/python/packages/jumpstarter/jumpstarter/driver/base.py
+++ b/python/packages/jumpstarter/jumpstarter/driver/base.py
@@ -12,9 +12,11 @@ from dataclasses import field
 from inspect import isasyncgenfunction, iscoroutinefunction
 from itertools import chain
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 from uuid import UUID, uuid4
 
 import aiohttp
+import yarl
 from anyio import BrokenResourceError, to_thread
 from grpc import StatusCode
 from jumpstarter_protocol import jumpstarter_pb2, jumpstarter_pb2_grpc, router_pb2_grpc
@@ -235,48 +237,112 @@ class Driver(
             finally:
                 del self.resources[resource_uuid]
 
+    @staticmethod
+    def _make_url(url: str) -> yarl.URL:
+        """Construct a yarl.URL preserving percent-encoding in the path.
+
+        yarl.URL() normalizes %XX sequences (e.g. %40 → @), which breaks
+        signed redirect URLs (CloudFront, S3) whose signatures cover the
+        encoded form.  Using encoded=True keeps the raw string intact.
+        """
+        return yarl.URL(url, encoded=True)
+
+    @staticmethod
+    def _redact_url(url: str) -> str:
+        """Redact query parameters from a URL to avoid leaking credentials in logs."""
+        parsed = urlparse(url)
+        if parsed.query:
+            return urlunparse(parsed._replace(query="[REDACTED]"))
+        return url
+
+    _SENSITIVE_HEADER_PREFIXES = ("authorization", "cookie", "proxy-authorization", "x-amz-", "x-ms-", "x-goog-")
+
+    @classmethod
+    def _strip_sensitive_headers(
+        cls, headers: dict[str, str], original_url: str, redirect_url: str
+    ) -> dict[str, str]:
+        """Strip auth headers when a redirect crosses origins."""
+        orig = yarl.URL(original_url)
+        dest = yarl.URL(redirect_url)
+        if (orig.scheme, orig.host, orig.port) == (dest.scheme, dest.host, dest.port):
+            return headers
+        return {
+            k: v for k, v in headers.items()
+            if not k.lower().startswith(cls._SENSITIVE_HEADER_PREFIXES)
+        }
+
+    @asynccontextmanager
+    async def _presigned_get(
+        self, url: str, headers: dict[str, str], timeout: aiohttp.ClientTimeout, max_redirects: int = 10
+    ):
+        """GET with manual redirect following to preserve percent-encoding in URLs."""
+        current_url = url
+        current_headers = headers
+        for _ in range(max_redirects + 1):
+            async with aiohttp.request(
+                "GET", self._make_url(current_url), headers=current_headers, raise_for_status=True,
+                timeout=timeout, allow_redirects=False,
+            ) as resp:
+                if resp.status not in (301, 302, 303, 307, 308):
+                    async with AiohttpStreamReaderStream(reader=resp.content) as stream:
+                        yield ProgressStream(stream=stream, logging=True)
+                        return
+                location = resp.headers.get("Location", "")
+                if not location:
+                    raise RuntimeError(
+                        f"Presigned HTTP GET redirect missing Location header for {self._redact_url(current_url)}"
+                    )
+                current_headers = self._strip_sensitive_headers(current_headers, current_url, location)
+                current_url = location
+        raise RuntimeError(f"Too many redirects ({max_redirects}) for {self._redact_url(url)}")
+
     @asynccontextmanager
     async def _resource_from_presigned(self, headers, url: str, method: str, timeout: int):
         client_timeout = aiohttp.ClientTimeout(total=timeout)
         try:
             match method:
                 case "GET":
-                    async with aiohttp.request(
-                        method, url, headers=headers, raise_for_status=True, timeout=client_timeout
-                    ) as resp:
-                        async with AiohttpStreamReaderStream(reader=resp.content) as stream:
-                            yield ProgressStream(stream=stream, logging=True)
+                    async with self._presigned_get(url, headers, client_timeout) as stream:
+                        yield stream
                 case "PUT":
                     remote, stream = create_memory_stream()
                     async with aiohttp.request(
-                        method, url, headers=headers, raise_for_status=True, data=remote, timeout=client_timeout
-                    ) as resp:
+                        method, self._make_url(url), headers=headers, raise_for_status=True,
+                        data=remote, timeout=client_timeout,
+                    ) as _resp:
                         async with stream:
                             yield ProgressStream(stream=stream, logging=True)
                 case _:
                     # INVARIANT: method is always one of GET or PUT, see PresignedRequestResource
                     raise ValueError("unreachable")
         except aiohttp.ClientResponseError as e:
+            safe_url = self._redact_url(url)
             raise RuntimeError(
-                f"Presigned HTTP {method} request failed: status={e.status}, reason={e.message!r}, url={url}"
+                f"Presigned HTTP {method} request failed: status={e.status}, reason={e.message!r}, url={safe_url}"
             ) from e
         except BrokenResourceError as e:
+            safe_url = self._redact_url(url)
             cause = e.__cause__
             if cause is not None:
                 raise RuntimeError(
-                    f"Presigned HTTP {method} stream interrupted for {url}: {type(cause).__name__}: {cause!s}"
+                    f"Presigned HTTP {method} stream interrupted for {safe_url}: {type(cause).__name__}: {cause!s}"
                 ) from e
-            raise RuntimeError(f"Presigned HTTP {method} stream interrupted for {url}") from e
+            raise RuntimeError(f"Presigned HTTP {method} stream interrupted for {safe_url}") from e
         except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError, aiohttp.ServerTimeoutError) as e:
+            safe_url = self._redact_url(url)
             raise RuntimeError(
-                f"Presigned HTTP {method} stream failed (connection/read error) for {url}: "
+                f"Presigned HTTP {method} stream failed (connection/read error) for {safe_url}: "
                 f"{type(e).__name__}: {e!s}"
             ) from e
         except TimeoutError as e:
-            raise TimeoutError(f"Presigned HTTP {method} request timed out after {timeout}s for {url}") from e
+            safe_url = self._redact_url(url)
+            raise TimeoutError(
+                f"Presigned HTTP {method} request timed out after {timeout}s for {safe_url}"
+            ) from e
         except OSError as e:
+            safe_url = self._redact_url(url)
             raise RuntimeError(
-                f"Presigned HTTP {method} stream failed with OS error for {url}: {type(e).__name__}: {e!s}"
+                f"Presigned HTTP {method} stream failed with OS error for {safe_url}: {type(e).__name__}: {e!s}"
             ) from e
 
     @asynccontextmanager

--- a/python/packages/jumpstarter/jumpstarter/driver/base_test.py
+++ b/python/packages/jumpstarter/jumpstarter/driver/base_test.py
@@ -1,0 +1,98 @@
+import yarl
+
+from .base import Driver
+
+
+def test_make_url_preserves_percent_encoding():
+    """_make_url must preserve %XX sequences that appear in presigned URLs.
+
+    Without encoded=True, yarl.URL normalizes %40 to @, breaking S3/CloudFront
+    signatures which are computed over the percent-encoded form.
+    """
+    url = "https://cdn.example.com/path%40encoded/file.bin?X-Amz-Signature=abc123"
+
+    broken = yarl.URL(url)
+    assert "%40" not in str(broken), "sanity: yarl.URL() should decode %40"
+
+    preserved = Driver._make_url(url)
+    assert str(preserved) == url
+
+
+def test_make_url_preserves_multiple_encoded_sequences():
+    url = "https://cdn.example.com/a%40b%2Fc%23d?token=xyz"
+
+    preserved = Driver._make_url(url)
+    assert str(preserved) == url
+    assert "%40" in str(preserved)
+    assert "%2F" in str(preserved)
+    assert "%23" in str(preserved)
+
+
+def test_strip_sensitive_headers_same_origin():
+    headers = {
+        "Authorization": "Bearer tok",
+        "x-amz-security-token": "sess",
+        "Content-Type": "application/octet-stream",
+    }
+    result = Driver._strip_sensitive_headers(
+        headers, "https://s3.amazonaws.com/a", "https://s3.amazonaws.com/b"
+    )
+    assert result == headers
+
+
+def test_strip_sensitive_headers_cross_origin():
+    headers = {
+        "Authorization": "Bearer tok",
+        "x-amz-security-token": "sess",
+        "x-amz-server-side-encryption-customer-key": "secret",
+        "Content-Type": "application/octet-stream",
+        "Host": "s3.amazonaws.com",
+    }
+    result = Driver._strip_sensitive_headers(headers, "https://s3.amazonaws.com/a", "https://cdn.example.com/b")
+    assert "Authorization" not in result
+    assert "x-amz-security-token" not in result
+    assert "x-amz-server-side-encryption-customer-key" not in result
+    assert result["Content-Type"] == "application/octet-stream"
+    assert result["Host"] == "s3.amazonaws.com"
+
+
+def test_strip_sensitive_headers_different_port():
+    headers = {"Authorization": "Bearer tok", "Accept": "*/*"}
+    result = Driver._strip_sensitive_headers(headers, "https://s3.amazonaws.com:443/a", "https://s3.amazonaws.com:8443/b")
+    assert "Authorization" not in result
+    assert result["Accept"] == "*/*"
+
+
+def test_strip_sensitive_headers_scheme_change():
+    headers = {"Authorization": "Bearer tok", "Accept": "*/*"}
+    result = Driver._strip_sensitive_headers(
+        headers, "https://s3.amazonaws.com/a", "http://s3.amazonaws.com/a"
+    )
+    assert "Authorization" not in result
+    assert result["Accept"] == "*/*"
+
+
+def test_strip_sensitive_headers_cloud_providers():
+    headers = {"x-ms-blob-type": "BlockBlob", "x-goog-encryption-key": "key", "Accept": "*/*"}
+    result = Driver._strip_sensitive_headers(headers, "https://a.blob.core.windows.net/c", "https://evil.com/c")
+    assert "x-ms-blob-type" not in result
+    assert "x-goog-encryption-key" not in result
+    assert result["Accept"] == "*/*"
+
+
+def test_strip_sensitive_headers_cookie_and_proxy_auth():
+    headers = {"Cookie": "session=abc", "Proxy-Authorization": "Basic xyz", "Accept": "*/*"}
+    result = Driver._strip_sensitive_headers(headers, "https://s3.amazonaws.com/a", "https://evil.com/b")
+    assert "Cookie" not in result
+    assert "Proxy-Authorization" not in result
+    assert result["Accept"] == "*/*"
+
+
+def test_redact_url_with_query_params():
+    url = "https://s3.amazonaws.com/bucket/key?X-Amz-Credential=AKIA123&X-Amz-Signature=abc"
+    assert Driver._redact_url(url) == "https://s3.amazonaws.com/bucket/key?[REDACTED]"
+
+
+def test_redact_url_without_query_params():
+    url = "https://s3.amazonaws.com/bucket/key"
+    assert Driver._redact_url(url) == url

--- a/python/packages/jumpstarter/pyproject.toml
+++ b/python/packages/jumpstarter/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "anyio>=4.4.0,!=4.6.2",
     "aiohttp>=3.10.5",
+    "yarl>=1.6.0",
     "pydantic>=2.8.2",
     "xdg-base-dirs>=6.0.2",
     "pydantic-settings>=2.9.1",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -23,6 +23,7 @@ members = [
     "jumpstarter-driver-composite",
     "jumpstarter-driver-corellium",
     "jumpstarter-driver-doip",
+    "jumpstarter-driver-dut-network",
     "jumpstarter-driver-dutlink",
     "jumpstarter-driver-energenie",
     "jumpstarter-driver-esp32",
@@ -1944,6 +1945,7 @@ dependencies = [
     { name = "rich" },
     { name = "tenacity" },
     { name = "xdg-base-dirs" },
+    { name = "yarl" },
 ]
 
 [package.dev-dependencies]
@@ -1971,6 +1973,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.0.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
+    { name = "yarl", specifier = ">=1.6.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1999,6 +2002,7 @@ dependencies = [
     { name = "jumpstarter-driver-composite" },
     { name = "jumpstarter-driver-corellium" },
     { name = "jumpstarter-driver-doip" },
+    { name = "jumpstarter-driver-dut-network" },
     { name = "jumpstarter-driver-dutlink" },
     { name = "jumpstarter-driver-esp32" },
     { name = "jumpstarter-driver-flashers" },
@@ -2045,6 +2049,7 @@ requires-dist = [
     { name = "jumpstarter-driver-composite", editable = "packages/jumpstarter-driver-composite" },
     { name = "jumpstarter-driver-corellium", editable = "packages/jumpstarter-driver-corellium" },
     { name = "jumpstarter-driver-doip", editable = "packages/jumpstarter-driver-doip" },
+    { name = "jumpstarter-driver-dut-network", editable = "packages/jumpstarter-driver-dut-network" },
     { name = "jumpstarter-driver-dutlink", editable = "packages/jumpstarter-driver-dutlink" },
     { name = "jumpstarter-driver-esp32", editable = "packages/jumpstarter-driver-esp32" },
     { name = "jumpstarter-driver-flashers", editable = "packages/jumpstarter-driver-flashers" },
@@ -2443,6 +2448,34 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-dut-network"
+source = { editable = "packages/jumpstarter-driver-dut-network" }
+dependencies = [
+    { name = "click" },
+    { name = "jumpstarter" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.1.7" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
yarl.URL() normalizes %XX sequences (e.g. %40 → @), which breaks S3/CloudFront presigned URL signatures that are computed over the encoded form. This adds `_make_url(encoded=True)` to preserve encoding, manual redirect following to avoid aiohttp re-encoding Location headers, and an original_url passthrough so already-signed HTTP URLs bypass OpenDAL's presign (which strips query params).