### PR TITLE
fix: include exporter/client name and namespace in auth error messages

### DIFF
--- a/controller/internal/oidc/token.go
+++ b/controller/internal/oidc/token.go
@@ -10,10 +10,34 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func k8sToGRPCCode(err error) codes.Code {
+	switch {
+	case apierrors.IsNotFound(err):
+		return codes.NotFound
+	case apierrors.IsForbidden(err):
+		return codes.PermissionDenied
+	case apierrors.IsUnauthorized(err):
+		return codes.Unauthenticated
+	case apierrors.IsAlreadyExists(err):
+		return codes.AlreadyExists
+	case apierrors.IsConflict(err):
+		return codes.Aborted
+	case apierrors.IsInvalid(err):
+		return codes.InvalidArgument
+	case apierrors.IsServiceUnavailable(err):
+		return codes.Unavailable
+	case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err):
+		return codes.DeadlineExceeded
+	default:
+		return codes.Internal
+	}
+}
 
 func VerifyOIDCToken(
 	ctx context.Context,
@@ -53,7 +77,7 @@ func VerifyClientObjectToken(
 
 	decision, _, err := authn.Authorize(ctx, attrs)
 	if err != nil {
-		return nil, fmt.Errorf("client %s/%s: %w", clientNamespace, clientName, err)
+		return nil, status.Errorf(status.Code(err), "client %s/%s: %v", clientNamespace, clientName, err)
 	}
 
 	if decision != authorizer.DecisionAllow {
@@ -65,7 +89,7 @@ func VerifyClientObjectToken(
 		Namespace: clientNamespace,
 		Name:      clientName,
 	}, &client); err != nil {
-		return nil, fmt.Errorf("client %s/%s: %w", clientNamespace, clientName, err)
+		return nil, status.Errorf(k8sToGRPCCode(err), "client %s/%s: %v", clientNamespace, clientName, err)
 	}
 
 	return &client, nil
@@ -92,7 +116,7 @@ func VerifyExporterObjectToken(
 
 	decision, _, err := authn.Authorize(ctx, attrs)
 	if err != nil {
-		return nil, fmt.Errorf("exporter %s/%s: %w", exporterNamespace, exporterName, err)
+		return nil, status.Errorf(status.Code(err), "exporter %s/%s: %v", exporterNamespace, exporterName, err)
 	}
 
 	if decision != authorizer.DecisionAllow {
@@ -104,7 +128,7 @@ func VerifyExporterObjectToken(
 		Namespace: exporterNamespace,
 		Name:      exporterName,
 	}, &exporter); err != nil {
-		return nil, fmt.Errorf("exporter %s/%s: %w", exporterNamespace, exporterName, err)
+		return nil, status.Errorf(k8sToGRPCCode(err), "exporter %s/%s: %v", exporterNamespace, exporterName, err)
 	}
 
 	return &exporter, nil

--- a/controller/internal/oidc/token.go
+++ b/controller/internal/oidc/token.go
@@ -48,21 +48,24 @@ func VerifyClientObjectToken(
 		return nil, status.Errorf(codes.InvalidArgument, "object kind mismatch")
 	}
 
+	clientName := attrs.GetName()
+	clientNamespace := attrs.GetNamespace()
+
 	decision, _, err := authn.Authorize(ctx, attrs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("client %s/%s: %w", clientNamespace, clientName, err)
 	}
 
 	if decision != authorizer.DecisionAllow {
-		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
+		return nil, status.Errorf(codes.PermissionDenied, "permission denied for client %s/%s", clientNamespace, clientName)
 	}
 
 	var client jumpstarterdevv1alpha1.Client
 	if err = kclient.Get(ctx, types.NamespacedName{
-		Namespace: attrs.GetNamespace(),
-		Name:      attrs.GetName(),
+		Namespace: clientNamespace,
+		Name:      clientName,
 	}, &client); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("client %s/%s: %w", clientNamespace, clientName, err)
 	}
 
 	return &client, nil
@@ -84,21 +87,24 @@ func VerifyExporterObjectToken(
 		return nil, status.Errorf(codes.InvalidArgument, "object kind mismatch")
 	}
 
+	exporterName := attrs.GetName()
+	exporterNamespace := attrs.GetNamespace()
+
 	decision, _, err := authn.Authorize(ctx, attrs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("exporter %s/%s: %w", exporterNamespace, exporterName, err)
 	}
 
 	if decision != authorizer.DecisionAllow {
-		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
+		return nil, status.Errorf(codes.PermissionDenied, "permission denied for exporter %s/%s", exporterNamespace, exporterName)
 	}
 
 	var exporter jumpstarterdevv1alpha1.Exporter
 	if err = kclient.Get(ctx, types.NamespacedName{
-		Namespace: attrs.GetNamespace(),
-		Name:      attrs.GetName(),
+		Namespace: exporterNamespace,
+		Name:      exporterName,
 	}, &exporter); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("exporter %s/%s: %w", exporterNamespace, exporterName, err)
 	}
 
 	return &exporter, nil

--- a/controller/internal/oidc/token_test.go
+++ b/controller/internal/oidc/token_test.go
@@ -145,6 +145,89 @@ func TestVerifyExporterObjectToken_TokenFailureDoesNotIncludeIdentity(t *testing
 	}
 }
 
+func TestVerifyExporterObjectToken_AuthorizeErrorPreservesGRPCCode(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "ns",
+			Resource:  "Exporter",
+			Name:      "exp",
+		},
+	}
+	authz := &stubAuthorizer{
+		err: status.Errorf(codes.Unavailable, "backend down"),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyExporterObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("expected Unavailable, got %v", st.Code())
+	}
+	if !strings.Contains(err.Error(), "exp") {
+		t.Errorf("error should contain exporter name, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ns") {
+		t.Errorf("error should contain namespace, got: %s", err.Error())
+	}
+}
+
+func TestVerifyExporterObjectToken_GetFailurePreservesGRPCCode(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "prod-namespace",
+			Resource:  "Exporter",
+			Name:      "prod-exporter",
+		},
+	}
+	authz := &stubAuthorizer{
+		decision: authorizer.DecisionAllow,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyExporterObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error (exporter not found), got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+	if !strings.Contains(err.Error(), "prod-exporter") {
+		t.Errorf("error should contain exporter name, got: %s", err.Error())
+	}
+}
+
 func TestVerifyExporterObjectToken_PermissionDeniedPreservesGRPCCode(t *testing.T) {
 	authn := &stubAuthenticator{
 		resp: &authenticator.Response{

--- a/controller/internal/oidc/token_test.go
+++ b/controller/internal/oidc/token_test.go
@@ -264,3 +264,153 @@ func TestVerifyExporterObjectToken_PermissionDeniedPreservesGRPCCode(t *testing.
 		t.Errorf("expected PermissionDenied, got %v", st.Code())
 	}
 }
+
+func TestVerifyClientObjectToken_PermissionDeniedIncludesClientIdentity(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "test-namespace",
+			Resource:  "Client",
+			Name:      "my-client",
+		},
+	}
+	authz := &stubAuthorizer{
+		decision: authorizer.DecisionDeny,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyClientObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied code, got %v", st.Code())
+	}
+	if !strings.Contains(err.Error(), "my-client") {
+		t.Errorf("error should contain client name 'my-client', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "test-namespace") {
+		t.Errorf("error should contain namespace 'test-namespace', got: %s", err.Error())
+	}
+}
+
+func TestVerifyClientObjectToken_GetFailureIncludesClientIdentity(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "prod-namespace",
+			Resource:  "Client",
+			Name:      "prod-client",
+		},
+	}
+	authz := &stubAuthorizer{
+		decision: authorizer.DecisionAllow,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyClientObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error (client not found), got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound code, got %v", st.Code())
+	}
+	if !strings.Contains(err.Error(), "prod-client") {
+		t.Errorf("error should contain client name 'prod-client', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "prod-namespace") {
+		t.Errorf("error should contain namespace 'prod-namespace', got: %s", err.Error())
+	}
+}
+
+func TestVerifyClientObjectToken_TokenFailureDoesNotIncludeIdentity(t *testing.T) {
+	authn := &stubAuthenticator{
+		err: fmt.Errorf("invalid token"),
+	}
+	attrs := &stubAttributesGetter{}
+	authz := &stubAuthorizer{}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyClientObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if err.Error() != "invalid token" {
+		t.Errorf("expected raw error 'invalid token', got: %s", err.Error())
+	}
+}
+
+func TestVerifyClientObjectToken_AuthorizeErrorPreservesGRPCCode(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "ns",
+			Resource:  "Client",
+			Name:      "cli",
+		},
+	}
+	authz := &stubAuthorizer{
+		err: status.Errorf(codes.Unavailable, "backend down"),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyClientObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("expected Unavailable, got %v", st.Code())
+	}
+	if !strings.Contains(err.Error(), "cli") {
+		t.Errorf("error should contain client name, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ns") {
+		t.Errorf("error should contain namespace, got: %s", err.Error())
+	}
+}

--- a/controller/internal/oidc/token_test.go
+++ b/controller/internal/oidc/token_test.go
@@ -1,0 +1,183 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type stubAuthenticator struct {
+	resp *authenticator.Response
+	ok   bool
+	err  error
+}
+
+func (s *stubAuthenticator) AuthenticateContext(_ context.Context) (*authenticator.Response, bool, error) {
+	return s.resp, s.ok, s.err
+}
+
+type stubAttributesGetter struct {
+	attrs authorizer.Attributes
+	err   error
+}
+
+func (s *stubAttributesGetter) ContextAttributes(_ context.Context, _ user.Info) (authorizer.Attributes, error) {
+	return s.attrs, s.err
+}
+
+type stubAuthorizer struct {
+	decision authorizer.Decision
+	reason   string
+	err      error
+}
+
+func (s *stubAuthorizer) Authorize(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+	return s.decision, s.reason, s.err
+}
+
+func TestVerifyExporterObjectToken_PermissionDeniedIncludesExporterIdentity(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "test-namespace",
+			Resource:  "Exporter",
+			Name:      "my-exporter",
+		},
+	}
+	authz := &stubAuthorizer{
+		decision: authorizer.DecisionDeny,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyExporterObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied code, got %v", st.Code())
+	}
+	if !strings.Contains(err.Error(), "my-exporter") {
+		t.Errorf("error should contain exporter name 'my-exporter', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "test-namespace") {
+		t.Errorf("error should contain namespace 'test-namespace', got: %s", err.Error())
+	}
+}
+
+func TestVerifyExporterObjectToken_GetFailureIncludesExporterIdentity(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "prod-namespace",
+			Resource:  "Exporter",
+			Name:      "prod-exporter",
+		},
+	}
+	authz := &stubAuthorizer{
+		decision: authorizer.DecisionAllow,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyExporterObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error (exporter not found), got nil")
+	}
+
+	if !strings.Contains(err.Error(), "prod-exporter") {
+		t.Errorf("error should contain exporter name 'prod-exporter', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "prod-namespace") {
+		t.Errorf("error should contain namespace 'prod-namespace', got: %s", err.Error())
+	}
+}
+
+func TestVerifyExporterObjectToken_TokenFailureDoesNotIncludeIdentity(t *testing.T) {
+	authn := &stubAuthenticator{
+		err: fmt.Errorf("invalid token"),
+	}
+	attrs := &stubAttributesGetter{}
+	authz := &stubAuthorizer{}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyExporterObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if err.Error() != "invalid token" {
+		t.Errorf("expected raw error 'invalid token', got: %s", err.Error())
+	}
+}
+
+func TestVerifyExporterObjectToken_PermissionDeniedPreservesGRPCCode(t *testing.T) {
+	authn := &stubAuthenticator{
+		resp: &authenticator.Response{
+			User: &user.DefaultInfo{Name: "test-user"},
+		},
+		ok: true,
+	}
+	attrs := &stubAttributesGetter{
+		attrs: authorizer.AttributesRecord{
+			User:      &user.DefaultInfo{Name: "test-user"},
+			Namespace: "ns",
+			Resource:  "Exporter",
+			Name:      "exp",
+		},
+	}
+	authz := &stubAuthorizer{
+		decision: authorizer.DecisionDeny,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := VerifyExporterObjectToken(context.Background(), authn, authz, attrs, fakeClient)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}


### PR DESCRIPTION
## Summary
- Adds target name and namespace to authentication error messages in `VerifyExporterObjectToken` and `VerifyClientObjectToken`, so operators can identify which exporter or client failed auth
- Introduces `k8sToGRPCCode` helper to preserve proper gRPC status codes when wrapping k8s API errors
- Adds comprehensive test coverage for both verification functions

Closes #27

## Test plan
- [x] `VerifyExporterObjectToken` permission denied error includes exporter name and namespace
- [x] `VerifyClientObjectToken` permission denied error includes client name and namespace
- [x] Get failures (not found) include identity in error message
- [x] gRPC status codes are preserved through error wrapping
- [x] Token failures (before identity is known) do not leak identity info

🤖 Generated with [Claude Code](https://claude.com/claude-code)