### PR TITLE
fix: raise TypeError in V1Alpha1Lease.from_dict for non-dict spec

### DIFF
--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Literal, Optional
 
 from kubernetes_asyncio.client.models import V1Condition, V1ObjectMeta, V1ObjectReference
@@ -37,7 +38,10 @@ class V1Alpha1Lease(JsonBaseModel):
 
     @staticmethod
     def from_dict(dict: dict):
-        selector_data = dict["spec"].get("selector", {})
+        spec = dict["spec"]
+        if not isinstance(spec, Mapping):
+            raise TypeError(f"spec must be a dict, got {type(spec).__name__}")
+        selector_data = spec.get("selector", {})
         return V1Alpha1Lease(
             api_version=dict["apiVersion"],
             kind=dict["kind"],
@@ -70,10 +74,10 @@ class V1Alpha1Lease(JsonBaseModel):
                 ],
             ),
             spec=V1Alpha1LeaseSpec(
-                client=V1ObjectReference(name=dict["spec"]["clientRef"]["name"])
-                if "clientRef" in dict["spec"]
+                client=V1ObjectReference(name=spec["clientRef"]["name"])
+                if "clientRef" in spec
                 else None,
-                duration=dict["spec"]["duration"] if "duration" in dict["spec"] else None,
+                duration=spec["duration"] if "duration" in spec else None,
                 selector=V1Alpha1LeaseSelector(match_labels=selector_data.get("matchLabels", {})),
             ),
         )

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
@@ -74,9 +74,7 @@ class V1Alpha1Lease(JsonBaseModel):
                 ],
             ),
             spec=V1Alpha1LeaseSpec(
-                client=V1ObjectReference(name=spec["clientRef"]["name"])
-                if "clientRef" in spec
-                else None,
+                client=V1ObjectReference(name=spec["clientRef"]["name"]) if "clientRef" in spec else None,
                 duration=spec["duration"] if "duration" in spec else None,
                 selector=V1Alpha1LeaseSelector(match_labels=selector_data.get("matchLabels", {})),
             ),

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
@@ -40,7 +40,7 @@ class V1Alpha1Lease(JsonBaseModel):
     def from_dict(dict: dict):
         spec = dict["spec"]
         if not isinstance(spec, Mapping):
-            raise TypeError(f"spec must be a dict, got {type(spec).__name__}")
+            raise TypeError(f"spec must be a dict, got {type(spec).__name__}: {repr(spec)}")
         selector_data = spec.get("selector", {})
         return V1Alpha1Lease(
             api_version=dict["apiVersion"],

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/leases.py
@@ -37,29 +37,29 @@ class V1Alpha1Lease(JsonBaseModel):
     status: V1Alpha1LeaseStatus
 
     @staticmethod
-    def from_dict(dict: dict):
-        spec = dict["spec"]
+    def from_dict(data: dict):
+        spec = data["spec"]
         if not isinstance(spec, Mapping):
             raise TypeError(f"spec must be a dict, got {type(spec).__name__}: {repr(spec)}")
         selector_data = spec.get("selector", {})
         return V1Alpha1Lease(
-            api_version=dict["apiVersion"],
-            kind=dict["kind"],
+            api_version=data["apiVersion"],
+            kind=data["kind"],
             metadata=V1ObjectMeta(
-                creation_timestamp=dict["metadata"]["creationTimestamp"],
-                generation=dict["metadata"]["generation"],
-                managed_fields=dict["metadata"]["managedFields"],
-                name=dict["metadata"]["name"],
-                namespace=dict["metadata"]["namespace"],
-                resource_version=dict["metadata"]["resourceVersion"],
-                uid=dict["metadata"]["uid"],
+                creation_timestamp=data["metadata"]["creationTimestamp"],
+                generation=data["metadata"]["generation"],
+                managed_fields=data["metadata"]["managedFields"],
+                name=data["metadata"]["name"],
+                namespace=data["metadata"]["namespace"],
+                resource_version=data["metadata"]["resourceVersion"],
+                uid=data["metadata"]["uid"],
             ),
             status=V1Alpha1LeaseStatus(
-                begin_time=dict["status"]["beginTime"] if "beginTime" in dict["status"] else None,
-                end_time=dict["status"]["endTime"] if "endTime" in dict["status"] else None,
-                ended=dict["status"]["ended"],
-                exporter=V1ObjectReference(name=dict["status"]["exporterRef"]["name"])
-                if "exporterRef" in dict["status"]
+                begin_time=data["status"]["beginTime"] if "beginTime" in data["status"] else None,
+                end_time=data["status"]["endTime"] if "endTime" in data["status"] else None,
+                ended=data["status"]["ended"],
+                exporter=V1ObjectReference(name=data["status"]["exporterRef"]["name"])
+                if "exporterRef" in data["status"]
                 else None,
                 conditions=[
                     V1Condition(
@@ -70,7 +70,7 @@ class V1Alpha1Lease(JsonBaseModel):
                         status=cond["status"],
                         type=cond["type"],
                     )
-                    for cond in dict["status"]["conditions"]
+                    for cond in data["status"]["conditions"]
                 ],
             ),
             spec=V1Alpha1LeaseSpec(
@@ -135,8 +135,8 @@ class V1Alpha1LeaseList(V1Alpha1List[V1Alpha1Lease]):
     kind: Literal["LeaseList"] = Field(default="LeaseList")
 
     @staticmethod
-    def from_dict(dict: dict):
-        return V1Alpha1LeaseList(items=[V1Alpha1Lease.from_dict(c) for c in dict["items"]])
+    def from_dict(data: dict):
+        return V1Alpha1LeaseList(items=[V1Alpha1Lease.from_dict(c) for c in data["items"]])
 
     @classmethod
     def rich_add_columns(cls, table):

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/test_leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/test_leases.py
@@ -1,3 +1,4 @@
+import pytest
 from kubernetes_asyncio.client.models import V1Condition, V1ObjectMeta, V1ObjectReference
 
 from jumpstarter_kubernetes import V1Alpha1Lease, V1Alpha1LeaseSelector, V1Alpha1LeaseSpec, V1Alpha1LeaseStatus
@@ -152,3 +153,23 @@ def test_lease_from_dict_without_match_labels_name_targeted():
     )
 
     assert lease.spec.selector.match_labels == {}
+
+
+def test_from_dict_raises_type_error_when_spec_is_a_list():
+    with pytest.raises(TypeError):
+        V1Alpha1Lease.from_dict({"spec": []})
+
+
+def test_from_dict_raises_type_error_when_spec_is_a_string():
+    with pytest.raises(TypeError):
+        V1Alpha1Lease.from_dict({"spec": "invalid"})
+
+
+def test_from_dict_raises_type_error_when_spec_is_an_integer():
+    with pytest.raises(TypeError):
+        V1Alpha1Lease.from_dict({"spec": 42})
+
+
+def test_from_dict_raises_type_error_when_spec_is_none():
+    with pytest.raises(TypeError):
+        V1Alpha1Lease.from_dict({"spec": None})

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/test_leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/test_leases.py
@@ -173,3 +173,13 @@ def test_from_dict_raises_type_error_when_spec_is_an_integer():
 def test_from_dict_raises_type_error_when_spec_is_none():
     with pytest.raises(TypeError):
         V1Alpha1Lease.from_dict({"spec": None})
+
+
+def test_from_dict_raises_type_error_when_spec_is_a_boolean():
+    with pytest.raises(TypeError):
+        V1Alpha1Lease.from_dict({"spec": True})
+
+
+def test_from_dict_does_not_raise_type_error_when_spec_is_an_empty_dict():
+    with pytest.raises(KeyError):
+        V1Alpha1Lease.from_dict({"spec": {}})

--- a/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/test_leases.py
+++ b/python/packages/jumpstarter-kubernetes/jumpstarter_kubernetes/test_leases.py
@@ -180,6 +180,6 @@ def test_from_dict_raises_type_error_when_spec_is_a_boolean():
         V1Alpha1Lease.from_dict({"spec": True})
 
 
-def test_from_dict_does_not_raise_type_error_when_spec_is_an_empty_dict():
+def test_from_dict_with_empty_spec_raises_key_error_not_type_error():
     with pytest.raises(KeyError):
         V1Alpha1Lease.from_dict({"spec": {}})


### PR DESCRIPTION
## Summary
- Add type check in `V1Alpha1Lease.from_dict` to raise `TypeError` when `spec` is not a dict, instead of leaking an `AttributeError` from `.get()`
- Extract `spec` into a local variable to avoid repeated `dict["spec"]` lookups
- Add regression tests covering list, string, integer, None, boolean, and empty dict inputs

Fixes https://github.com/jumpstarter-dev/jumpstarter/issues/719

## Test plan
- [x] `test_from_dict_raises_type_error_when_spec_is_a_list`
- [x] `test_from_dict_raises_type_error_when_spec_is_a_string`
- [x] `test_from_dict_raises_type_error_when_spec_is_an_integer`
- [x] `test_from_dict_raises_type_error_when_spec_is_none`
- [x] `test_from_dict_raises_type_error_when_spec_is_a_boolean`
- [x] `test_from_dict_does_not_raise_type_error_when_spec_is_an_empty_dict`
- [x] Existing `test_leases.py` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)