### PR TITLE
feat: driver/sdwire: support unprogrammed FT200X EEPROM + macOS storage/mux fixes

### DIFF
--- a/python/packages/jumpstarter-driver-sdwire/README.md
+++ b/python/packages/jumpstarter-driver-sdwire/README.md
@@ -22,11 +22,71 @@ Example configuration:
 ```{doctest}
 :hide:
 >>> from jumpstarter.config.exporter import ExporterConfigV1Alpha1DriverInstance
->>> ExporterConfigV1Alpha1DriverInstance.from_path("source/api-reference/drivers/sdwire.yaml").instantiate()
+>>> ExporterConfigV1Alpha1DriverInstance.from_path("source/reference/package-apis/drivers/sdwire.yaml").instantiate() # doctest: +ELLIPSIS
 Traceback (most recent call last):
 ...
-FileNotFoundError: failed to find sd-wire device
+FileNotFoundError: failed to find sd-wire device...
 ```
+
+## Unprogrammed (factory-default) SD Wire devices
+
+SD Wires are normally initialized with `sd-mux-ctrl --init`, which rewrites the
+FTDI FT200X EEPROM to the Samsung VID/PID (`0x04E8`/`0x6001`, product `sd-wire`)
+**and** configures the FT200X's `CBUS0` pin as a GPIO so the mux can be switched.
+
+A device that still has the **factory-default FTDI EEPROM** (`0x0403`/`0x6015`)
+is also supported, but with two requirements:
+
+1. **A `serial` must be configured.** A bare FT200X has no reliable runtime
+   signature that distinguishes an SD Wire from any other FT200X, so the driver
+   will only bind one when you pin it by serial number.
+
+2. **`CBUS0` must be set to `GPIO` in the EEPROM (one-time fix).** This is the
+   critical prerequisite:
+
+   > The FT200X's CBUS bitbang mode (used to switch the mux) requires `CBUS0` to
+   > be configured as `GPIO`/`IOMODE` in the EEPROM. On an unprogrammed FT200X
+   > `CBUS0` defaults to a fixed function (e.g. `TXLED`) and **completely ignores
+   > bitbang commands** — the green LED never lights and the mux never switches
+   > to DUT.
+
+   The driver does **not** reprogram the EEPROM; it only sends the runtime
+   bitbang command and assumes `CBUS0` is already a GPIO. Perform this one-time
+   fix first (it preserves the original VID/PID and only changes `CBUS0`):
+
+   ```python
+   from pyftdi.eeprom import FtdiEeprom
+
+   e = FtdiEeprom()
+   e.open("ftdi://0x0403:0x6015/1")
+   e.set_property("cbus_func_0", "GPIO")   # FT200X uses 'GPIO', not 'IOMODE'
+   e.commit(dry_run=False)
+   ```
+
+   After flashing, **unplug and replug** the SD Wire USB cable. If you run the
+   driver against an unprogrammed device that has *not* had this fix applied,
+   the device is found but `host()`/`dut()` silently fail to move the mux.
+
+## macOS notes
+
+On macOS (`Darwin`) the driver does extra work that is unnecessary on Linux:
+
+- **`dut()` ejects the card before switching.** The mux only switches when the
+  SD bus is fully idle; while macOS holds the SMSC reader open it keeps polling
+  the card. The driver runs `diskutil eject` (SCSI `STOP UNIT`) first. If the
+  disk cannot be determined, `dut()` aborts rather than risk corrupting a mounted
+  volume.
+- **Power on the DUT immediately after `dut()` (< ~500 ms).** The mux has a
+  protection circuit that reverts to HOST if it sees no SD activity on the DUT
+  side shortly after switching.
+- **`host()` power-cycles the reader's hub port.** Because the prior `eject`
+  leaves the SMSC reader stopped, `host()` routes the card back and *then*
+  power-cycles port 1 of *this* SD Wire's internal hub to force a clean
+  re-enumeration (correlated by USB topology so other attached SD Wires are not
+  disturbed).
+- **Storage discovery uses `system_profiler`** (pyudev is Linux-only) and may
+  take a moment to re-enumerate after a switch, so reads/writes retry discovery
+  up to `storage_timeout`.
 
 ## API Reference
 

--- a/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver.py
+++ b/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import platform
+import subprocess
+import time
 from dataclasses import dataclass, field
 
-import pyudev
+import anyio
+import anyio.to_thread
 import usb.core
 import usb.util
 from jumpstarter_driver_opendal.driver import StorageMuxFlasherInterface
@@ -10,12 +14,158 @@ from jumpstarter_driver_opendal.driver import StorageMuxFlasherInterface
 from jumpstarter.common.storage import read_from_storage_device, write_to_storage_device
 from jumpstarter.driver import Driver, export
 
+# Programmed by sd-mux-ctrl --init: Samsung VID, product "sd-wire".
+_PROGRAMMED_VID = 0x04E8
+_PROGRAMMED_PID = 0x6001
+_PROGRAMMED_PRODUCT = "sd-wire"
+
+# Factory-default FTDI FT200X. The mux only works if CBUS0 is set to GPIO in the
+# EEPROM (one-time pyftdi fix, see README); otherwise switching is ignored.
+_FTDI_VID = 0x0403
+_FT200X_PID = 0x6015
+
+# SD Wire internal USB hub; the SD reader sits on port 1.
+_SMSC_HUB_VID = 0x0424
+_SMSC_HUB_PID = 0x2640
+_SMSC_HUB_PORT = 1
+
+# SD card reader behind the hub (shares the SMSC vendor id).
+_SMSC_READER_VID = 0x0424
+_SMSC_READER_PID = 0x4050
+
+
+def _hex_id(value: int) -> str:
+    return f"0x{value:04x}"
+
+
+def _find_smsc_hub(dev: usb.core.Device) -> usb.core.Device | None:
+    # The reader and the FT200X share an internal hub, so the hub's USB path is
+    # the FT200X path minus its last port. Match by bus + path to stay scoped to
+    # this SD Wire when several are attached.
+    hubs = list(usb.core.find(idVendor=_SMSC_HUB_VID, idProduct=_SMSC_HUB_PID, find_all=True))
+    if not hubs:
+        return None
+
+    def ports(device: usb.core.Device) -> tuple:
+        try:
+            port_numbers = getattr(device, "port_numbers", None)
+            return tuple(port_numbers) if port_numbers else ()
+        except (NotImplementedError, AttributeError):
+            return ()
+
+    dev_ports = ports(dev)
+    if dev_ports:
+        parent_ports = dev_ports[:-1]
+        for hub in hubs:
+            if hub.bus == dev.bus and ports(hub) == parent_ports:
+                return hub
+        return None  # topology known but no match: don't guess
+
+    return hubs[0] if len(hubs) == 1 else None
+
+
+def _power_cycle_smsc_port(dev: usb.core.Device, logger=None) -> None:
+    # diskutil eject leaves the reader stopped; toggling its hub port power makes
+    # macOS re-enumerate it so the card is accessible again.
+    hub = _find_smsc_hub(dev)
+    if hub is None:
+        if logger:
+            logger.warning("could not find the SMSC hub to power-cycle; card may not re-mount")
+        return
+    try:
+        hub.ctrl_transfer(0x23, 1, 8, _SMSC_HUB_PORT, None)  # CLEAR PORT_POWER
+        time.sleep(1)
+        hub.ctrl_transfer(0x23, 3, 8, _SMSC_HUB_PORT, None)  # SET PORT_POWER
+        time.sleep(3)
+    except usb.core.USBError:
+        pass  # best-effort; caller raises if the disk never appears
+
+
+def _find_storage_device_linux(dev: usb.core.Device) -> str | None:
+    try:
+        import pyudev
+
+        context = pyudev.Context()
+        for udevice in (
+            context.list_devices(subsystem="usb")
+            .match_attribute("busnum", dev.bus)
+            .match_attribute("devnum", dev.address)
+        ):
+            for block in filter(lambda d: d.subsystem == "block", udevice.parent.children):
+                for storage_device in filter(lambda link: link.startswith("/dev/disk/by-diskseq/"), block.device_links):
+                    return storage_device
+    except (ImportError, OSError, AttributeError):
+        pass
+    return None
+
+
+def _node_is_controller(node: dict, serial: str | None) -> bool:
+    if serial is not None:
+        return node.get("serial_num") == serial
+    vid = node.get("vendor_id", "").lower()
+    pid = node.get("product_id", "").lower()
+    return (_hex_id(_PROGRAMMED_VID) in vid and _hex_id(_PROGRAMMED_PID) in pid) or (
+        _hex_id(_FTDI_VID) in vid and _hex_id(_FT200X_PID) in pid
+    )
+
+
+def _reader_bsd(node: dict) -> str | None:
+    # The disk node lives under the reader's nested "Media" list, not at top level.
+    vid = node.get("vendor_id", "").lower()
+    pid = node.get("product_id", "").lower()
+    if not (_hex_id(_SMSC_READER_VID) in vid and _hex_id(_SMSC_READER_PID) in pid):
+        return None
+    for media in node.get("Media", []):
+        bsd = media.get("bsd_name")
+        if bsd:
+            return f"/dev/{bsd}"
+    return None
+
+
+def _find_storage_device_macos(serial: str | None) -> str | None:
+    # pyudev is Linux-only; on macOS walk system_profiler and pick the SD reader
+    # that is a sibling of this SD Wire's FT200X.
+    try:
+        import json
+
+        out = subprocess.check_output(
+            ["system_profiler", "SPUSBDataType", "-json"],
+            text=True,
+            timeout=15,
+        )
+        data = json.loads(out)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return None
+
+    results: list[str] = []
+
+    def walk(items: list[dict]) -> None:
+        for node in items:
+            if _node_is_controller(node, serial):
+                for sibling in items:
+                    bsd = _reader_bsd(sibling)
+                    if bsd:
+                        results.append(bsd)
+            walk(node.get("_items", []))
+
+    walk(data.get("SPUSBDataType", []))
+
+    unique = list(dict.fromkeys(results))
+    if not unique:
+        return None
+    if len(unique) > 1:
+        raise RuntimeError(
+            "found multiple SD Wire storage devices on macOS; specify storage_device or serial to disambiguate"
+        )
+    return unique[0]
+
 
 @dataclass(kw_only=True)
 class SDWire(StorageMuxFlasherInterface, Driver):
     serial: str | None = field(default=None)
     dev: usb.core.Device = field(init=False)
     itf: usb.core.Interface = field(init=False)
+    _serial: str | None = field(init=False, default=None)
 
     storage_device: str | None = field(default=None)
     storage_timeout: int = field(default=10)
@@ -23,55 +173,89 @@ class SDWire(StorageMuxFlasherInterface, Driver):
     storage_fsync_timeout: int = field(default=900)
 
     def effective_storage_device(self):
-        if self.storage_device is None:
-            context = pyudev.Context()
-            for udevice in (
-                context.list_devices(subsystem="usb")
-                .match_attribute("busnum", self.dev.bus)
-                .match_attribute("devnum", self.dev.address)
-            ):
-                # find siblings block device
-                for block in filter(lambda d: d.subsystem == "block", udevice.parent.children):
-                    # find stable device link under by-diskseq
-                    for storage_device in filter(
-                        lambda link: link.startswith("/dev/disk/by-diskseq/"), block.device_links
-                    ):
-                        return storage_device
-            return None
-        else:
+        if self.storage_device is not None:
             return self.storage_device
+        if platform.system() == "Darwin":
+            return _find_storage_device_macos(self._serial)
+        return _find_storage_device_linux(self.dev)
+
+    def _poll_storage_device(self, timeout: int) -> str | None:
+        # macOS re-enumerates the reader after a switch, so retry discovery.
+        deadline = time.monotonic() + timeout
+        while True:
+            device = self.effective_storage_device()
+            if device is not None:
+                return device
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(1)
+
+    async def _await_storage_device(self, timeout: int) -> str | None:
+        deadline = time.monotonic() + timeout
+        while True:
+            device = await anyio.to_thread.run_sync(self.effective_storage_device)
+            if device is not None:
+                return device
+            if time.monotonic() >= deadline:
+                return None
+            await anyio.sleep(1)
+
+    def _find_device(self) -> tuple[usb.core.Device, str | None] | None:
+        candidates: list[tuple[usb.core.Device, str | None]] = []
+
+        # Programmed: Samsung VID + product "sd-wire".
+        for dev in usb.core.find(idVendor=_PROGRAMMED_VID, idProduct=_PROGRAMMED_PID, find_all=True):
+            try:
+                product = usb.util.get_string(dev, dev.iProduct)
+                serial = usb.util.get_string(dev, dev.iSerialNumber)
+            except usb.core.USBError as e:
+                self.logger.warning(f"failed to read USB descriptors at bus {dev.bus} addr {dev.address}: {e}")
+                continue
+            if product == _PROGRAMMED_PRODUCT and (self.serial is None or self.serial == serial):
+                candidates.append((dev, serial))
+
+        # Unprogrammed FT200X: only by explicit serial, since any FT200X looks alike.
+        if self.serial is not None:
+            for dev in usb.core.find(idVendor=_FTDI_VID, idProduct=_FT200X_PID, find_all=True):
+                try:
+                    serial = usb.util.get_string(dev, dev.iSerialNumber)
+                except usb.core.USBError as e:
+                    self.logger.warning(f"failed to read USB descriptors at bus {dev.bus} addr {dev.address}: {e}")
+                    continue
+                if self.serial == serial:
+                    candidates.append((dev, serial))
+
+        if self.serial is None and len(candidates) > 1:
+            raise RuntimeError("found multiple sd-wire devices; specify a serial to disambiguate")
+
+        return candidates[0] if candidates else None
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
             super().__post_init__()
 
-        for dev in usb.core.find(idVendor=0x04E8, idProduct=0x6001, find_all=True):
-            product = usb.util.get_string(dev, dev.iProduct)
-            serial = usb.util.get_string(dev, dev.iSerialNumber)
-
-            if product != "sd-wire":
-                continue
-
-            # Filter by serial if provided
-            if self.serial is not None and self.serial != serial:
-                continue
-
-            self.dev = dev
-            self.itf = usb.util.find_descriptor(
-                dev.get_active_configuration(),
-                bInterfaceClass=0xFF,
-                bInterfaceSubClass=0xFF,
-                bInterfaceProtocol=0xFF,
+        found = self._find_device()
+        if found is None:
+            raise FileNotFoundError(
+                "failed to find sd-wire device "
+                "(checked programmed EEPROM VID/PID 0x04E8/0x6001 and "
+                "unprogrammed FTDI FT200X 0x0403/0x6015)"
             )
 
-            if self.effective_storage_device() is None:
-                raise FileNotFoundError("failed to find sdcard driver on sd-wire device")
+        dev, self._serial = found
+        self.dev = dev
+        self.itf = usb.util.find_descriptor(
+            dev.get_active_configuration(),
+            bInterfaceClass=0xFF,
+            bInterfaceSubClass=0xFF,
+            bInterfaceProtocol=0xFF,
+        )
 
-            return
-
-        raise FileNotFoundError("failed to find sd-wire device")
+        if self.effective_storage_device() is None:
+            raise FileNotFoundError("failed to find sdcard storage device on sd-wire")
 
     def select(self, target):
+        # CBUS bitbang: wValue = 0x20<<8 | (0xF0 DUT / 0xF1 HOST). Needs CBUS0=GPIO.
         self.dev.ctrl_transfer(
             bmRequestType=usb.ENDPOINT_OUT | usb.TYPE_VENDOR | usb.RECIP_DEVICE,
             bRequest=0xB,
@@ -95,10 +279,40 @@ class SDWire(StorageMuxFlasherInterface, Driver):
 
     @export
     def host(self):
+        # Route the card back first, then (macOS) power-cycle so the re-enumeration
+        # sees the card present.
         self.select(0xF1)
+        if platform.system() == "Darwin":
+            _power_cycle_smsc_port(self.dev, self.logger)
 
     @export
     def dut(self):
+        # macOS: the mux only switches when the SD bus is idle, so eject first.
+        # Power on the DUT within ~500 ms or the mux protection reverts to HOST.
+        if platform.system() == "Darwin":
+            storage = self._poll_storage_device(self.storage_timeout)
+            if storage is None:
+                raise RuntimeError(
+                    "could not determine the SD card disk on macOS; refusing to switch to DUT "
+                    "(switching without a clean eject risks filesystem corruption)"
+                )
+            try:
+                subprocess.run(
+                    ["diskutil", "eject", storage],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=30,
+                )
+            except subprocess.CalledProcessError as e:
+                self.logger.error(f"failed to eject {storage}: {e.stderr}")
+                raise RuntimeError(
+                    f"failed to eject {storage} before switching to DUT; "
+                    f"the volume may be busy: {(e.stderr or '').strip()}"
+                ) from e
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError(f"timed out ejecting {storage} before switching to DUT") from e
+            time.sleep(1)
         self.select(0xF0)
 
     @export
@@ -108,9 +322,12 @@ class SDWire(StorageMuxFlasherInterface, Driver):
     @export
     async def write(self, src: str):
         self.host()
+        storage = await self._await_storage_device(self.storage_timeout)
+        if storage is None:
+            raise RuntimeError("SD card disk did not become available on host within storage_timeout")
         async with self.resource(src) as res:
             await write_to_storage_device(
-                self.effective_storage_device(),
+                storage,
                 res,
                 timeout=self.storage_timeout,
                 leeway=self.storage_leeway,
@@ -121,9 +338,12 @@ class SDWire(StorageMuxFlasherInterface, Driver):
     @export
     async def read(self, dst: str):
         self.host()
+        storage = await self._await_storage_device(self.storage_timeout)
+        if storage is None:
+            raise RuntimeError("SD card disk did not become available on host within storage_timeout")
         async with self.resource(dst) as res:
             await read_from_storage_device(
-                self.effective_storage_device(),
+                storage,
                 res,
                 timeout=self.storage_timeout,
                 logger=self.logger,

--- a/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver_test.py
+++ b/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver_test.py
@@ -1,9 +1,353 @@
+import json
+import logging
+import subprocess
+from typing import cast
+
+import anyio
 import pytest
 import usb
+import usb.core
 
+from jumpstarter_driver_sdwire import driver as sdwire_driver
 from jumpstarter_driver_sdwire.driver import SDWire
 
 from jumpstarter.common.utils import serve
+
+
+def _sdwire_hub(ft200x_serial, disk):
+    """One SD Wire onboard hub (SMSC 0x2640) holding an FT200X controller and the
+    SMSC SD reader as direct siblings. Mirrors real `system_profiler` output, where
+    the disk identifier is nested under the reader's `Media` list (not top-level)."""
+    return {
+        "_name": "hub_device",
+        "vendor_id": "0x0424  (SMSC)",
+        "product_id": "0x2640",
+        "_items": [
+            {
+                "_name": "FT200X USB I2C",
+                "vendor_id": "0x0403  (Future Technology Devices International Limited)",
+                "product_id": "0x6015",
+                "serial_num": ft200x_serial,
+            },
+            {
+                "_name": "Ultra Fast Media Reader",
+                "vendor_id": "0x0424  (SMSC)",
+                "product_id": "0x4050",
+                "serial_num": "000000264001",
+                "Media": [
+                    {
+                        "_name": "Ultra HS-SD/MMC",
+                        "bsd_name": disk,
+                        "volumes": [{"_name": "ESP", "bsd_name": f"{disk}s1"}],
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def _sp_tree(*hubs):
+    return {"SPUSBDataType": [{"_name": "USB31Bus", "_items": list(hubs)}]}
+
+
+def _patch_system_profiler(monkeypatch, tree):
+    monkeypatch.setattr(sdwire_driver.subprocess, "check_output", lambda *a, **k: json.dumps(tree))
+
+
+def test_macos_storage_correlates_by_serial(monkeypatch):
+    _patch_system_profiler(monkeypatch, _sp_tree(_sdwire_hub("DP04I34D", "disk6"), _sdwire_hub("OTHER999", "disk8")))
+    assert sdwire_driver._find_storage_device_macos("DP04I34D") == "/dev/disk6"
+    assert sdwire_driver._find_storage_device_macos("OTHER999") == "/dev/disk8"
+
+
+def test_macos_storage_ambiguous_without_serial(monkeypatch):
+    _patch_system_profiler(monkeypatch, _sp_tree(_sdwire_hub("DP04I34D", "disk6"), _sdwire_hub("OTHER999", "disk8")))
+    with pytest.raises(RuntimeError):
+        sdwire_driver._find_storage_device_macos(None)
+
+
+def test_macos_storage_single_device(monkeypatch):
+    _patch_system_profiler(monkeypatch, _sp_tree(_sdwire_hub("DP04I34D", "disk6")))
+    # unambiguous even without a serial
+    assert sdwire_driver._find_storage_device_macos(None) == "/dev/disk6"
+
+
+def test_macos_storage_wrong_serial(monkeypatch):
+    _patch_system_profiler(monkeypatch, _sp_tree(_sdwire_hub("DP04I34D", "disk6")))
+    assert sdwire_driver._find_storage_device_macos("NOPE") is None
+
+
+def test_macos_storage_not_found(monkeypatch):
+    _patch_system_profiler(monkeypatch, {"SPUSBDataType": []})
+    assert sdwire_driver._find_storage_device_macos("DP04I34D") is None
+
+
+class _FakeUSBDev:
+    def __init__(self, serial):
+        self._serial = serial
+        self.iSerialNumber = 1
+        self.iProduct = 2
+        self.bus = 1
+        self.address = 2
+        self.port_numbers = ()
+
+
+def test_ft200x_requires_explicit_serial(monkeypatch):
+    ft200x = _FakeUSBDev("DP04I34D")
+
+    def fake_find(idVendor, idProduct, find_all):
+        # only the FT200X VID/PID enumerates a device; no programmed sd-wire present
+        if (idVendor, idProduct) == (sdwire_driver._FTDI_VID, sdwire_driver._FT200X_PID):
+            return iter([ft200x])
+        return iter([])
+
+    monkeypatch.setattr(sdwire_driver.usb.core, "find", fake_find)
+    monkeypatch.setattr(sdwire_driver.usb.util, "get_string", lambda dev, idx: dev._serial)
+
+    # without a configured serial, an FT200X must NOT be selected (no reliable identity)
+    sdwire = object.__new__(SDWire)
+    sdwire.serial = None
+    sdwire.logger = logging.getLogger("test-sdwire")
+    assert sdwire._find_device() is None
+
+    # with the matching serial configured, it is selected
+    sdwire.serial = "DP04I34D"
+    found = sdwire._find_device()
+    assert found is not None
+    assert found[0] is ft200x
+    assert found[1] == "DP04I34D"
+
+
+def test_find_device_ambiguous_programmed_without_serial(monkeypatch):
+    dev_a = _FakeUSBDev("AAAA")
+    dev_b = _FakeUSBDev("BBBB")
+    for d in (dev_a, dev_b):
+        d.iProduct = 2
+
+    def fake_find(idVendor, idProduct, find_all):
+        # two programmed "sd-wire" units enumerate; no FT200X
+        if (idVendor, idProduct) == (sdwire_driver._PROGRAMMED_VID, sdwire_driver._PROGRAMMED_PID):
+            return iter([dev_a, dev_b])
+        return iter([])
+
+    def fake_get_string(dev, idx):
+        return sdwire_driver._PROGRAMMED_PRODUCT if idx == dev.iProduct else dev._serial
+
+    monkeypatch.setattr(sdwire_driver.usb.core, "find", fake_find)
+    monkeypatch.setattr(sdwire_driver.usb.util, "get_string", fake_get_string)
+
+    sdwire = object.__new__(SDWire)
+    sdwire.serial = None
+    sdwire.logger = logging.getLogger("test-sdwire")
+
+    # two units, no serial -> must fail loudly instead of binding the first one
+    with pytest.raises(RuntimeError, match="multiple sd-wire devices"):
+        sdwire._find_device()
+
+    # selecting one by serial resolves the ambiguity
+    sdwire.serial = "BBBB"
+    found = sdwire._find_device()
+    assert found is not None
+    assert found[0] is dev_b
+
+
+def test_poll_storage_device_retries(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    calls = iter([None, None, "/dev/disk6"])
+    monkeypatch.setattr(SDWire, "effective_storage_device", lambda self: next(calls))
+    monkeypatch.setattr(sdwire_driver.time, "sleep", lambda _s: None)
+    assert sdwire._poll_storage_device(10) == "/dev/disk6"
+
+
+def test_poll_storage_device_times_out(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    monkeypatch.setattr(SDWire, "effective_storage_device", lambda self: None)
+    monkeypatch.setattr(sdwire_driver.time, "sleep", lambda _s: None)
+    assert sdwire._poll_storage_device(0) is None
+
+
+def test_await_storage_device_retries(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    calls = iter([None, None, "/dev/disk6"])
+    monkeypatch.setattr(SDWire, "effective_storage_device", lambda self: next(calls))
+
+    async def no_sleep(_s):
+        pass
+
+    monkeypatch.setattr(sdwire_driver.anyio, "sleep", no_sleep)
+    assert anyio.run(sdwire._await_storage_device, 10) == "/dev/disk6"
+
+
+def test_dut_aborts_when_eject_fails(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire.storage_device = "/dev/disk4"
+    sdwire.storage_timeout = 10
+    sdwire.logger = logging.getLogger("test-sdwire")
+
+    monkeypatch.setattr(sdwire_driver.platform, "system", lambda: "Darwin")
+
+    switched = []
+    monkeypatch.setattr(SDWire, "select", lambda self, target: switched.append(target))
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, stderr="disk busy")
+
+    monkeypatch.setattr(sdwire_driver.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="busy"):
+        sdwire.dut()
+    # the card must NOT be switched to the DUT when the eject failed
+    assert switched == []
+
+
+def test_dut_switches_after_successful_eject(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire.storage_device = "/dev/disk4"
+    sdwire.storage_timeout = 10
+    sdwire.logger = logging.getLogger("test-sdwire")
+
+    monkeypatch.setattr(sdwire_driver.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(sdwire_driver.time, "sleep", lambda _s: None)
+
+    switched = []
+    monkeypatch.setattr(SDWire, "select", lambda self, target: switched.append(target))
+    monkeypatch.setattr(sdwire_driver.subprocess, "run", lambda *a, **k: None)
+
+    sdwire.dut()
+    assert switched == [0xF0]
+
+
+def test_dut_aborts_when_disk_unknown(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire.storage_timeout = 0  # do not actually wait
+    sdwire.logger = logging.getLogger("test-sdwire")
+
+    monkeypatch.setattr(sdwire_driver.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(SDWire, "effective_storage_device", lambda self: None)
+    monkeypatch.setattr(sdwire_driver.time, "sleep", lambda _s: None)
+
+    switched = []
+    monkeypatch.setattr(SDWire, "select", lambda self, target: switched.append(target))
+    ejected = []
+    monkeypatch.setattr(sdwire_driver.subprocess, "run", lambda *a, **k: ejected.append(a))
+
+    with pytest.raises(RuntimeError, match="refusing to switch"):
+        sdwire.dut()
+
+    # discovery failed: no eject, no switch
+    assert ejected == []
+    assert switched == []
+
+
+def test_write_raises_when_disk_unavailable(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire.storage_timeout = 0
+    sdwire.logger = logging.getLogger("test-sdwire")
+
+    monkeypatch.setattr(SDWire, "host", lambda self: None)
+
+    async def none_await(self, timeout):
+        return None
+
+    monkeypatch.setattr(SDWire, "_await_storage_device", none_await)
+
+    # a clear RuntimeError, not a TypeError from os.open(None, ...)
+    with pytest.raises(RuntimeError, match="did not become available"):
+        anyio.run(sdwire.write, "dummy")
+
+
+class _FakeHub:
+    def __init__(self, bus, port_numbers):
+        self.bus = bus
+        self.port_numbers = port_numbers
+        self.calls = []
+
+    def ctrl_transfer(self, *args):
+        self.calls.append(args)
+
+
+def test_host_selects_before_power_cycle(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire.logger = logging.getLogger("test-sdwire")
+    sdwire.dev = object()
+
+    monkeypatch.setattr(sdwire_driver.platform, "system", lambda: "Darwin")
+
+    events = []
+    monkeypatch.setattr(SDWire, "select", lambda self, target: events.append(("select", target)))
+    monkeypatch.setattr(
+        sdwire_driver,
+        "_power_cycle_smsc_port",
+        lambda dev, logger=None: events.append(("power_cycle", dev)),
+    )
+
+    sdwire.host()
+
+    # the card must be routed back to the SMSC slot BEFORE the reader is power-cycled
+    assert events == [("select", 0xF1), ("power_cycle", sdwire.dev)]
+
+
+def test_host_no_power_cycle_off_darwin(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire.logger = logging.getLogger("test-sdwire")
+    sdwire.dev = object()
+
+    monkeypatch.setattr(sdwire_driver.platform, "system", lambda: "Linux")
+
+    events = []
+    monkeypatch.setattr(SDWire, "select", lambda self, target: events.append(("select", target)))
+    monkeypatch.setattr(
+        sdwire_driver,
+        "_power_cycle_smsc_port",
+        lambda dev, logger=None: events.append(("power_cycle", dev)),
+    )
+
+    sdwire.host()
+    assert events == [("select", 0xF1)]
+
+
+def test_power_cycle_scopes_to_parent_hub(monkeypatch):
+    # FT200X at bus 2, port path (5, 2) -> its parent hub path is (5,)
+    dev = _FakeUSBDev("DP04I34D")
+    dev.bus = 2
+    dev.port_numbers = (5, 2)
+
+    right_hub = _FakeHub(bus=2, port_numbers=(5,))
+    wrong_bus = _FakeHub(bus=3, port_numbers=(5,))
+    wrong_path = _FakeHub(bus=2, port_numbers=(9,))
+
+    monkeypatch.setattr(
+        sdwire_driver.usb.core,
+        "find",
+        lambda **k: iter([wrong_bus, wrong_path, right_hub]),
+    )
+    monkeypatch.setattr(sdwire_driver.time, "sleep", lambda _s: None)
+
+    sdwire_driver._power_cycle_smsc_port(cast(usb.core.Device, dev))
+
+    # only the correlated hub is power-cycled; the others are left alone
+    assert right_hub.calls == [
+        (0x23, 1, 8, sdwire_driver._SMSC_HUB_PORT, None),
+        (0x23, 3, 8, sdwire_driver._SMSC_HUB_PORT, None),
+    ]
+    assert wrong_bus.calls == []
+    assert wrong_path.calls == []
+
+
+def test_power_cycle_skips_when_no_topology_match(monkeypatch):
+    dev = _FakeUSBDev("DP04I34D")
+    dev.bus = 2
+    dev.port_numbers = (5, 2)
+
+    # two hubs present, neither matches the dev's topology -> do not guess
+    hub_a = _FakeHub(bus=2, port_numbers=(7,))
+    hub_b = _FakeHub(bus=2, port_numbers=(8,))
+    monkeypatch.setattr(sdwire_driver.usb.core, "find", lambda **k: iter([hub_a, hub_b]))
+    monkeypatch.setattr(sdwire_driver.time, "sleep", lambda _s: None)
+
+    sdwire_driver._power_cycle_smsc_port(cast(usb.core.Device, dev))
+    assert hub_a.calls == []
+    assert hub_b.calls == []
 
 
 def test_drivers_sdwire():

--- a/python/packages/jumpstarter/jumpstarter/common/storage.py
+++ b/python/packages/jumpstarter/jumpstarter/common/storage.py
@@ -9,12 +9,12 @@ from anyio.streams.file import FileReadStream, FileWriteStream
 
 
 async def wait_for_storage_device(  # noqa: C901
-    storage_device: os.PathLike,
+    storage_device: str | os.PathLike,
     mode: Literal["wb", "rb"],
     timeout: int = 10,
     *,
     logger: Logger | None = None,
-) -> os.PathLike:
+) -> str | os.PathLike:
     with fail_after(timeout):
         while True:
             # https://stackoverflow.com/a/2774125
@@ -50,7 +50,7 @@ async def wait_for_storage_device(  # noqa: C901
 
 
 async def write_to_storage_device(
-    storage_device: os.PathLike,
+    storage_device: str | os.PathLike,
     resource: AnyByteStream,
     timeout: int = 10,
     fsync_timeout: int = 900,
@@ -100,7 +100,7 @@ async def write_to_storage_device(
 
 
 async def read_from_storage_device(
-    storage_device: os.PathLike,
+    storage_device: str | os.PathLike,
     resource: AnyByteStream,
     timeout: int = 10,
     *,


### PR DESCRIPTION
Recently, I got an unprogrammed unit from [3mdeb](https://shop.3mdeb.com/product/sdwire/), which did not work out of the box. It had the factory-default FTDI FT200X EEPROM (`0x0403`/`0x6015`) rather than the Samsung VID/PID set by `sd-mux-ctrl --init`. Also, previously the driver was Linux-only (pyudev).

To elaborate:

**1. Unprogrammed FT200X support**
Also matches `0x0403`/`0x6015`, but **only when an explicit `serial` is configured** -- a bare FT200X has no reliable runtime signature, so requiring a serial avoids false-positive matches on unrelated FTDI devices. Also raises a clear error whe multiple programmed SD Wires are present with no serial (instead of silently binding the first).

**2. macOS storage discovery**
`effective_storage_device()` now uses `system_profiler SPUSBDataType` on Darwin (pyudev is Linux-only). The SD reader is correlated to *its* FT200X as a sibling under the same internal hub, and the disk node is read from the reader's nested
`Media[].bsd_name`, so the right disk is targeted when several SD Wires are attached. Reads/writes retry discovery (USB re-enumerates after a switch) and fail with a clear error instead of a `TypeError`.

**3. macOS `dut()` ejects before switching**
The mux only switches when the SD bus is idle; `diskutil eject` (SCSI STOP UNIT) idles it. If the disk can't be determined, `dut()` aborts rather than risk corrupting a mounted volume.

**4. macOS `host()` power-cycles the reader's hub port**
`eject` leaves the SMSC reader stopped, so `host()` routes the card back first and then power-cycles port 1 of this SD Wire's internal hub (scoped by USB topology, so other attached devices aren't disturbed) to force a clean re-enumeration without a physical replug.