### PR TITLE
ci: make linkcheck job non-blocking for PRs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -103,6 +103,7 @@ jobs:
 
   linkcheck:
     runs-on: ubuntu-latest
+    continue-on-error: true
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to the `linkcheck` job in the Documentation workflow
- The job still runs on every PR for visibility, but its failure no longer blocks merging
- Prevents external link breakage (third-party sites going down, URL changes) from gating unrelated PRs

## Test plan
- [ ] Verify the workflow file diff is correct (single line addition)
- [ ] On a future run where a link is broken, the job shows as neutral (yellow) rather than failed (red), and does not block merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)