### PR TITLE
chore: enable ruff ERA rule to catch commented-out code

### DIFF
--- a/python/examples/automotive/jumpstarter_example_automotive/mock_ecu.py
+++ b/python/examples/automotive/jumpstarter_example_automotive/mock_ecu.py
@@ -376,16 +376,16 @@ class MockDiagnosticEcu:
         positive_sid = data[0] + 0x40
 
         with self.state._lock:
-            # deAuthenticate (task=0)
+            # deAuthenticate, task 0
             if task == 0x00:
                 self.state.authenticated = False
                 self.state.auth_challenge = b""
                 return bytes([positive_sid, task, AUTH_RETURN_DEAUTHENTICATED])
 
-            # requestChallengeForAuthentication (task=5)
-            # Wire request: [SID, task, commConfig(1b), algorithmIndicator(16b)]
-            # Wire response: [+SID, task, returnValue, algoIndicator(16b),
-            #                  lenPrefixed(challenge), lenPrefixed(neededAdditionalParam)]
+            # requestChallengeForAuthentication, task 5
+            # Wire request: SID, task, commConfig (1 byte), algorithmIndicator (16 bytes)
+            # Wire response: +SID, task, returnValue, algoIndicator (16 bytes),
+            #                  lenPrefixed challenge, lenPrefixed neededAdditionalParam
             if task == 0x05:
                 algo = data[3:19] if len(data) >= 19 else bytes(16)
                 challenge = os.urandom(16)
@@ -396,11 +396,11 @@ class MockDiagnosticEcu:
                 resp += struct.pack(">H", 0)  # no neededAdditionalParameter
                 return resp
 
-            # verifyProofOfOwnershipUnidirectional (task=6)
-            # Wire request: [SID, task, algorithmIndicator(16b),
-            #                lenPrefixed(proof), lenPrefixed(challenge), lenPrefixed(additional)]
-            # Wire response: [+SID, task, returnValue, algoIndicator(16b),
-            #                  lenPrefixed(sessionKeyInfo)]
+            # verifyProofOfOwnershipUnidirectional, task 6
+            # Wire request: SID, task, algorithmIndicator (16 bytes),
+            #                lenPrefixed proof, lenPrefixed challenge, lenPrefixed additional
+            # Wire response: +SID, task, returnValue, algoIndicator (16 bytes),
+            #                  lenPrefixed sessionKeyInfo
             if task == 0x06:
                 if not self.state.auth_challenge:
                     return _nrc(data[0], NRC_CONDITIONS_NOT_CORRECT)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/__init__.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/__init__.py
@@ -5,6 +5,6 @@ import truststore
 # if we are running in MacOS avoid injecting system certificates to avoid
 # https://github.com/jumpstarter-dev/jumpstarter/issues/362
 # also allow to force the system certificates injection with
-# JUMPSTARTER_FORCE_SYSTEM_CERTS=1
+# the JUMPSTARTER_FORCE_SYSTEM_CERTS environment variable set to "1"
 if os.uname().sysname != "Darwin" or os.environ.get("JUMPSTARTER_FORCE_SYSTEM_CERTS") == "1":
     truststore.inject_into_ssl()

--- a/python/packages/jumpstarter-driver-ble/jumpstarter_driver_ble/driver.py
+++ b/python/packages/jumpstarter-driver-ble/jumpstarter_driver_ble/driver.py
@@ -132,7 +132,6 @@ class BleWriteNotifyStream(Driver):
                             address=self.address,
                             service_uuid=self.service_uuid,
                             write_char_uuid=self.write_char_uuid,
-                            # read_char_uuid=self.read_char_uuid,
                             notify_char_uuid=self.notify_char_uuid,
                         ),
                     ) as stream:

--- a/python/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/corellium/api_test.py
+++ b/python/packages/jumpstarter-driver-corellium/jumpstarter_driver_corellium/corellium/api_test.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 
-# import websockets
 from .api import ApiClient
 from .exceptions import CorelliumApiException
 from .types import Device, Instance, Project

--- a/python/packages/jumpstarter-driver-doip/jumpstarter_driver_doip/conftest.py
+++ b/python/packages/jumpstarter-driver-doip/jumpstarter_driver_doip/conftest.py
@@ -69,7 +69,7 @@ def _handle_vehicle_identification() -> bytes:
 
 
 def _handle_entity_status() -> bytes:
-    # node_type(B=0), max_sockets(B=16), open_sockets(B=1), max_data_size(L=4096)
+    # Fields: node_type 0, max_sockets 16, open_sockets 1, max_data_size 4096
     resp = struct.pack("!BBBL", 0x00, 16, 1, 4096)
     return _pack_doip(ENTITY_STATUS_RESPONSE, resp)
 

--- a/python/packages/jumpstarter-driver-dut-network/jumpstarter_driver_dut_network/driver.py
+++ b/python/packages/jumpstarter-driver-dut-network/jumpstarter_driver_dut_network/driver.py
@@ -137,9 +137,9 @@ class DutNetwork(Driver):
                 "Provide a valid IP address or a resolvable DNS name."
             )
 
-        # results[0] is (family, type, proto, canonname, sockaddr)
-        # sockaddr for AF_INET is (address, port)
-        return results[0][4][0]
+        _family, _type, _proto, _canonname, sockaddr = results[0]
+        address, _port = sockaddr
+        return address
 
     def _validate_config(self) -> None:
         network = ipaddress.ip_network(self.subnet, strict=False)

--- a/python/packages/jumpstarter-driver-dutlink/examples/dutlink.py
+++ b/python/packages/jumpstarter-driver-dutlink/examples/dutlink.py
@@ -7,13 +7,7 @@ from jumpstarter_driver_network.adapters import PexpectAdapter
 
 from jumpstarter.common.utils import env
 
-# initialize client from exporter config
-# from jumpstarter.config.client import ClientConfigV1Alpha1
-# with ClientConfigV1Alpha1.load("default").lease(selector="example.com/board=dutlink") as lease:
-#     with lease.connect() as client:
-
-# initialize client from environment
-# e.g. `jmp-exporter shell dutlink`
+# initialize client from environment, e.g. `jmp-exporter shell dutlink`
 if __name__ == "__main__":
     with env() as client:
         dutlink = client.dutlink

--- a/python/packages/jumpstarter-driver-mitmproxy/examples/addons/_template.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/examples/addons/_template.py
@@ -98,6 +98,12 @@ class Handler:
                 f"WS client message: {last_msg.content!r}"
             )
 
+            # To echo back to client with modification, use:
+            #   ctx.master.commands.call(  # noqa: ERA001
+            #       "inject.websocket", flow, True,  # noqa: ERA001
+            #       b'{"type": "echo", "data": ...}',  # noqa: ERA001
+            #   )  # noqa: ERA001
+
     def cleanup(self) -> None:
         """Called when the addon is unloaded.
 

--- a/python/packages/jumpstarter-driver-mitmproxy/examples/addons/_template.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/examples/addons/_template.py
@@ -98,12 +98,6 @@ class Handler:
                 f"WS client message: {last_msg.content!r}"
             )
 
-            # Example: echo back to client with modification
-            # ctx.master.commands.call(
-            #     "inject.websocket", flow, True,
-            #     b'{"type": "echo", "data": ...}',
-            # )
-
     def cleanup(self) -> None:
         """Called when the addon is unloaded.
 

--- a/python/packages/jumpstarter-driver-mitmproxy/examples/addons/mjpeg_stream.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/examples/addons/mjpeg_stream.py
@@ -164,7 +164,7 @@ class Handler:
         # e.g. ("streaming", "video", "camera", "rear", "snapshot.jpg")
         parts = flow.request.path_components
 
-        # Expected: streaming/video/camera/{camera_id}/{resource}
+        # Expect at least 5 segments: streaming/video/camera/<camera_id>/<resource>
         if len(parts) < 5:
             return False
 

--- a/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/client.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/jumpstarter_driver_mitmproxy/client.py
@@ -1325,9 +1325,8 @@ class MitmproxyClient(DriverClient):
 # ── CLI helpers ────────────────────────────────────────────────
 
 
-# Fixed column widths (characters):
-#   2 (indent) + 8 (timestamp) + 1 + 7 (method) + 1 + PATH + 1 + 3 (status)
-#   + 1 + 7 (duration) + 1 + 8 (size) + 1 + 13 (tag) = 54 + PATH
+# Fixed column widths (characters), totalling 54 plus the variable-width PATH:
+# indent 2, timestamp 8, method 7, status 3, duration 7, size 8, tag 13, separators 6
 _FIXED_COLS_WIDTH = 54
 _MIN_PATH_WIDTH = 20
 

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/clients.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/clients.py
@@ -58,7 +58,6 @@ class V1Alpha1Client(JsonBaseModel):
     def rich_add_columns(cls, table):
         table.add_column("NAME", no_wrap=True)
         table.add_column("ENDPOINT")
-        # table.add_column("AGE")
 
     def rich_add_rows(self, table):
         table.add_row(

--- a/python/packages/jumpstarter-mcp/jumpstarter_mcp/server_test.py
+++ b/python/packages/jumpstarter-mcp/jumpstarter_mcp/server_test.py
@@ -166,8 +166,7 @@ class TestWalkClickTree:
         assert "secret" not in names
 
 
-# ---------------------------------------------------------------------------
-# Introspection: _get_public_method_names / list_drivers / get_driver_methods
+# Introspection tests
 # ---------------------------------------------------------------------------
 
 

--- a/python/packages/jumpstarter/jumpstarter/client/selectors.py
+++ b/python/packages/jumpstarter/jumpstarter/client/selectors.py
@@ -25,7 +25,7 @@ def parse_label_selector(selector: str) -> tuple[dict[str, str], list[tuple[str,
         if not part:
             continue
 
-        # key in (v1, v2, ...)
+        # Match "key in (v1, v2, ...)" syntax
         if m := re.match(r"^([a-zA-Z0-9_./-]+)\s+in\s+\(([^)]*)\)$", part):
             key, values = m.groups()
             match_expressions.append((key, "in", [v.strip() for v in values.split(",")]))
@@ -36,11 +36,11 @@ def parse_label_selector(selector: str) -> tuple[dict[str, str], list[tuple[str,
         # !key (DoesNotExist)
         elif m := re.match(r"^!\s*([a-zA-Z0-9_./-]+)$", part):
             match_expressions.append((m.group(1), "!exists", []))
-        # key!=value (whitespace-tolerant)
+        # Match "key != value" syntax (whitespace-tolerant)
         elif m := re.match(r"^([a-zA-Z0-9_./-]+)\s*!=\s*(.+)$", part):
             key, value = m.groups()
             match_expressions.append((key, "!=", [value.strip()]))
-        # key=value or key==value (whitespace-tolerant)
+        # Match "key=value" or "key==value" syntax (whitespace-tolerant)
         elif m := re.match(r"^([a-zA-Z0-9_./-]+)\s*==?\s*(.+)$", part):
             key, value = m.groups()
             match_labels[key] = value.strip()

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -305,7 +305,7 @@ class TestHookExecutor:
             result = await executor.execute_before_lease_hook(lease_scope)
             assert result is None
             info_calls = [str(call) for call in mock_logger.info.call_args_list]
-            # sum([0, 1, 4, 9]) == 14
+            # Expected total: 0 + 1 + 4 + 9 == 14
             assert any("PYTHON_OK: 14" in call for call in info_calls)
 
     async def test_script_file_sh(self, lease_scope, tmp_path) -> None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -87,7 +87,7 @@ line-length = 120
 
 [tool.ruff.lint]
 exclude = ["packages/jumpstarter-protocol"]
-extend-select = ["I", "C", "E", "F", "W", "B"]
+extend-select = ["I", "C", "E", "F", "W", "B", "ERA"]
 
 [tool.ruff.lint.isort]
 known-local-folder = ["packages", "examples", "jumpstarter"]


### PR DESCRIPTION
## Summary
- Adds the `ERA` (eradicate) rule to the ruff lint configuration, which catches commented-out code
- Resolves all 18 existing violations: removes dead commented-out code and rewords documentation comments that happened to parse as valid Python

## Test plan
- [x] `ruff check` passes with zero violations
- [x] `ruff check --select ERA` returns clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)