### PR TITLE
fix: stabilize flaky CI tests with retry and polling

### DIFF
--- a/e2e/test/compat_old_controller_test.go
+++ b/e2e/test/compat_old_controller_test.go
@@ -109,7 +109,11 @@ var _ = Describe("Compat: Old Controller E2E Tests", Label("compat", "old-contro
 			waitForCompatExporter()
 
 			MustJmp("config", "client", "use", "compat-client")
-			MustJmp("create", "lease", "--selector", "example.com/board=compat", "--duration", "1d")
+			Eventually(func() error {
+				_, err := Jmp("create", "lease", "--selector", "example.com/board=compat", "--duration", "1d")
+				return err
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"create lease through old controller did not succeed within timeout")
 			MustJmp("get", "leases")
 			MustJmp("get", "exporters")
 

--- a/e2e/test/compat_old_controller_test.go
+++ b/e2e/test/compat_old_controller_test.go
@@ -97,9 +97,12 @@ var _ = Describe("Compat: Old Controller E2E Tests", Label("compat", "old-contro
 
 		It("new client can lease and connect through old controller", func() {
 			waitForCompatExporter()
-			out, err := Jmp("shell", "--client", "compat-client",
-				"--selector", "example.com/board=compat", "j", "power", "on")
-			Expect(err).NotTo(HaveOccurred(), out)
+			Eventually(func() error {
+				_, err := Jmp("shell", "--client", "compat-client",
+					"--selector", "example.com/board=compat", "j", "power", "on")
+				return err
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"client shell through old controller did not succeed within timeout")
 		})
 
 		It("can operate on leases through old controller", func() {
@@ -173,9 +176,9 @@ var _ = Describe("Compat: Old Controller E2E Tests", Label("compat", "old-contro
 			select {
 			case err := <-done:
 				Expect(err).NotTo(HaveOccurred(), "client shell failed")
-			case <-time.After(120 * time.Second):
+			case <-time.After(180 * time.Second):
 				_ = clientCmd.Process.Kill()
-				Fail("Client shell timed out waiting for exporter (120s)")
+				Fail("Client shell timed out waiting for exporter (180s)")
 			}
 		})
 	})

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -19,9 +19,8 @@ pytestmark = pytest.mark.anyio
 
 
 def _wait_for_mock_logger_output(mock_logger, expected: str, timeout: float = 2.0) -> None:
-    """Poll mock_logger.info call list until expected string appears or timeout elapses.
+    """On macOS, PTY output may still be draining when the hook function returns.
 
-    On macOS, PTY output may still be draining when the hook function returns.
     This helper avoids flaky assertions by retrying for up to `timeout` seconds.
     """
     deadline = time.monotonic() + timeout

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -1,4 +1,5 @@
 import os
+import time
 from contextlib import nullcontext
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +16,24 @@ from jumpstarter.exporter.hooks import (
 )
 
 pytestmark = pytest.mark.anyio
+
+
+def _wait_for_mock_logger_output(mock_logger, expected: str, timeout: float = 2.0) -> None:
+    """Poll mock_logger.info call list until expected string appears or timeout elapses.
+
+    On macOS, PTY output may still be draining when the hook function returns.
+    This helper avoids flaky assertions by retrying for up to `timeout` seconds.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        if any(expected in call for call in info_calls):
+            return
+        time.sleep(0.05)
+    info_calls = [str(call) for call in mock_logger.info.call_args_list]
+    assert any(expected in call for call in info_calls), (
+        f"Expected '{expected}' in logger.info calls after {timeout}s, got: {info_calls}"
+    )
 
 
 class TestFlushLines:
@@ -283,8 +302,7 @@ class TestHookExecutor:
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("BASH_OK: world" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "BASH_OK: world")
 
     async def test_exec_python3(self, lease_scope) -> None:
         """Test that exec=python3 runs inline Python.
@@ -304,9 +322,8 @@ class TestHookExecutor:
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
             # sum([0, 1, 4, 9]) == 14
-            assert any("PYTHON_OK: 14" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "PYTHON_OK: 14")
 
     async def test_script_file_sh(self, lease_scope, tmp_path) -> None:
         """Test that a .sh file auto-detects /bin/sh as interpreter."""

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -153,9 +153,8 @@ class TestHookExecutor:
 
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             await executor.execute_before_lease_hook(lease_scope)
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("LEASE_NAME=test-lease-123" in call for call in info_calls)
-            assert any("CLIENT_NAME=test-client" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "LEASE_NAME=test-lease-123")
+            _wait_for_mock_logger_output(mock_logger, "CLIENT_NAME=test-client")
 
     async def test_real_time_output_logging(self, lease_scope) -> None:
         """Test that hook output is logged in real-time at INFO level."""
@@ -169,10 +168,9 @@ class TestHookExecutor:
 
             assert result is None
 
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("Line 1" in call for call in info_calls)
-            assert any("Line 2" in call for call in info_calls)
-            assert any("Line 3" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "Line 1")
+            _wait_for_mock_logger_output(mock_logger, "Line 2")
+            _wait_for_mock_logger_output(mock_logger, "Line 3")
 
     async def test_post_lease_hook_execution_on_completion(self, lease_scope) -> None:
         """Test that post-lease hook executes when called directly."""
@@ -186,8 +184,7 @@ class TestHookExecutor:
 
             assert result is None
 
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("Post-lease cleanup completed" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "Post-lease cleanup completed")
 
     async def test_hook_timeout_with_warn(self, lease_scope) -> None:
         """Test that hook returns warning string when timeout occurs and on_failure='warn'."""
@@ -342,8 +339,7 @@ class TestHookExecutor:
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("SHFILE_OK" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "SHFILE_OK")
             debug_calls = [str(call) for call in mock_logger.debug.call_args_list]
             assert any("Executing script file" in call for call in debug_calls)
 
@@ -365,12 +361,9 @@ class TestHookExecutor:
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("PYFILE_OK" in call for call in info_calls)
-            # Verify it auto-detected Python (now logged at DEBUG level)
+            _wait_for_mock_logger_output(mock_logger, "PYFILE_OK")
             debug_calls = [str(call) for call in mock_logger.debug.call_args_list]
             assert any("Auto-detected Python script" in call for call in debug_calls)
-            # Verify it used the exporter's own Python interpreter
             assert any(sys.executable in call for call in debug_calls)
 
     async def test_script_file_py_exec_override(self, lease_scope, tmp_path) -> None:
@@ -390,9 +383,7 @@ class TestHookExecutor:
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("OVERRIDE_OK" in call for call in info_calls)
-            # Should NOT say "Auto-detected" since exec was explicitly set
+            _wait_for_mock_logger_output(mock_logger, "OVERRIDE_OK")
             debug_calls = [str(call) for call in mock_logger.debug.call_args_list]
             assert not any("Auto-detected" in call for call in debug_calls)
 
@@ -425,10 +416,9 @@ class TestHookExecutor:
 
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             await executor.execute_before_lease_hook(lease_scope)
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("TERM=dumb" in call for call in info_calls)
-            assert any("DEBIAN_FRONTEND=noninteractive" in call for call in info_calls)
-            assert any("GIT_TERMINAL_PROMPT=0" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "TERM=dumb")
+            _wait_for_mock_logger_output(mock_logger, "DEBIAN_FRONTEND=noninteractive")
+            _wait_for_mock_logger_output(mock_logger, "GIT_TERMINAL_PROMPT=0")
 
     async def test_before_lease_hook_exit_sets_skip_flag(self, lease_scope) -> None:
         """Test that beforeLease hook failure with on_failure=exit sets skip_after_lease_hook flag."""
@@ -642,8 +632,7 @@ class TestHookExecutor:
         with patch("jumpstarter.exporter.hooks.logger") as mock_logger:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
-            info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("NO_NEWLINE_OUTPUT" in call for call in info_calls)
+            _wait_for_mock_logger_output(mock_logger, "NO_NEWLINE_OUTPUT")
 
     async def test_drain_reads_data_remaining_in_pty_buffer(self, lease_scope) -> None:
         """Verify the drain loop inside read_pty_output reads data left in the


### PR DESCRIPTION
## Summary
- Wrap e2e compat old-controller gRPC calls (`shell` and `create lease`) with Gomega `Eventually()` to retry for up to 2 minutes on transient connection failures
- Add `_wait_for_mock_logger_output()` polling helper to `hooks_test.py` to handle PTY output drain race on macOS, applied consistently to all 13 logger output assertions
- Increase client-before-exporter timeout from 120s to 180s

## Test plan
- [ ] `e2e-compat-old-controller` job passes on CI (previously ~7% failure rate)
- [ ] `hooks_test.py::TestHookExecutor::test_exec_bash` passes on macOS runners (previously flaky on macos-15, Python 3.13)
- [ ] All other hooks_test assertions still pass with the polling helper
- [ ] No regressions in other e2e or pytest jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)