### PR TITLE
fix: guard DurationParamType against OverflowError on large values

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -36,40 +36,43 @@ class DurationParamType(click.ParamType):
         super().__init__()
         self.minimum = minimum
 
+    def _parse_string(self, value: str, param, ctx) -> timedelta:
+        try:
+            int_value = int(value)
+            try:
+                return timedelta(seconds=int_value)
+            except OverflowError:
+                self.fail(f"{value!r} exceeds the maximum allowed duration", param, ctx)
+        except ValueError:
+            pass
+
+        try:
+            seconds = parse_duration(value)
+            if seconds is not None and isinstance(seconds, (int, float)):
+                return timedelta(seconds=seconds)
+        except (ValueError, TypeError, OverflowError):
+            pass
+
+        try:
+            return TypeAdapter(timedelta).validate_python(value)
+        except (ValueError, ValidationError):
+            self.fail(
+                f"{value!r} is not a valid duration "
+                "(e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')",
+                param,
+                ctx,
+            )
+
     def convert(self, value, param, ctx):
         if isinstance(value, timedelta):
             td = value
         elif isinstance(value, int):
-            # Integer as seconds (backward compatibility)
-            td = timedelta(seconds=value)
-        elif isinstance(value, str):
-            # Try parsing as plain integer first (backward compatibility)
             try:
-                int_value = int(value)
-                td = timedelta(seconds=int_value)
-            except ValueError:
-                # Parse with pytimeparse2 first (supports human-readable formats)
-                td = None
-                try:
-                    seconds = parse_duration(value)
-                    if seconds is not None and isinstance(seconds, (int, float)):
-                        td = timedelta(seconds=seconds)
-                except (ValueError, TypeError):
-                    pass
-
-                # Fall back to pydantic/speedate for ISO 8601 and other formats
-                if td is None:
-                    try:
-                        td = TypeAdapter(timedelta).validate_python(value)
-                    except (ValueError, ValidationError):
-                        self.fail(
-                            (
-                                f"{value!r} is not a valid duration "
-                                "(e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')"
-                            ),
-                            param,
-                            ctx,
-                        )
+                td = timedelta(seconds=value)
+            except OverflowError:
+                self.fail(f"{value!r} exceeds the maximum allowed duration", param, ctx)
+        elif isinstance(value, str):
+            td = self._parse_string(value, param, ctx)
         else:
             self.fail(
                 f"{value!r} is not a valid duration (e.g., '30m', '3h30m', '1d', '1d3h40m')",
@@ -77,12 +80,9 @@ class DurationParamType(click.ParamType):
                 ctx,
             )
 
-        # Validate minimum if specified
         if self.minimum is not None and td < self.minimum:
             min_seconds = int(self.minimum.total_seconds())
-            self.fail(
-                f"{value!r} must be at least {min_seconds} seconds", param, ctx
-            )
+            self.fail(f"{value!r} must be at least {min_seconds} seconds", param, ctx)
 
         return td
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -56,12 +56,13 @@ class DurationParamType(click.ParamType):
 
         try:
             return TypeAdapter(timedelta).validate_python(value)
-        except (ValueError, ValidationError):
+        except (ValueError, ValidationError) as exc:
             self.fail(
                 f"{value!r} is not a valid duration (e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')",
                 param,
                 ctx,
             )
+            raise exc
 
     def convert(self, value, param, ctx):
         if isinstance(value, timedelta):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -10,6 +10,7 @@ def _opt_selector_callback(_ctx, _param, value):
     """Combine multiple selector values into a single comma-separated string."""
     return ",".join(value) if value else None
 
+
 opt_selector = click.option(
     "-l",
     "--selector",
@@ -57,8 +58,7 @@ class DurationParamType(click.ParamType):
             return TypeAdapter(timedelta).validate_python(value)
         except (ValueError, ValidationError):
             self.fail(
-                f"{value!r} is not a valid duration "
-                "(e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')",
+                f"{value!r} is not a valid duration (e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')",
                 param,
                 ctx,
             )

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -71,7 +71,7 @@ class DurationParamType(click.ParamType):
     def convert(self, value, param, ctx):
         if isinstance(value, timedelta):
             td = value
-        elif isinstance(value, (str, int)):
+        elif isinstance(value, (str, int, float)):
             td = self._parse_string(str(value), param, ctx)
         else:
             self.fail(

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -79,10 +79,12 @@ class DurationParamType(click.ParamType):
                 param,
                 ctx,
             )
+            raise  # satisfy ty: self.fail is NoReturn but ty cannot verify it
 
         if self.minimum is not None and td < self.minimum:
             min_seconds = int(self.minimum.total_seconds())
             self.fail(f"{value!r} must be at least {min_seconds} seconds", param, ctx)
+            raise  # satisfy ty: self.fail is NoReturn but ty cannot verify it
 
         return td
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -60,7 +60,7 @@ class DurationParamType(click.ParamType):
 
         try:
             return TypeAdapter(timedelta).validate_python(value)
-        except (ValueError, ValidationError):
+        except (ValueError, ValidationError, OverflowError):
             self.fail(
                 f"{value!r} is not a valid duration (e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')",
                 param,

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -51,29 +51,25 @@ class DurationParamType(click.ParamType):
             seconds = parse_duration(value)
             if seconds is not None and isinstance(seconds, (int, float)):
                 return timedelta(seconds=seconds)
-        except (ValueError, TypeError, OverflowError):
+        except OverflowError:
+            self.fail(f"{value!r} exceeds the maximum allowed duration", param, ctx)
+        except (ValueError, TypeError):
             pass
 
         try:
             return TypeAdapter(timedelta).validate_python(value)
-        except (ValueError, ValidationError) as exc:
+        except (ValueError, ValidationError):
             self.fail(
                 f"{value!r} is not a valid duration (e.g., '30m', '3h30m', '1d', '1d3h40m', 'PT1H30M', '01:30:00')",
                 param,
                 ctx,
             )
-            raise exc
 
     def convert(self, value, param, ctx):
         if isinstance(value, timedelta):
             td = value
-        elif isinstance(value, int):
-            try:
-                td = timedelta(seconds=value)
-            except OverflowError:
-                self.fail(f"{value!r} exceeds the maximum allowed duration", param, ctx)
-        elif isinstance(value, str):
-            td = self._parse_string(value, param, ctx)
+        elif isinstance(value, (str, int)):
+            td = self._parse_string(str(value), param, ctx)
         else:
             self.fail(
                 f"{value!r} is not a valid duration (e.g., '30m', '3h30m', '1d', '1d3h40m')",

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -44,6 +44,7 @@ class DurationParamType(click.ParamType):
                 return timedelta(seconds=int_value)
             except OverflowError:
                 self.fail(f"{value!r} exceeds the maximum allowed duration", param, ctx)
+                raise  # satisfy ty: self.fail is NoReturn but ty cannot verify it
         except ValueError:
             pass
 
@@ -53,6 +54,7 @@ class DurationParamType(click.ParamType):
                 return timedelta(seconds=seconds)
         except OverflowError:
             self.fail(f"{value!r} exceeds the maximum allowed duration", param, ctx)
+            raise  # satisfy ty: self.fail is NoReturn but ty cannot verify it
         except (ValueError, TypeError):
             pass
 
@@ -64,6 +66,7 @@ class DurationParamType(click.ParamType):
                 param,
                 ctx,
             )
+            raise  # satisfy ty: self.fail is NoReturn but ty cannot verify it
 
     def convert(self, value, param, ctx):
         if isinstance(value, timedelta):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
@@ -108,4 +108,3 @@ class TestDurationParamType:
         param_type = DurationParamType()
         with pytest.raises(click.BadParameter, match="is not a valid duration"):
             param_type.convert(object(), None, None)
-

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
@@ -92,6 +92,18 @@ class TestDurationParamType:
         td = DURATION.convert(42, None, None)
         assert td == timedelta(seconds=42)
 
+    def test_large_string_integer_raises_bad_parameter_not_overflow(self):
+        with pytest.raises(click.BadParameter, match="exceeds the maximum allowed duration"):
+            DURATION.convert("86400000000000", None, None)
+
+    def test_large_integer_raises_bad_parameter_not_overflow(self):
+        with pytest.raises(click.BadParameter, match="exceeds the maximum allowed duration"):
+            DURATION.convert(86400000000000, None, None)
+
+    def test_large_negative_string_raises_bad_parameter_not_overflow(self):
+        with pytest.raises(click.BadParameter, match="exceeds the maximum allowed duration"):
+            DURATION.convert("-86400000000000", None, None)
+
     def test_unsupported_type_raises_click_exception(self):
         param_type = DurationParamType()
         with pytest.raises(click.BadParameter, match="is not a valid duration"):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
@@ -104,6 +104,10 @@ class TestDurationParamType:
         with pytest.raises(click.BadParameter, match="exceeds the maximum allowed duration"):
             DURATION.convert("-86400000000000", None, None)
 
+    def test_large_pytimeparse_duration_raises_bad_parameter_not_overflow(self):
+        with pytest.raises(click.BadParameter, match="exceeds the maximum allowed duration"):
+            DURATION.convert("999999999d23h59m59.999999s", None, None)
+
     def test_unsupported_type_raises_click_exception(self):
         param_type = DurationParamType()
         with pytest.raises(click.BadParameter, match="is not a valid duration"):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
@@ -112,6 +112,10 @@ class TestDurationParamType:
         td = DURATION.convert("86399999999999", None, None)
         assert td == timedelta(days=999999999, hours=23, minutes=59, seconds=59)
 
+    def test_float_value_as_seconds(self):
+        td = DURATION.convert(3.5, None, None)
+        assert td == timedelta(seconds=3.5)
+
     def test_unsupported_type_raises_click_exception(self):
         param_type = DurationParamType()
         with pytest.raises(click.BadParameter, match="is not a valid duration"):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
@@ -108,6 +108,10 @@ class TestDurationParamType:
         with pytest.raises(click.BadParameter, match="exceeds the maximum allowed duration"):
             DURATION.convert("999999999d23h59m59.999999s", None, None)
 
+    def test_value_at_timedelta_max_seconds_succeeds(self):
+        td = DURATION.convert("86399999913600", None, None)
+        assert td == timedelta(days=999999999)
+
     def test_unsupported_type_raises_click_exception(self):
         param_type = DurationParamType()
         with pytest.raises(click.BadParameter, match="is not a valid duration"):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common_test.py
@@ -109,8 +109,8 @@ class TestDurationParamType:
             DURATION.convert("999999999d23h59m59.999999s", None, None)
 
     def test_value_at_timedelta_max_seconds_succeeds(self):
-        td = DURATION.convert("86399999913600", None, None)
-        assert td == timedelta(days=999999999)
+        td = DURATION.convert("86399999999999", None, None)
+        assert td == timedelta(days=999999999, hours=23, minutes=59, seconds=59)
 
     def test_unsupported_type_raises_click_exception(self):
         param_type = DurationParamType()


### PR DESCRIPTION
## Summary
- Fixes `OverflowError` crash in `DurationParamType.convert()` when extremely large integer values (e.g. `86400000000000`) are passed, which cause `timedelta(seconds=...)` to overflow
- Catches `OverflowError` in both the integer and string-integer parsing paths and converts it to a user-friendly `click.BadParameter` error
- Extracts string parsing logic into `_parse_string()` for clarity and adds `OverflowError` to the `pytimeparse2` exception handling
- Adds regression tests for large positive integers, large string integers, and large negative string integers

Closes #717

## Test plan
- [x] `test_large_string_integer_raises_bad_parameter_not_overflow` -- verifies string `"86400000000000"` raises `BadParameter` not `OverflowError`
- [x] `test_large_integer_raises_bad_parameter_not_overflow` -- verifies int `86400000000000` raises `BadParameter` not `OverflowError`
- [x] `test_large_negative_string_raises_bad_parameter_not_overflow` -- verifies string `"-86400000000000"` raises `BadParameter` not `OverflowError`
- [x] All existing `DurationParamType` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)