### PR TITLE
fix: remove unreliable energenie.com link to prevent flaky CI

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -113,6 +113,3 @@ copybutton_line_continuation_character = "\\"
 
 # matrix.to uses client-side fragment routing; anchor checks are false positives.
 linkcheck_anchors_ignore_for_url = [r"^https://matrix\.to/"]
-
-# energenie.com is chronically unreliable and causes flaky CI failures.
-linkcheck_ignore = [r"^https://energenie\.com/"]

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -113,3 +113,6 @@ copybutton_line_continuation_character = "\\"
 
 # matrix.to uses client-side fragment routing; anchor checks are false positives.
 linkcheck_anchors_ignore_for_url = [r"^https://matrix\.to/"]
+
+# energenie.com is chronically unreliable and causes flaky CI failures.
+linkcheck_ignore = [r"^https://energenie\.com/"]

--- a/python/packages/jumpstarter-driver-energenie/README.md
+++ b/python/packages/jumpstarter-driver-energenie/README.md
@@ -2,7 +2,7 @@
 
 Drivers for EnerGenie products.
 
-This driver provides a client for the [EnerGenie Programmable power switch](https://energenie.com/products.aspx?sg=239). The driver was tested on EG-PMS2-LAN device only but should be easy to support other devices.
+This driver provides a client for the EnerGenie Programmable power switch. The driver was tested on EG-PMS2-LAN device only but should be easy to support other devices.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Removes the `energenie.com` product link from the energenie driver README
- The site chronically times out from GitHub Actions runners, causing the Documentation linkcheck workflow to fail repeatedly on main (3 failures in the last 10 commits)

## Test plan
- [ ] Documentation linkcheck workflow passes without energenie.com timeout failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)