### PR TITLE
feat: default exporter configs to ~/.config/jumpstarter

### DIFF
--- a/e2e/test/compat_old_client_test.go
+++ b/e2e/test/compat_old_client_test.go
@@ -74,11 +74,11 @@ var _ = Describe("Compat: Old Client E2E Tests", Label("compat", "old-client"), 
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			out, err = Jmp("admin", "create", "exporter", "-n", ns, "compat-old-exporter",
-				"--save", "--label", "example.com/board=compat-old")
+				"--out", SystemExporterConfigPath("compat-old-exporter"), "--label", "example.com/board=compat-old")
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
-			MergeExporterConfig("/etc/jumpstarter/exporters/compat-old-exporter.yaml", overlayPath)
+			MergeExporterConfig(SystemExporterConfigPath("compat-old-exporter"), overlayPath)
 		})
 	})
 
@@ -177,11 +177,11 @@ var _ = Describe("Compat: Old Client E2E Tests", Label("compat", "old-client"), 
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			out, err = Jmp("admin", "create", "exporter", "-n", ns, "compat-old-exporter-wait",
-				"--save", "--label", "example.com/board=compat-old-wait")
+				"--out", SystemExporterConfigPath("compat-old-exporter-wait"), "--label", "example.com/board=compat-old-wait")
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
-			MergeExporterConfig("/etc/jumpstarter/exporters/compat-old-exporter-wait.yaml", overlayPath)
+			MergeExporterConfig(SystemExporterConfigPath("compat-old-exporter-wait"), overlayPath)
 
 			// Start client BEFORE exporter
 			clientCmd := JmpCmd("shell", "--client", "compat-old-client-wait",

--- a/e2e/test/compat_old_controller_test.go
+++ b/e2e/test/compat_old_controller_test.go
@@ -68,11 +68,11 @@ var _ = Describe("Compat: Old Controller E2E Tests", Label("compat", "old-contro
 
 		It("can create exporter with admin cli", func() {
 			out, err := Jmp("admin", "create", "exporter", "-n", ns, "compat-exporter",
-				"--save", "--label", "example.com/board=compat")
+				"--out", SystemExporterConfigPath("compat-exporter"), "--label", "example.com/board=compat")
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
-			MergeExporterConfig("/etc/jumpstarter/exporters/compat-exporter.yaml", overlayPath)
+			MergeExporterConfig(SystemExporterConfigPath("compat-exporter"), overlayPath)
 		})
 
 		It("new exporter registers with old controller", func() {
@@ -145,11 +145,11 @@ var _ = Describe("Compat: Old Controller E2E Tests", Label("compat", "old-contro
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			out, err = Jmp("admin", "create", "exporter", "-n", ns, "compat-exporter-wait",
-				"--save", "--label", "example.com/board=compat-wait")
+				"--out", SystemExporterConfigPath("compat-exporter-wait"), "--label", "example.com/board=compat-wait")
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
-			MergeExporterConfig("/etc/jumpstarter/exporters/compat-exporter-wait.yaml", overlayPath)
+			MergeExporterConfig(SystemExporterConfigPath("compat-exporter-wait"), overlayPath)
 
 			// Start client BEFORE exporter
 			clientCmd := JmpCmd("shell", "--client", "compat-client-wait",

--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -102,10 +102,11 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), out)
 
 			out, err = Jmp("admin", "create", "exporter", "-n", ns, "test-exporter-legacy",
-				"--save", "--label", "example.com/board=legacy")
+				"--out", SystemExporterConfigPath("test-exporter-legacy"),
+				"--label", "example.com/board=legacy")
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			exporterConfigPath := "/etc/jumpstarter/exporters/test-exporter-legacy.yaml"
+			exporterConfigPath := SystemExporterConfigPath("test-exporter-legacy")
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
 			MergeExporterConfig(exporterConfigPath, overlayPath)
 
@@ -159,13 +160,14 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, func() {
 		})
 
 		It("can login with oidc test-exporter-oidc", func() {
-			out, err := Jmp("login", "--exporter", "test-exporter-oidc", "--name", "test-exporter-oidc",
+			out, err := Jmp("login", "--exporter-config", SystemExporterConfigPath("test-exporter-oidc"),
+				"--name", "test-exporter-oidc",
 				"--endpoint", Endpoint(), "--namespace", Namespace(),
 				"--issuer", "https://dex.dex.svc.cluster.local:5556",
 				"--username", "test-exporter-oidc@example.com", "--password", "password")
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			exporterConfigPath := "/etc/jumpstarter/exporters/test-exporter-oidc.yaml"
+			exporterConfigPath := SystemExporterConfigPath("test-exporter-oidc")
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
 			MergeExporterConfig(exporterConfigPath, overlayPath)
 
@@ -178,16 +180,21 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, func() {
 			ns := Namespace()
 			token := MustKubectl("create", "-n", ns, "token", "test-exporter-sa")
 
+			// test-exporter-sa intentionally uses the default per-user config
+			// location (~/.config/jumpstarter/exporters) to exercise that path,
+			// while oidc/legacy use the production system location.
 			out, err := Jmp("login", "--exporter", "test-exporter-sa",
 				"--endpoint", Endpoint(), "--namespace", ns, "--name", "test-exporter-sa",
 				"--issuer", "https://dex.dex.svc.cluster.local:5556",
 				"--connector-id", "kubernetes", "--token", token)
 			Expect(err).NotTo(HaveOccurred(), out)
 
+			Expect(UserExporterConfigPath("test-exporter-sa")).To(BeAnExistingFile())
+
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
-			MergeExporterConfig("/etc/jumpstarter/exporters/test-exporter-oidc.yaml", overlayPath)
-			MergeExporterConfig("/etc/jumpstarter/exporters/test-exporter-sa.yaml", overlayPath)
-			MergeExporterConfig("/etc/jumpstarter/exporters/test-exporter-legacy.yaml", overlayPath)
+			MergeExporterConfig(SystemExporterConfigPath("test-exporter-oidc"), overlayPath)
+			MergeExporterConfig(UserExporterConfigPath("test-exporter-sa"), overlayPath)
+			MergeExporterConfig(SystemExporterConfigPath("test-exporter-legacy"), overlayPath)
 
 			out, err = Jmp("config", "exporter", "list", "-o", "yaml")
 			Expect(err).NotTo(HaveOccurred(), out)

--- a/e2e/test/go.mod
+++ b/e2e/test/go.mod
@@ -7,6 +7,7 @@ tool github.com/onsi/ginkgo/v2/ginkgo
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	go.yaml.in/yaml/v3 v3.0.4
 )
 
 require (
@@ -15,7 +16,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/e2e/test/hooks_test.go
+++ b/e2e/test/hooks_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 	BeforeAll(func() {
 		tracker = NewProcessTracker()
 		ns = Namespace()
-		exporterConfigPath = "/etc/jumpstarter/exporters/test-exporter-hooks.yaml"
+		exporterConfigPath = SystemExporterConfigPath("test-exporter-hooks")
 
 		// Create client and exporter for hooks tests
 		MustJmp("admin", "create", "client", "-n", ns, "test-client-hooks",
@@ -80,7 +80,7 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 			"--issuer", "https://dex.dex.svc.cluster.local:5556",
 			"--username", "test-client-hooks@example.com", "--password", "password", "--unsafe")
 
-		MustJmp("login", "--exporter", "test-exporter-hooks",
+		MustJmp("login", "--exporter-config", SystemExporterConfigPath("test-exporter-hooks"),
 			"--endpoint", Endpoint(), "--namespace", ns, "--name", "test-exporter-hooks",
 			"--issuer", "https://dex.dex.svc.cluster.local:5556",
 			"--username", "test-exporter-hooks@example.com", "--password", "password")

--- a/e2e/test/utils.go
+++ b/e2e/test/utils.go
@@ -599,6 +599,18 @@ func DumpControllerLogs(maxLines int) {
 
 // --- Exporter config helpers ---
 
+// SystemExporterConfigPath returns the production system path for an exporter
+// config (used for deployments where exporters are not a user workload).
+func SystemExporterConfigPath(name string) string {
+	return filepath.Join("/etc/jumpstarter/exporters", name+".yaml")
+}
+
+// UserExporterConfigPath returns the per-user default path for an exporter
+// config (the location the CLI writes to when no explicit path is given).
+func UserExporterConfigPath(name string) string {
+	return filepath.Join(os.Getenv("HOME"), ".config", "jumpstarter", "exporters", name+".yaml")
+}
+
 // MergeExporterConfig merges an overlay YAML into an exporter config file
 // using native Go YAML parsing (no external yq dependency).
 func MergeExporterConfig(exporterConfigPath, overlayFile string) {

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -27,6 +27,8 @@ else:
     def tmp_config_path(tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "client-config"))
         monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", tmp_path / "exporters")
+        # Isolate the legacy system fallback so tests never touch the real /etc.
+        monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", tmp_path / "system-exporters")
 
     @pytest.fixture(autouse=True)
     def console_size(monkeypatch):

--- a/python/docs/source/getting-started/configuration/files.md
+++ b/python/docs/source/getting-started/configuration/files.md
@@ -71,9 +71,16 @@ $ jmp config client delete <alias>  # Remove a client config locally
 ## Exporter Configuration
 
 **File**: All valid {term}`exporter` configuration files with a `.yaml` extension  
-**Location**: `/etc/jumpstarter/exporters/*.yaml`  
+**Location**: `~/.config/jumpstarter/exporters/*.yaml` (per-user) or `/etc/jumpstarter/exporters/*.yaml` (system-wide)
+
 **Description**: Defines {term}`exporter` settings including connection details and
-driver configurations.  
+driver configurations.
+
+Exporter configs created via the CLI default to the per-user location. Both the per-user and
+system locations are searched when loading, with the per-user path taking precedence. The user
+config home can be overridden with `JMP_CLIENT_CONFIG_HOME` or `XDG_CONFIG_HOME`. The
+`jmp admin create exporter` and `jmp admin import exporter` commands also accept `--out <file>`
+to write the config to an explicit path.
 
 **Format**:
 ```yaml

--- a/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete.py
+++ b/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete.py
@@ -117,14 +117,17 @@ async def delete_exporter(
                 click.echo(f"Deleted exporter '{name}' in namespace '{namespace}'")
             else:
                 click.echo(f"exporter.jumpstarter.dev/{name}")
-            # Save the exporter config
-            if ExporterConfigV1Alpha1.exists(name) and (
-                delete or nointeractive is False and click.confirm("Delete exporter configuration?")
-            ):
-                # Delete the exporter config
-                ExporterConfigV1Alpha1.delete(name)
-                if output is None:
-                    click.echo("Exporter configuration successfully deleted")
+            if ExporterConfigV1Alpha1.user_config_exists(name):
+                if delete or nointeractive is False and click.confirm("Delete exporter configuration?"):
+                    ExporterConfigV1Alpha1.delete(name)
+                    if output is None:
+                        click.echo("Exporter configuration successfully deleted")
+            elif ExporterConfigV1Alpha1.exists(name) and output is None:
+                click.echo(
+                    f"Warning: a system config at {ExporterConfigV1Alpha1.resolve_path(name)} "
+                    "was not removed and may still be used by the exporter.",
+                    err=True,
+                )
     except ApiException as e:
         handle_k8s_api_exception(e)
     except ConfigException as e:

--- a/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete_test.py
+++ b/python/packages/jumpstarter-cli-admin/jumpstarter_cli_admin/delete_test.py
@@ -176,17 +176,20 @@ EXPORTER_CONFIG = ExporterConfigV1Alpha1(
 
 @patch.object(ExporterConfigV1Alpha1, "delete")
 @patch.object(ExporterConfigV1Alpha1, "exists")
+@patch.object(ExporterConfigV1Alpha1, "user_config_exists")
 @patch.object(ExportersV1Alpha1Api, "delete_exporter")
 @patch.object(ExportersV1Alpha1Api, "_load_kube_config")
 def test_delete_exporter(
     _mock_load_kube_config,
     mock_delete_exporter: AsyncMock,
+    mock_user_config_exists: Mock,
     mock_config_exists: Mock,
     mock_config_delete: Mock,
 ):
     runner = CliRunner()
 
     # Delete exporter object and config does not exist
+    mock_user_config_exists.return_value = False
     mock_config_exists.return_value = False
     result = runner.invoke(delete, ["exporter", EXPORTER_NAME])
     assert result.exit_code == 0
@@ -195,11 +198,13 @@ def test_delete_exporter(
     mock_delete_exporter.assert_called_once_with(EXPORTER_NAME)
     mock_config_delete.assert_not_called()
 
+    mock_user_config_exists.reset_mock()
     mock_config_exists.reset_mock()
     mock_delete_exporter.reset_mock()
     mock_config_delete.reset_mock()
 
     # Delete exporter object and config exists, delete = n
+    mock_user_config_exists.return_value = True
     mock_config_exists.return_value = True
     result = runner.invoke(delete, ["exporter", EXPORTER_NAME], input="n\n")
     assert result.exit_code == 0
@@ -208,11 +213,13 @@ def test_delete_exporter(
     mock_delete_exporter.assert_called_once_with(EXPORTER_NAME)
     mock_config_delete.assert_not_called()
 
+    mock_user_config_exists.reset_mock()
     mock_config_exists.reset_mock()
     mock_delete_exporter.reset_mock()
     mock_config_delete.reset_mock()
 
     # Delete exporter object and config exists, delete = Y
+    mock_user_config_exists.return_value = True
     mock_config_exists.return_value = True
     result = runner.invoke(delete, ["exporter", EXPORTER_NAME], input="Y\n")
     assert result.exit_code == 0
@@ -221,11 +228,13 @@ def test_delete_exporter(
     mock_delete_exporter.assert_called_once_with(EXPORTER_NAME)
     mock_config_delete.assert_called_with(EXPORTER_NAME)
 
+    mock_user_config_exists.reset_mock()
     mock_config_exists.reset_mock()
     mock_delete_exporter.reset_mock()
     mock_config_delete.reset_mock()
 
     # Delete exporter object nointeractive
+    mock_user_config_exists.return_value = True
     mock_config_exists.return_value = True
     result = runner.invoke(delete, ["exporter", EXPORTER_NAME, "--nointeractive"])
     assert result.exit_code == 0
@@ -234,11 +243,13 @@ def test_delete_exporter(
     mock_delete_exporter.assert_called_once_with(EXPORTER_NAME)
     mock_config_delete.assert_not_called()
 
+    mock_user_config_exists.reset_mock()
     mock_config_exists.reset_mock()
     mock_delete_exporter.reset_mock()
     mock_config_delete.reset_mock()
 
     # Delete exporter object output name
+    mock_user_config_exists.return_value = True
     mock_config_exists.return_value = True
     result = runner.invoke(delete, ["exporter", EXPORTER_NAME, "--nointeractive", "--output", "name"])
     assert result.exit_code == 0
@@ -246,6 +257,7 @@ def test_delete_exporter(
     mock_delete_exporter.assert_called_once_with(EXPORTER_NAME)
     mock_config_delete.assert_not_called()
 
+    mock_user_config_exists.reset_mock()
     mock_config_exists.reset_mock()
     mock_delete_exporter.reset_mock()
     mock_config_delete.reset_mock()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter.py
@@ -8,9 +8,19 @@ from jumpstarter_cli_common.opt import (
 )
 from jumpstarter_cli_common.print import model_print
 
+from jumpstarter.common.exceptions import ConfigurationError
 from jumpstarter.config.exporter import ExporterConfigV1Alpha1, ObjectMeta
 
-arg_alias = click.argument("alias", default="default")
+
+def _validate_alias_param(ctx, param, value):
+    try:
+        ExporterConfigV1Alpha1.validate_alias(value)
+    except ConfigurationError as e:
+        raise click.BadParameter(str(e)) from e
+    return value
+
+
+arg_alias = click.argument("alias", default="default", callback=_validate_alias_param)
 
 
 @click.group("exporter")
@@ -29,11 +39,9 @@ def config_exporter():
 @arg_alias
 def create_exporter_config(alias, namespace, name, endpoint, token, output: PathOutputType):
     """Create an exporter config."""
-    try:
-        ExporterConfigV1Alpha1.load(alias)
-    except FileNotFoundError:
-        pass
-    else:
+    # Guard against overwriting an existing user-level config (the write target).
+    # A same-named config in the system location (/etc) is allowed to be shadowed.
+    if ExporterConfigV1Alpha1.user_config_exists(alias):
         raise click.ClickException(f'exporter "{alias}" exists')
 
     config = ExporterConfigV1Alpha1(
@@ -57,9 +65,18 @@ def delete_exporter_config(alias, output: PathOutputType):
         ExporterConfigV1Alpha1.load(alias)
     except FileNotFoundError as err:
         raise click.ClickException(f'exporter "{alias}" does not exist') from err
-    path = ExporterConfigV1Alpha1.delete(alias)
+    try:
+        path = ExporterConfigV1Alpha1.delete(alias)
+    except ConfigurationError as err:
+        raise click.ClickException(str(err)) from err
     if output == OutputMode.PATH:
         click.echo(path)
+    if ExporterConfigV1Alpha1.exists(alias):
+        click.echo(
+            f"Warning: {path} deleted, but a system config at "
+            f"{ExporterConfigV1Alpha1.resolve_path(alias)} still exists and will now be used.",
+            err=True,
+        )
 
 
 @config_exporter.command("edit")

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter_test.py
@@ -1,9 +1,83 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from .config_exporter import config_exporter
+from jumpstarter.config.exporter import ExporterConfigV1Alpha1
+
+
+def _write_system_config(path: Path, name: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: {name}
+endpoint: "jumpstarter.my-lab.com:1443"
+token: "test-token"
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("bad_alias", ["../evil", "/tmp/evil", "a/b", ".", ".."])
+def test_invalid_alias_rejected_by_cli(bad_alias: str):
+    """Commands that accept an alias reject traversal/invalid aliases with a Click error, not a traceback."""
+    runner = CliRunner()
+    for subcmd in (["create", bad_alias], ["delete", bad_alias], ["edit", bad_alias]):
+        result = runner.invoke(config_exporter, subcmd)
+        assert result.exit_code != 0, f"{subcmd} should fail for alias {bad_alias!r}"
+        assert "Invalid exporter alias" in result.output, f"Expected error message in output for {subcmd}"
+
+
+def test_create_shadows_system_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Creating a user config is allowed over a system config, and blocked when a user config already exists."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    # A config exists only in the system location.
+    _write_system_config(system_path / "myexporter.yaml", "myexporter")
+
+    runner = CliRunner()
+    # Creating a user-level config of the same alias is allowed (it shadows the system one).
+    result = runner.invoke(
+        config_exporter,
+        ["create", "myexporter"],
+        input="default\nmyexporter\njumpstarter.my-lab.com:1443\ntest-token\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert (user_path / "myexporter.yaml").exists()
+    assert ExporterConfigV1Alpha1.load("myexporter").path == user_path / "myexporter.yaml"
+
+    # A second create now fails because a user-level config already exists.
+    result = runner.invoke(
+        config_exporter,
+        ["create", "myexporter"],
+        input="default\nmyexporter\njumpstarter.my-lab.com:1443\ntest-token\n",
+    )
+    assert result.exit_code != 0
+    assert "exists" in result.output
+
+
+def test_delete_system_only_shows_click_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Deleting an alias that exists only in the system location exits non-zero with a user-facing error."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    _write_system_config(system_path / "sys.yaml", "sys")
+
+    runner = CliRunner()
+    result = runner.invoke(config_exporter, ["delete", "sys"])
+
+    assert result.exit_code != 0
+    assert "system location" in result.output
 
 
 def test_edit_passes_string_filename_to_click_edit():

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -379,7 +379,7 @@ class ClientConfigV1Alpha1(BaseSettings):
     @classmethod
     def _get_path(cls, alias: str) -> Path:
         """Get the regular path of a client config given an alias."""
-        return (cls.CLIENT_CONFIGS_PATH / alias).with_suffix(".yaml")
+        return cls.CLIENT_CONFIGS_PATH / f"{alias}.yaml"
 
     @classmethod
     def load(cls, alias: str) -> Self:

--- a/python/packages/jumpstarter/jumpstarter/config/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/config/exporter.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import errno
+import os
+import tempfile
 from contextlib import asynccontextmanager, contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Self
@@ -9,7 +12,7 @@ import yaml
 from anyio.from_thread import start_blocking_portal
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from .common import ObjectMeta
+from .common import CONFIG_PATH, ObjectMeta
 from .grpc import call_credentials
 from .tls import TLSConfigV1Alpha1
 from jumpstarter.common.exceptions import ConfigurationError, MissingDriverError
@@ -148,7 +151,20 @@ class ExporterConfigV1Alpha1DriverInstance(RootModel):
 
 
 class ExporterConfigV1Alpha1(BaseModel):
-    BASE_PATH: ClassVar[Path] = Path("/etc/jumpstarter/exporters")
+    """Exporter configuration (jumpstarter.dev/v1alpha1 ExporterConfig).
+
+    Stores credentials, endpoint, driver tree, hooks, and failure-detection
+    settings for a single exporter instance.  The CLI writes new configs to
+    ``BASE_PATH`` (user config dir); ``SYSTEM_CONFIG_PATH`` is kept as a
+    read fallback for production deployments (systemd units, containers).
+    """
+
+    # Default location for exporter configs created via the CLI. Lives under the
+    # user config dir (e.g. ~/.config/jumpstarter/exporters), consistent with clients.
+    BASE_PATH: ClassVar[Path] = CONFIG_PATH / "exporters"
+    # System-wide location, kept as a read fallback so production deployments
+    # (systemd units, containers mounting /etc/jumpstarter) keep working.
+    SYSTEM_CONFIG_PATH: ClassVar[Path] = Path("/etc/jumpstarter/exporters")
 
     alias: str = Field(default="default")
 
@@ -172,15 +188,48 @@ class ExporterConfigV1Alpha1(BaseModel):
     path: Path | None = Field(default=None)
 
     @classmethod
-    def _get_path(cls, alias: str):
-        return (cls.BASE_PATH / alias).with_suffix(".yaml")
+    def validate_alias(cls, alias: str) -> None:
+        if not alias or alias in (".", "..") or any(sep in alias for sep in ("/", "\\")):
+            raise ConfigurationError(
+                f"Invalid exporter alias '{alias}': must not contain path separators or be '.' / '..'"
+            )
 
     @classmethod
-    def exists(cls, alias: str):
+    def _get_path(cls, alias: str) -> Path:
+        cls.validate_alias(alias)
+        return cls.BASE_PATH / f"{alias}.yaml"
+
+    @classmethod
+    def _resolve_path(cls, alias: str) -> Path:
+        """Return an alias's config path, preferring the user dir over the production system location.
+
+        Falls back to the system location only when the user-dir file does not exist. When neither
+        exists, the user-dir path is returned so callers raise a ``FileNotFoundError`` pointing at
+        the current default location.
+        """
+        user_path = cls._get_path(alias)
+        if user_path.exists():
+            return user_path
+        system_path = cls.SYSTEM_CONFIG_PATH / f"{alias}.yaml"
+        if system_path.exists():
+            return system_path
+        return user_path
+
+    @classmethod
+    def user_config_exists(cls, alias: str) -> bool:
         return cls._get_path(alias).exists()
 
     @classmethod
-    def load_path(cls, path: Path):
+    def resolve_path(cls, alias: str) -> Path:
+        return cls._resolve_path(alias)
+
+    @classmethod
+    def exists(cls, alias: str) -> bool:
+        """Return True if a config for the alias exists in either the user or system location."""
+        return cls._resolve_path(alias).exists()
+
+    @classmethod
+    def load_path(cls, path: Path) -> Self:
         with path.open() as f:
             config = cls.model_validate(yaml.safe_load(f))
             config.path = path
@@ -188,38 +237,73 @@ class ExporterConfigV1Alpha1(BaseModel):
 
     @classmethod
     def load(cls, alias: str) -> Self:
-        config = cls.load_path(cls._get_path(alias))
+        """Load the config for an alias, searching the user dir then the system fallback."""
+        config = cls.load_path(cls._resolve_path(alias))
         config.alias = alias
         return config
 
     @classmethod
     def list(cls) -> ExporterConfigListV1Alpha1:
+        """List exporter configs from the user and system locations (user takes precedence)."""
+        # Aliases in the user config dir take precedence over the production system location.
+        aliases: dict[str, None] = {}
+        for base in (cls.BASE_PATH, cls.SYSTEM_CONFIG_PATH):
+            with suppress(FileNotFoundError):
+                for entry in base.iterdir():
+                    if entry.suffix == ".yaml":
+                        aliases.setdefault(entry.stem, None)
         exporters = []
-        with suppress(FileNotFoundError):
-            for entry in cls.BASE_PATH.iterdir():
-                exporters.append(cls.load(entry.stem))
+        for alias in aliases:
+            with suppress(FileNotFoundError):
+                exporters.append(cls.load(alias))
         return ExporterConfigListV1Alpha1(items=exporters)
 
     @classmethod
     def dump_yaml(self, config: Self) -> str:
+        """Serialize a config to a YAML string, omitting internal fields (alias, path)."""
         return yaml.safe_dump(config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), sort_keys=False)
 
     @classmethod
     def save(cls, config: Self, path: Optional[str] = None) -> Path:
+        """Save the config to disk, defaulting to the user config dir when no path is given."""
         # Set the config path before saving
         if path is None:
             config.path = cls._get_path(config.alias)
-            config.path.parent.mkdir(parents=True, exist_ok=True)
         else:
             config.path = Path(path)
-        with config.path.open(mode="w") as f:
-            yaml.safe_dump(config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), f, sort_keys=False)
+        config.path.parent.mkdir(parents=True, exist_ok=True)
+        temp_fd, temp_path = tempfile.mkstemp(prefix=f".{config.path.name}.", dir=config.path.parent)
+        try:
+            os.fchmod(temp_fd, 0o600)
+            with os.fdopen(temp_fd, "w") as f:
+                yaml.safe_dump(
+                    config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), f, sort_keys=False
+                )
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_path, config.path)
+            os.chmod(config.path, 0o600)
+        finally:
+            try:
+                os.unlink(temp_path)
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
         return config.path
 
     @classmethod
     def delete(cls, alias: str) -> Path:
+        """Delete the user-dir config file for an alias and return its path."""
         path = cls._get_path(alias)
-        path.unlink(missing_ok=True)
+        if not path.exists():
+            system_path = cls.SYSTEM_CONFIG_PATH / f"{alias}.yaml"
+            if system_path.exists():
+                raise ConfigurationError(
+                    f"Exporter config '{alias}' exists only in the system location"
+                    f" '{system_path}' and cannot be deleted."
+                )
+            return path
+        path.unlink()
         return path
 
     @asynccontextmanager

--- a/python/packages/jumpstarter/jumpstarter/config/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/exporter_test.py
@@ -5,6 +5,7 @@ import pytest
 from .common import ObjectMeta
 from .exporter import ExporterConfigV1Alpha1, ExporterConfigV1Alpha1DriverInstance
 from .tls import TLSConfigV1Alpha1
+from jumpstarter.common.exceptions import ConfigurationError
 
 pytestmark = pytest.mark.anyio
 
@@ -154,3 +155,120 @@ export:
     assert "afterLease:" in yaml_output
     assert "before_lease:" not in yaml_output
     assert "after_lease:" not in yaml_output
+
+
+def _write_minimal_config(path: Path, name: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: {name}
+endpoint: "jumpstarter.my-lab.com:1443"
+token: "test-token"
+""",
+        encoding="utf-8",
+    )
+
+
+def test_exporter_config_system_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A system-location config is found; saving shadows it in the user dir."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    # A config that only exists in the legacy system location is still found.
+    _write_minimal_config((system_path / "legacy.yaml"), "legacy")
+
+    assert ExporterConfigV1Alpha1.exists("legacy")
+    legacy = ExporterConfigV1Alpha1.load("legacy")
+    assert legacy.alias == "legacy"
+    assert legacy.path == system_path / "legacy.yaml"
+    assert {e.alias for e in ExporterConfigV1Alpha1.list().items} == {"legacy"}
+
+    # Saving defaults to the user dir, never touching the system location.
+    ExporterConfigV1Alpha1.save(legacy)
+    assert (user_path / "legacy.yaml").exists()
+    # The user-dir copy now shadows the system one.
+    assert ExporterConfigV1Alpha1.load("legacy").path == user_path / "legacy.yaml"
+
+
+def test_exporter_config_user_shadows_system(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The user config takes precedence and list() de-duplicates aliases."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    _write_minimal_config((system_path / "dup.yaml"), "dup")
+    _write_minimal_config((user_path / "dup.yaml"), "dup")
+
+    # User dir takes precedence and list() does not return duplicates.
+    assert ExporterConfigV1Alpha1.load("dup").path == user_path / "dup.yaml"
+    aliases = [e.alias for e in ExporterConfigV1Alpha1.list().items]
+    assert aliases == ["dup"]
+
+
+def test_delete_system_only_refuses(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """delete() raises ConfigurationError when the alias exists only in the system location."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    _write_minimal_config(system_path / "sys.yaml", "sys")
+
+    with pytest.raises(ConfigurationError, match="system location"):
+        ExporterConfigV1Alpha1.delete("sys")
+
+    assert (system_path / "sys.yaml").exists()
+
+
+def test_delete_both_locations_removes_only_user(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """delete() removes the user-dir copy and leaves the system-location copy intact."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    _write_minimal_config(user_path / "both.yaml", "both")
+    _write_minimal_config(system_path / "both.yaml", "both")
+
+    ExporterConfigV1Alpha1.delete("both")
+
+    assert not (user_path / "both.yaml").exists()
+    assert (system_path / "both.yaml").exists()
+
+
+def test_delete_nonexistent_is_noop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """delete() is a no-op when the alias does not exist in either location."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    returned = ExporterConfigV1Alpha1.delete("ghost")
+    assert returned == ExporterConfigV1Alpha1._get_path("ghost")
+
+
+def test_list_merges_user_and_system(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """list() returns configs from both user and system dirs when aliases differ."""
+    user_path = tmp_path / "user"
+    system_path = tmp_path / "system"
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", user_path)
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", system_path)
+
+    _write_minimal_config(user_path / "alpha.yaml", "alpha")
+    _write_minimal_config(system_path / "beta.yaml", "beta")
+
+    aliases = {e.alias for e in ExporterConfigV1Alpha1.list().items}
+    assert aliases == {"alpha", "beta"}
+
+
+@pytest.mark.parametrize("bad_alias", ["/tmp/evil", "../evil", "a/b", "a\\b", ".", "..", ""])
+def test_alias_path_traversal_rejected(bad_alias: str):
+    """Aliases with path separators or dot-segments are rejected before any filesystem access."""
+    with pytest.raises(ConfigurationError, match="Invalid exporter alias"):
+        ExporterConfigV1Alpha1.validate_alias(bad_alias)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -85,6 +85,7 @@ docs = [
     { name = "esbonio", specifier = ">=0.16.4" },
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "myst-parser", specifier = ">=5.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "sphinx", specifier = "<8.1.0" },
     { name = "sphinx-autobuild", specifier = ">=2024.4.16" },


### PR DESCRIPTION
Fixes #76.
  
Exporter configs created via the CLI now default to `~/.config/jumpstarter/exporters/` (consistent with clients), instead of the hardcoded `/etc/jumpstarter/exporters/` which needs root. `/etc` is kept as a read fallback, so existing systemd/container deployments keep working.