### PR TITLE
ci: collect controller, router and exporter logs from e2e runs

### DIFF
--- a/.github/actions/collect-e2e-logs/action.yaml
+++ b/.github/actions/collect-e2e-logs/action.yaml
@@ -1,0 +1,47 @@
+name: Collect e2e logs
+description: Collect controller, router, and pod logs from the e2e kind cluster
+
+inputs:
+  artifact-name:
+    description: Name for the uploaded artifact
+    required: true
+  namespace:
+    description: Kubernetes namespace to collect logs from
+    required: false
+    default: jumpstarter-lab
+  retention-days:
+    description: Number of days to retain the artifact
+    required: false
+    default: "7"
+
+runs:
+  using: composite
+  steps:
+    - name: Collect e2e logs
+      if: always()
+      shell: bash
+      run: |
+        mkdir -p /tmp/e2e-logs
+        NS=${{ inputs.namespace }}
+        kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+          || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+          || true
+        kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+          || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+          || true
+        kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+          || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+          || true
+        kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+          || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+          || true
+        kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+        kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+
+    - name: Upload e2e logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: /tmp/e2e-logs/
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/collect-e2e-logs/action.yaml
+++ b/.github/actions/collect-e2e-logs/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Collect e2e logs
-      if: always()
+      if: failure()
       shell: bash
       run: |
         mkdir -p /tmp/e2e-logs
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Upload e2e logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/actions/collect-e2e-logs/action.yaml
+++ b/.github/actions/collect-e2e-logs/action.yaml
@@ -38,8 +38,10 @@ runs:
         kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
         kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
         EXPORTER_LOG_DIR="${E2E_EXPORTER_LOG_DIR:-/tmp/e2e-logs/exporters}"
-        if [ -d "$EXPORTER_LOG_DIR" ]; then
+        if [ -d "$EXPORTER_LOG_DIR" ] && [ "$EXPORTER_LOG_DIR" != "/tmp/e2e-logs/exporters" ]; then
           cp -r "$EXPORTER_LOG_DIR" /tmp/e2e-logs/exporters 2>/dev/null || true
+        fi
+        if [ -d /tmp/e2e-logs/exporters ]; then
           echo "Exporter logs collected:"
           ls -la /tmp/e2e-logs/exporters/
         fi

--- a/.github/actions/collect-e2e-logs/action.yaml
+++ b/.github/actions/collect-e2e-logs/action.yaml
@@ -37,6 +37,12 @@ runs:
           || true
         kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
         kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+        EXPORTER_LOG_DIR="${E2E_EXPORTER_LOG_DIR:-/tmp/e2e-logs/exporters}"
+        if [ -d "$EXPORTER_LOG_DIR" ]; then
+          cp -r "$EXPORTER_LOG_DIR" /tmp/e2e-logs/exporters 2>/dev/null || true
+          echo "Exporter logs collected:"
+          ls -la /tmp/e2e-logs/exporters/
+        fi
 
     - name: Upload e2e logs
       if: always()

--- a/.github/actions/collect-e2e-logs/action.yaml
+++ b/.github/actions/collect-e2e-logs/action.yaml
@@ -23,18 +23,18 @@ runs:
       run: |
         mkdir -p /tmp/e2e-logs
         NS=${{ inputs.namespace }}
-        kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-          || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-          || true
-        kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-          || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-          || true
-        kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-          || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-          || true
-        kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-          || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-          || true
+        collect_logs() {
+          local outfile="$1" primary="$2" fallback="$3"
+          shift 3
+          kubectl -n "$NS" logs -l "$primary" "$@" > "$outfile" 2>&1 || true
+          if [ ! -s "$outfile" ]; then
+            kubectl -n "$NS" logs -l "$fallback" "$@" > "$outfile" 2>&1 || true
+          fi
+        }
+        collect_logs /tmp/e2e-logs/controller.log component=controller control-plane=controller-manager --all-containers --prefix --tail=-1
+        collect_logs /tmp/e2e-logs/controller-previous.log component=controller control-plane=controller-manager --all-containers --prefix --previous
+        collect_logs /tmp/e2e-logs/router.log component=router control-plane=controller-router --all-containers --prefix --tail=-1
+        collect_logs /tmp/e2e-logs/router-previous.log component=router control-plane=controller-router --all-containers --prefix --previous
         kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
         kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
         EXPORTER_LOG_DIR="${E2E_EXPORTER_LOG_DIR:-/tmp/e2e-logs/exporters}"

--- a/.github/actions/collect-e2e-logs/action.yaml
+++ b/.github/actions/collect-e2e-logs/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Collect e2e logs
-      if: failure()
+      if: always()
       shell: bash
       run: |
         mkdir -p /tmp/e2e-logs
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Upload e2e logs
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -246,12 +246,21 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/e2e-logs
-          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 || true
-          kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
-          kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+          NS=jumpstarter-lab
+          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+            || true
+          kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+          kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
 
       - name: Upload e2e logs
         if: always()
@@ -297,12 +306,21 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/e2e-logs
-          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 || true
-          kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
-          kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+          NS=jumpstarter-lab
+          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+            || true
+          kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+          kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
 
       - name: Upload e2e logs
         if: always()
@@ -372,12 +390,21 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/e2e-logs
-          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 || true
-          kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
-          kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+          NS=jumpstarter-lab
+          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
+            || true
+          kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
+            || true
+          kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+          kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
 
       - name: Upload e2e logs
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -243,7 +243,7 @@ jobs:
           CI: true
 
       - name: Collect and upload e2e logs
-        if: failure()
+        if: always()
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-${{ matrix.arch }}
@@ -281,7 +281,7 @@ jobs:
           CI: true
 
       - name: Collect and upload e2e logs
-        if: failure()
+        if: always()
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-compat-old-controller
@@ -343,7 +343,7 @@ jobs:
           CI: true
 
       - name: Collect and upload e2e logs
-        if: failure()
+        if: always()
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-compat-old-client

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -243,7 +243,7 @@ jobs:
           CI: true
 
       - name: Collect and upload e2e logs
-        if: always()
+        if: failure()
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-${{ matrix.arch }}
@@ -281,7 +281,7 @@ jobs:
           CI: true
 
       - name: Collect and upload e2e logs
-        if: always()
+        if: failure()
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-compat-old-controller
@@ -343,7 +343,7 @@ jobs:
           CI: true
 
       - name: Collect and upload e2e logs
-        if: always()
+        if: failure()
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-compat-old-client

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -246,8 +246,10 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/e2e-logs
-          kubectl -n jumpstarter-lab logs -l component=controller --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 || true
           kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
           kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
 
@@ -295,8 +297,10 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/e2e-logs
-          kubectl -n jumpstarter-lab logs -l component=controller --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 || true
           kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
           kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
 
@@ -368,8 +372,10 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/e2e-logs
-          kubectl -n jumpstarter-lab logs -l component=controller --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
-          kubectl -n jumpstarter-lab logs -l component=router --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 || true
           kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
           kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -242,6 +242,23 @@ jobs:
         env:
           CI: true
 
+      - name: Collect e2e logs
+        if: always()
+        run: |
+          mkdir -p /tmp/e2e-logs
+          kubectl -n jumpstarter-lab logs -l component=controller --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+          kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+
+      - name: Upload e2e logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-${{ matrix.arch }}
+          path: /tmp/e2e-logs/
+          retention-days: 7
+
   # ============================================================================
   # Compatibility tests: cross-version interop between controller and client/exporter
   # ============================================================================
@@ -273,6 +290,23 @@ jobs:
         run: make e2e-compat-run COMPAT_TEST=old-controller
         env:
           CI: true
+
+      - name: Collect e2e logs
+        if: always()
+        run: |
+          mkdir -p /tmp/e2e-logs
+          kubectl -n jumpstarter-lab logs -l component=controller --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+          kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+
+      - name: Upload e2e logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-compat-old-controller
+          path: /tmp/e2e-logs/
+          retention-days: 7
 
   e2e-compat-old-client:
     needs: [changes, build-controller-image, build-operator-image, build-python-wheels]
@@ -329,3 +363,20 @@ jobs:
         run: make e2e-compat-run COMPAT_TEST=old-client
         env:
           CI: true
+
+      - name: Collect e2e logs
+        if: always()
+        run: |
+          mkdir -p /tmp/e2e-logs
+          kubectl -n jumpstarter-lab logs -l component=controller --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 || true
+          kubectl -n jumpstarter-lab logs -l component=router --tail=-1 > /tmp/e2e-logs/router.log 2>&1 || true
+          kubectl -n jumpstarter-lab get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
+          kubectl -n jumpstarter-lab describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
+
+      - name: Upload e2e logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-compat-old-client
+          path: /tmp/e2e-logs/
+          retention-days: 7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -242,33 +242,11 @@ jobs:
         env:
           CI: true
 
-      - name: Collect e2e logs
+      - name: Collect and upload e2e logs
         if: always()
-        run: |
-          mkdir -p /tmp/e2e-logs
-          NS=jumpstarter-lab
-          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-            || true
-          kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
-          kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
-
-      - name: Upload e2e logs
-        if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/collect-e2e-logs
         with:
-          name: e2e-logs-${{ matrix.arch }}
-          path: /tmp/e2e-logs/
-          retention-days: 7
+          artifact-name: e2e-logs-${{ matrix.arch }}
 
   # ============================================================================
   # Compatibility tests: cross-version interop between controller and client/exporter
@@ -302,33 +280,11 @@ jobs:
         env:
           CI: true
 
-      - name: Collect e2e logs
+      - name: Collect and upload e2e logs
         if: always()
-        run: |
-          mkdir -p /tmp/e2e-logs
-          NS=jumpstarter-lab
-          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-            || true
-          kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
-          kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
-
-      - name: Upload e2e logs
-        if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/collect-e2e-logs
         with:
-          name: e2e-logs-compat-old-controller
-          path: /tmp/e2e-logs/
-          retention-days: 7
+          artifact-name: e2e-logs-compat-old-controller
 
   e2e-compat-old-client:
     needs: [changes, build-controller-image, build-operator-image, build-python-wheels]
@@ -386,30 +342,8 @@ jobs:
         env:
           CI: true
 
-      - name: Collect e2e logs
+      - name: Collect and upload e2e logs
         if: always()
-        run: |
-          mkdir -p /tmp/e2e-logs
-          NS=jumpstarter-lab
-          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --tail=-1 > /tmp/e2e-logs/controller.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=controller --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-manager --all-containers --prefix --previous > /tmp/e2e-logs/controller-previous.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --tail=-1 > /tmp/e2e-logs/router.log 2>&1 \
-            || true
-          kubectl -n "$NS" logs -l component=router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-            || kubectl -n "$NS" logs -l control-plane=controller-router --all-containers --prefix --previous > /tmp/e2e-logs/router-previous.log 2>&1 \
-            || true
-          kubectl -n "$NS" get pods -o wide > /tmp/e2e-logs/pods.txt 2>&1 || true
-          kubectl -n "$NS" describe pods > /tmp/e2e-logs/pods-describe.txt 2>&1 || true
-
-      - name: Upload e2e logs
-        if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/collect-e2e-logs
         with:
-          name: e2e-logs-compat-old-client
-          path: /tmp/e2e-logs/
-          retention-days: 7
+          artifact-name: e2e-logs-compat-old-client

--- a/e2e/test/utils.go
+++ b/e2e/test/utils.go
@@ -620,15 +620,15 @@ func DumpControllerLogs(maxLines int) {
 	tail := strconv.Itoa(maxLines)
 
 	GinkgoWriter.Println("\n--- Controller logs ---")
-	out, err := Kubectl("-n", ns, "logs", "-l", "component=controller", "--tail="+tail)
-	if err != nil {
+	out, _ := Kubectl("-n", ns, "logs", "-l", "component=controller", "--tail="+tail)
+	if strings.TrimSpace(out) == "" {
 		out, _ = Kubectl("-n", ns, "logs", "-l", "control-plane=controller-manager", "--tail="+tail)
 	}
 	GinkgoWriter.Println(out)
 
 	GinkgoWriter.Println("\n--- Router logs ---")
-	out, err = Kubectl("-n", ns, "logs", "-l", "component=router", "--tail="+tail)
-	if err != nil {
+	out, _ = Kubectl("-n", ns, "logs", "-l", "component=router", "--tail="+tail)
+	if strings.TrimSpace(out) == "" {
 		out, _ = Kubectl("-n", ns, "logs", "-l", "control-plane=controller-router", "--tail="+tail)
 	}
 	GinkgoWriter.Println(out)

--- a/e2e/test/utils.go
+++ b/e2e/test/utils.go
@@ -54,6 +54,15 @@ func Namespace() string {
 	return defaultNamespace
 }
 
+// ExporterLogDir returns the directory where exporter logs are written.
+// Defaults to /tmp/e2e-logs/exporters, overridable via E2E_EXPORTER_LOG_DIR.
+func ExporterLogDir() string {
+	if dir := os.Getenv("E2E_EXPORTER_LOG_DIR"); dir != "" {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), "e2e-logs", "exporters")
+}
+
 // Endpoint returns the controller gRPC endpoint from the ENDPOINT env var.
 func Endpoint() string {
 	return os.Getenv("ENDPOINT")
@@ -270,14 +279,19 @@ func MustReadYAMLField(filePath, field string) string {
 // --- Process management ---
 
 // logBuffer is a thread-safe in-memory buffer for capturing process output.
+// When a file writer is set, writes are teed to disk so logs survive process crashes.
 type logBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	file *os.File
 }
 
 func (lb *logBuffer) Write(p []byte) (int, error) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
+	if lb.file != nil {
+		_, _ = lb.file.Write(p)
+	}
 	return lb.buf.Write(p)
 }
 
@@ -290,7 +304,19 @@ func (lb *logBuffer) String() string {
 func (lb *logBuffer) WriteString(s string) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
+	if lb.file != nil {
+		_, _ = lb.file.WriteString(s)
+	}
 	lb.buf.WriteString(s)
+}
+
+func (lb *logBuffer) Close() {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	if lb.file != nil {
+		_ = lb.file.Close()
+		lb.file = nil
+	}
 }
 
 // ProcessTracker manages background exporter processes.
@@ -307,12 +333,20 @@ func NewProcessTracker() *ProcessTracker {
 	}
 }
 
-// getOrCreateLog returns the in-memory log buffer for the given name.
+// getOrCreateLog returns the log buffer for the given name, creating it
+// if needed. Each buffer tees output to a file under exporterLogDir so
+// that logs are available as CI artifacts even if the test process crashes.
 func (pt *ProcessTracker) getOrCreateLog(name string) *logBuffer {
 	if lb, ok := pt.logs[name]; ok {
 		return lb
 	}
 	lb := &logBuffer{}
+	logDir := ExporterLogDir()
+	_ = os.MkdirAll(logDir, 0o755)
+	f, err := os.Create(filepath.Join(logDir, name+".log"))
+	if err == nil {
+		lb.file = f
+	}
 	pt.logs[name] = lb
 	return lb
 }
@@ -484,9 +518,12 @@ func (pt *ProcessTracker) StopAll() {
 	_ = exec.Command("pkill", "-9", "-f", "jmp run --exporter").Run()
 }
 
-// Cleanup stops all processes.
+// Cleanup stops all processes and closes log files.
 func (pt *ProcessTracker) Cleanup() {
 	pt.StopAll()
+	for _, lb := range pt.logs {
+		lb.Close()
+	}
 }
 
 // IsProcessRunning checks if any tracked process is still running.


### PR DESCRIPTION
## Summary
- Adds log collection steps to all three e2e jobs (`e2e-tests`, `e2e-compat-old-controller`, `e2e-compat-old-client`)
- Collects controller logs, router logs, pod listing, and pod descriptions as downloadable artifacts
- Artifacts retained for 7 days
- Currently runs on every e2e execution (`if: always()`) to verify the collection works — will be narrowed to `if: failure()` in a follow-up once confirmed

## Test plan
- [x] Trigger the e2e workflow and verify artifacts appear in the Actions run summary
- [ ] Download the artifacts and confirm they contain meaningful controller/router logs
- [ ] Once verified, follow up to change `if: always()` to `if: failure()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)