### PR TITLE
flashers: add default CA to be inject into flashing command

### DIFF
--- a/python/packages/jumpstarter-driver-flashers/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-flashers/examples/exporter.yaml
@@ -8,6 +8,9 @@ token: "<token>"
 export:
   storage:
     type: "jumpstarter_driver_flashers.driver.TIJ784S4Flasher"
+    config:
+      # CA certificate file path for HTTPS when flashing from a URL with a custom CA
+      # cacert: "/etc/pki/tls/certs/internal-ca.crt"
     children:
       serial:
         ref: "serial"

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -37,6 +37,7 @@ from opendal import Metadata, Operator
 
 from jumpstarter_driver_flashers.bundle import FlasherBundleManifestV1Alpha1
 
+from jumpstarter.client.core import DriverMethodNotImplemented
 from jumpstarter.client.decorators import driver_click_group
 from jumpstarter.common.exceptions import ArgumentError, JumpstarterException
 from jumpstarter.common.fls import get_fls_github_url
@@ -531,13 +532,46 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
             else:
                 self.logger.info("Leaving target powered on")
 
+    def _store_cacert_on_dut(self, console, manifest, cacert_content) -> str:
+        """Serve CA certificate via HTTP and download to DUT.
+
+        Writes the certificate to the exporter's HTTP storage and has the DUT
+        fetch it via curl, avoiding slow serial console transfer on boards
+        with CPS limits (e.g. NXP).
+
+        Args:
+            console: Console object for device interaction
+            manifest: Flasher manifest containing login prompt
+            cacert_content: CA certificate content (str or bytes)
+
+        Returns:
+            Path to stored CA certificate on the DUT
+        """
+        stored_cacert = "/tmp/cacert.crt"
+        cacert_bytes = cacert_content.encode() if isinstance(cacert_content, str) else cacert_content
+        self.http.storage.write_bytes("cacert.crt", cacert_bytes)
+        cacert_url = self.http.get_url() + "/cacert.crt"
+        self.logger.info(f"Downloading CA certificate to DUT from {cacert_url}")
+        console.sendline(f"curl -fsSL {cacert_url} -o {stored_cacert}")
+        console.expect(manifest.spec.login.prompt, timeout=EXPECT_TIMEOUT_DEFAULT)
+        console.sendline("echo $?")
+        console.expect(manifest.spec.login.prompt, timeout=EXPECT_TIMEOUT_DEFAULT)
+        try:
+            lines = console.before.decode(errors="ignore").strip().splitlines()
+            exit_code = int(lines[-1]) if lines else -1
+        except (IndexError, ValueError) as e:
+            raise FlashRetryableError("Failed to download CA certificate, could not parse exit code") from e
+        if exit_code != 0:
+            raise FlashRetryableError(f"Failed to download CA certificate from {cacert_url}, exit code: {exit_code}")
+        return stored_cacert
+
     def _setup_flasher_ssl(self, console, manifest, cacert_file: str | None) -> str | None:
         """Setup SSL configuration for the flasher.
 
         Args:
             console: Console object for device interaction
             manifest: Flasher manifest containing login prompt
-            cacert_file: Path to CA certificate file
+            cacert_file: Path to CA certificate file on the client filesystem
 
         Returns:
             Path to stored CA certificate in the DUT flasher, or None if no certificate was provided
@@ -547,21 +581,20 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         """
 
         if cacert_file:
-            cacert = b""
             try:
                 with open(cacert_file, "rb") as f:
                     cacert = f.read()
             except OSError as e:
                 self.logger.error(f"Error reading CA certificate file: {e}")
                 raise RuntimeError(f"Error reading CA certificate file: {e}") from e
-            self.logger.info("Storing the CA certificate in the remote DUT flasher")
-            # write the contents of cacert to /tmp/cacert.crt on the remote target through console
-            stored_cacert = "/tmp/cacert.crt"
-            console.sendline(f"cat > {stored_cacert} << EOF")
-            console.sendline(cacert)
-            console.sendline("\nEOF")
-            console.expect(manifest.spec.login.prompt, timeout=EXPECT_TIMEOUT_DEFAULT)
-            return stored_cacert
+            return self._store_cacert_on_dut(console, manifest, cacert)
+
+        try:
+            cacert_content = self.call("get_cacert")
+        except DriverMethodNotImplemented:
+            cacert_content = None
+        if cacert_content:
+            return self._store_cacert_on_dut(console, manifest, cacert_content)
 
         return None
 

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver.py
@@ -23,6 +23,7 @@ class BaseFlasher(Driver):
     cache_dir: str = field(default="/var/lib/jumpstarter/flasher")
     tftp_dir: str = field(default="/var/lib/tftpboot")
     http_dir: str = field(default="/var/www/html")
+    cacert: str | None = field(default=None)
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -68,6 +69,14 @@ class BaseFlasher(Driver):
     async def get_default_target(self):
         """Return the default target"""
         return self.default_target
+
+    @export
+    async def get_cacert(self) -> str | None:
+        """Return the CA certificate contents if configured"""
+        if not self.cacert:
+            return None
+        with open(self.cacert) as f:
+            return f.read()
 
     @export
     async def setup_flasher_bundle(self, force_flash_bundle: str | None = None):


### PR DESCRIPTION
if `ca` field is set on the exporter, inject it by default to the falshing command


