### PR TITLE
fix: consolidate Renovate Go groups and restrict Fedora to stable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -145,11 +145,11 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_g[a-f0-9]+_\\d+\\.\\d+\\.\\d+_okd_scos\\.(?:(?<prerelease>ec\\.\\d+)|(?<build>\\d+))$"
     },
     {
-      "description": "Restrict Fedora to stable releases (exclude rawhide)",
+      "description": "Track Fedora stable releases only (latest always points to current stable, never rawhide)",
       "matchPackageNames": [
         "fedora"
       ],
-      "allowedVersions": "<=44"
+      "followTag": "latest"
     },
     {
       "description": "Group Docker base images",

--- a/renovate.json
+++ b/renovate.json
@@ -108,28 +108,10 @@
       ]
     },
     {
-      "description": "Group remaining Go module updates",
-      "groupName": "go-deps-other",
+      "description": "Group all Go module updates (any dep can bump the Go toolchain)",
+      "groupName": "kubernetes",
       "matchManagers": [
         "gomod"
-      ],
-      "matchFileNames": [
-        "controller/go.mod",
-        "controller/deploy/operator/go.mod",
-        "e2e/test/go.mod"
-      ]
-    },
-    {
-      "description": "Group Go gRPC and protobuf modules",
-      "groupName": "grpc-protobuf-go",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "google.golang.org/grpc**",
-        "google.golang.org/protobuf**",
-        "google.golang.org/genproto**",
-        "github.com/grpc-ecosystem/**"
       ],
       "matchFileNames": [
         "controller/go.mod",
@@ -149,47 +131,6 @@
       ]
     },
     {
-      "description": "Group Go Kubernetes and controller dependencies",
-      "groupName": "kubernetes",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "k8s.io/**",
-        "sigs.k8s.io/controller-runtime**",
-        "sigs.k8s.io/yaml**",
-        "github.com/cert-manager/cert-manager**",
-        "github.com/openshift/api**"
-      ],
-      "matchFileNames": [
-        "controller/go.mod",
-        "controller/deploy/operator/go.mod",
-        "e2e/test/go.mod"
-      ],
-      "automerge": false
-    },
-    {
-      "description": "Group Go test framework",
-      "groupName": "go-testing",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "github.com/onsi/ginkgo**",
-        "github.com/onsi/gomega**"
-      ]
-    },
-    {
-      "description": "Group Go stdlib extensions",
-      "groupName": "golang-x",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "golang.org/x/**"
-      ]
-    },
-    {
       "description": "Custom versioning for devfile base-developer-image (track ubi major only)",
       "matchPackageNames": [
         "quay.io/devfile/base-developer-image"
@@ -202,6 +143,13 @@
         "ghcr.io/microshift-io/microshift"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_g[a-f0-9]+_\\d+\\.\\d+\\.\\d+_okd_scos\\.(?:(?<prerelease>ec\\.\\d+)|(?<build>\\d+))$"
+    },
+    {
+      "description": "Restrict Fedora to stable releases (exclude rawhide)",
+      "matchPackageNames": [
+        "fedora"
+      ],
+      "allowedVersions": "<=44"
     },
     {
       "description": "Group Docker base images",
@@ -228,8 +176,8 @@
       ]
     },
     {
-      "description": "Group Go version directives",
-      "groupName": "golang-version",
+      "description": "Group Go version directives with Kubernetes deps",
+      "groupName": "kubernetes",
       "matchDepTypes": [
         "golang"
       ],
@@ -241,14 +189,26 @@
       "automerge": false
     },
     {
-      "description": "Group .go-version with Go version directives",
-      "groupName": "golang-version",
+      "description": "Group .go-version with Kubernetes deps",
+      "groupName": "kubernetes",
       "matchManagers": [
         "custom.regex"
       ],
       "matchDepNames": [
         "go"
       ],
+      "automerge": false
+    },
+    {
+      "description": "Group go-toolset Docker image with Kubernetes deps",
+      "groupName": "kubernetes",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/go-toolset"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "automerge": false
     }
   ]


### PR DESCRIPTION
## Summary
- Consolidate all Go module groups (`go-deps-other`, `grpc-protobuf-go`, `kubernetes`, `go-testing`, `golang-x`, `golang-version`) into a single `kubernetes` group -- any Go dependency can bump the minimum Go version (verified: k8s.io/api v0.36.1 requires go 1.26.0, grpc/gin deps require go 1.25.0), so they must ship together with the Go toolchain (.go-version, go.mod directives, go-toolset container image)
- Restrict Fedora base image to `<=44` to prevent Renovate from proposing rawhide (Fedora 45)
- Add versioning regex for `ubi9/go-toolset` so only Go-version-style tags (`1.x.y`) are tracked, not UBI/RHEL build tags (`9.8-1780490420`)

## Renovate PRs affected
Once merged, Renovate will consolidate these into one PR:
- #764 (kubernetes)
- #763 (grpc-protobuf-go)
- #762 (go-testing)
- #757 (golang-x)
- #756 (go-deps-other)

And #765 (docker-base-images) will no longer propose Fedora 45 or go-toolset UBI tags.

## Test plan
- [ ] Verify Renovate validates the config (the `validate-renovate` CI job)
- [ ] After merge, confirm Renovate closes the redundant Go PRs and opens a single consolidated one
- [ ] Confirm Fedora stays at <=44 in future docker-base-images PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)