### PR TITLE
ci: skip e2e and python tests for docs-only changes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,8 @@ jobs:
               - 'controller/**'
               - 'e2e/**'
               - 'python/**'
+              - '!python/docs/**'
+              - '!python/**/*.md'
               - '.github/workflows/e2e.yaml'
               - 'Makefile'
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -31,6 +31,8 @@ jobs:
           filters: |
             python:
               - 'python/**'
+              - '!python/docs/**'
+              - '!python/**/*.md'
               - '.github/workflows/python-tests.yaml'
             renode_driver:
               - 'python/packages/jumpstarter-driver-renode/**'


### PR DESCRIPTION
## Summary
- Excludes `python/docs/**` and `python/**/*.md` from the path filters in e2e and python-tests workflows
- Docs-only PRs (like #707) currently trigger the full e2e suite and pytest matrix across 6 OS/Python combinations, wasting ~30 minutes of CI time per PR

## Test plan
- [ ] A docs-only PR should show e2e and python-tests as skipped
- [ ] A PR touching `.py` files under `python/` should still trigger both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)