### PR TITLE
ci: extract e2e artifact loading into a reusable composite action

### DIFF
--- a/.github/actions/load-e2e-artifacts/action.yaml
+++ b/.github/actions/load-e2e-artifacts/action.yaml
@@ -1,0 +1,36 @@
+name: Load e2e artifacts
+description: Download and load prebuilt controller/operator images and Python wheels for e2e tests
+
+inputs:
+  arch:
+    description: Architecture suffix for container image artifacts (amd64 or arm64)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download controller image
+      uses: actions/download-artifact@v4
+      with:
+        name: controller-image-${{ inputs.arch }}
+        path: /tmp/artifacts
+
+    - name: Download operator image
+      uses: actions/download-artifact@v4
+      with:
+        name: operator-image-${{ inputs.arch }}
+        path: /tmp/artifacts
+
+    - name: Download python wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: python-wheels
+        path: /tmp/python-wheels
+
+    - name: Load container images and operator manifest
+      shell: bash
+      run: |
+        docker load < /tmp/artifacts/controller-image.tar
+        docker load < /tmp/artifacts/operator-image.tar
+        mkdir -p controller/deploy/operator/dist
+        cp /tmp/artifacts/operator-install.yaml controller/deploy/operator/dist/install.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -193,30 +193,10 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Download controller image
-        uses: actions/download-artifact@v4
+      - name: Load e2e artifacts
+        uses: ./.github/actions/load-e2e-artifacts
         with:
-          name: controller-image-${{ matrix.arch }}
-          path: /tmp/artifacts
-
-      - name: Download operator image
-        uses: actions/download-artifact@v4
-        with:
-          name: operator-image-${{ matrix.arch }}
-          path: /tmp/artifacts
-
-      - name: Download python wheels
-        uses: actions/download-artifact@v4
-        with:
-          name: python-wheels
-          path: /tmp/python-wheels
-
-      - name: Load container images and operator manifest
-        run: |
-          docker load < /tmp/artifacts/controller-image.tar
-          docker load < /tmp/artifacts/operator-image.tar
-          mkdir -p controller/deploy/operator/dist
-          cp /tmp/artifacts/operator-install.yaml controller/deploy/operator/dist/install.yaml
+          arch: ${{ matrix.arch }}
 
       - name: Install nftables and dnsmasq for dut-network E2E
         run: |
@@ -291,30 +271,10 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Download controller image
-        uses: actions/download-artifact@v4
+      - name: Load e2e artifacts
+        uses: ./.github/actions/load-e2e-artifacts
         with:
-          name: controller-image-amd64
-          path: /tmp/artifacts
-
-      - name: Download operator image
-        uses: actions/download-artifact@v4
-        with:
-          name: operator-image-amd64
-          path: /tmp/artifacts
-
-      - name: Download python wheels
-        uses: actions/download-artifact@v4
-        with:
-          name: python-wheels
-          path: /tmp/python-wheels
-
-      - name: Load container images and operator manifest
-        run: |
-          docker load < /tmp/artifacts/controller-image.tar
-          docker load < /tmp/artifacts/operator-image.tar
-          mkdir -p controller/deploy/operator/dist
-          cp /tmp/artifacts/operator-install.yaml controller/deploy/operator/dist/install.yaml
+          arch: amd64
 
       - name: Setup compat environment (old client v0.7.4)
         run: make e2e-compat-setup COMPAT_SCENARIO=old-client


### PR DESCRIPTION
## Summary
- Extracts the duplicated download + docker-load sequence (controller image, operator image, Python wheels) into `.github/actions/load-e2e-artifacts/`
- Replaces 4 steps with a single `uses:` reference in both `e2e-tests` and `e2e-compat-old-client` jobs
- The composite action takes an `arch` input (`amd64` or `arm64`) to select the correct image artifacts

## Test plan
- [ ] Verify e2e-tests job passes on both amd64 and arm64
- [ ] Verify e2e-compat-old-client job passes (uses hardcoded `amd64`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)