### PR TITLE
fix: pin uv container image and fix docs substitutions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@ ENV UV_LINK_MODE=copy
 
 WORKDIR /opt
 
-COPY --from=ghcr.io/astral-sh/uv:0.4.4 /uv  /bin/uv
-COPY --from=ghcr.io/astral-sh/uv:0.4.4 /uvx /bin/uvx
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv  /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uvx /bin/uvx
 COPY ./.py-version ./.python-version
 
 # Install required tools for development

--- a/python/.devfile/Containerfile
+++ b/python/.devfile/Containerfile
@@ -8,8 +8,8 @@ LABEL summary="devfile jumpstarter developer image"
 LABEL description="Image with developers tools."
 LABEL io.k8s.display-name="jumpstarter-developer-universal"
 
-COPY --from=ghcr.io/astral-sh/uv:0.4.4 /uv  /bin/uv
-COPY --from=ghcr.io/astral-sh/uv:0.4.4 /uvx /bin/uvx
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv  /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uvx /bin/uvx
 
 USER root
 

--- a/python/.devfile/Containerfile.client
+++ b/python/.devfile/Containerfile.client
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.4.4 AS uv
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.11.19 AS uv
 
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.5 AS builder
 RUN dnf install -y make git && \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.4.4 AS uv
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.11.19 AS uv
 
 FROM --platform=$BUILDPLATFORM fedora:43 AS builder
 RUN dnf install -y make git && \
@@ -11,7 +11,7 @@ RUN dnf install -y python3 ustreamer libusb1 android-tools python3-libgpiod curl
     nftables dnsmasq iproute procps-ng tcpdump && \
     dnf clean all && \
     rm -rf /var/cache/dnf
-COPY --from=ghcr.io/astral-sh/uv:0.4.4 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 
 ARG FLS_VERSION=0.2.0
 RUN ARCH=$(uname -m) && \

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -90,6 +90,9 @@ _stable_branch = next(
 
 myst_substitutions = {
     "stable_branch": _stable_branch,
+    "stable_branch_index": f"[{_stable_branch}](https://pkg.jumpstarter.dev/{_stable_branch})",
+    "stable_branch_install_cmd": f"`./install.sh -s {_stable_branch}`",
+    "stable_branch_code": f"`{_stable_branch}`",
     "requires_python": tomllib.loads(
         Path(__file__).resolve().parents[2]
         .joinpath("packages/jumpstarter/pyproject.toml")

--- a/python/docs/source/getting-started/installation/packages.md
+++ b/python/docs/source/getting-started/installation/packages.md
@@ -39,7 +39,7 @@ If you have the repository cloned locally:
 | Installation Type | Command | Description |
 |------------------|---------|-------------|
 | Stable release (recommended) | `./install.sh` | Install stable {{stable_branch}} |
-| Stable release (explicit) | `./install.sh -s {{stable_branch}}` | Install stable {{stable_branch}} explicitly |
+| Stable release (explicit) | {{stable_branch_install_cmd}} | Install stable {{stable_branch}} explicitly |
 | Development version | `./install.sh -s main` | Install latest development version |
 | Release candidate | `./install.sh -s rc` | Install latest release candidate (when available) |
 | Custom directory | `./install.sh -d /opt/jumpstarter` | Install to custom directory |
@@ -73,7 +73,7 @@ echo 'source ~/.local/jumpstarter/set' >> ~/.bashrc
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-s, --source SOURCE` | Installation source ({{stable_branch}}, latest, rc, main) | `{{stable_branch}}` |
+| `-s, --source SOURCE` | Installation source ({{stable_branch}}, latest, rc, main) | {{stable_branch_code}} |
 | `-d, --dir DIR` | Installation directory | `~/.local/jumpstarter` |
 | `-h, --help` | Show help message | - |
 
@@ -165,7 +165,7 @@ indexes:
 | ------------------------------------------------------ | --------------------------------------------------------------------- |
 | [releases](https://pkg.jumpstarter.dev/)               | Release, or release-candidate versions                                |
 | [main](https://pkg.jumpstarter.dev/main/)              | Index tracking the main branch, equivalent to installing from sources |
-| [{{stable_branch}}](https://pkg.jumpstarter.dev/{{stable_branch}}) | Index tracking a stable branch                                        |
+| {{stable_branch_index}} | Index tracking a stable branch                                        |
 
 #### Installing from Source
 


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/astral-sh/uv` from `0.4.4` to `0.11.19` in all Dockerfiles and Containerfiles — the `0.4.4` tag pinned in #745 was an image format version containing an old uv binary without `uv build` support, breaking container builds. The registry publishes `0.11.x` tags matching the uv tool version (found via paginated tag listing).
- Fix myst substitutions for `{{stable_branch}}` in docs tables — substitutions don't work inside markdown link URLs or backtick code spans, so pre-build them as complete substitution values in `conf.py`.

## Test plan
- [x] Verify `python/Dockerfile` builds successfully
- [x] Verify docs build with `make docs` (substitutions render correctly)
- [x] Verify `make docs-linkcheck` passes (no broken `pkg.jumpstarter.dev` URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)