### PR TITLE
feat: add jumpstarter-driver-obd for OBD-II vehicle diagnostics

### DIFF
--- a/python/docs/source/reference/package-apis/drivers/index.md
+++ b/python/docs/source/reference/package-apis/drivers/index.md
@@ -64,6 +64,7 @@ Drivers for automotive diagnostic protocols:
 - {doc}`UDS <uds>` (`jumpstarter-driver-uds`) - Unified Diagnostic Services (ISO 14229)
 - {doc}`UDS over DoIP <uds-doip>` (`jumpstarter-driver-uds-doip`) - UDS diagnostics over DoIP transport
 - {doc}`UDS over CAN <uds-can>` (`jumpstarter-driver-uds-can`) - UDS diagnostics over CAN/ISO-TP transport
+- {doc}`OBD-II <obd>` (`jumpstarter-driver-obd`) - OBD-II vehicle diagnostics via ELM327
 - {doc}`SOME/IP <someip>` (`jumpstarter-driver-someip`) - SOME/IP protocol operations via opensomeip
 
 ### Flashing and Programming
@@ -115,6 +116,7 @@ iscsi.md
 mitmproxy.md
 network.md
 noyito-relay.md
+obd.md
 opendal.md
 pi-pico.md
 power.md

--- a/python/docs/source/reference/package-apis/drivers/obd.md
+++ b/python/docs/source/reference/package-apis/drivers/obd.md
@@ -1,0 +1,1 @@
+../../../../../packages/jumpstarter-driver-obd/README.md

--- a/python/packages/jumpstarter-all/pyproject.toml
+++ b/python/packages/jumpstarter-all/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "jumpstarter-driver-flashers",
   "jumpstarter-driver-http",
   "jumpstarter-driver-network",
+  "jumpstarter-driver-obd",
   "jumpstarter-driver-opendal",
   "jumpstarter-driver-power",
   "jumpstarter-driver-pi-pico",

--- a/python/packages/jumpstarter-driver-obd/.gitignore
+++ b/python/packages/jumpstarter-driver-obd/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-obd/README.md
+++ b/python/packages/jumpstarter-driver-obd/README.md
@@ -1,0 +1,119 @@
+# OBD-II Driver
+
+`jumpstarter-driver-obd` wraps [python-obd](https://python-obd.readthedocs.io/en/latest/)
+to query On-Board Diagnostics (OBD-II) PIDs from a vehicle ECU via an ELM327 adapter.
+
+## Installation
+
+```{code-block} console
+:substitutions:
+$ pip3 install --extra-index-url {{index_url}} jumpstarter-driver-obd
+```
+
+## Hardware Requirements
+
+- An ELM327 USB adapter (e.g. PremiumCord ELM327 USB)
+- A vehicle with an OBD-II port (petrol cars from 2001+, diesel from 2004+, all US cars from 1996+)
+- **macOS only**: ELM327 USB cables use a CH340 or CP2102 USB-serial chip that may need a kernel
+  extension — install the appropriate driver if the port does not appear after plugging in
+
+## Configuration
+
+### Auto-detect (recommended for a single adapter)
+
+Leave `port` unset or `null` to let python-obd scan available serial ports and connect to the first
+ELM327 it finds:
+
+```yaml
+export:
+  obd:
+    type: jumpstarter_driver_obd.driver.OBD
+    config:
+      port: null
+```
+
+```{note}
+Auto-detect is reliable on Linux (e.g. `/dev/ttyUSB0`). On **macOS** it is not: python-obd
+enumerates the `/dev/tty.*` call-in device nodes, but ELM327 adapters only open on the matching
+`/dev/cu.*` call-out node, so auto-detect fails to connect. On macOS, pass an explicit
+`/dev/cu.usbserial-*` port instead.
+```
+
+### Explicit port
+
+Specify the serial port directly when you have multiple adapters or want a deterministic setup:
+
+```yaml
+export:
+  obd:
+    type: jumpstarter_driver_obd.driver.OBD
+    config:
+      port: /dev/ttyUSB0       # Linux
+      # port: /dev/cu.usbserial-XXXX   # macOS
+      baudrate: 38400
+```
+
+### Config parameters
+
+| Parameter | Description | Type | Required | Default |
+|-----------|-------------|------|----------|---------|
+| port | Serial port path; `null` to auto-detect an ELM327 adapter | str \| null | no | null |
+| baudrate | ELM327 baud rate | int | no | 38400 |
+| fast | Enable ELM327 fast mode (~100–400 ms faster per query); unreliable on cheap clone adapters, so it is opt-in | bool | no | false |
+
+## Usage
+
+```python
+from jumpstarter_driver_obd import OBDConnectionStatus
+
+# Check connection state
+status = obd.status()                              # returns OBDConnectionStatus
+print(status == OBDConnectionStatus.CAR_CONNECTED) # True
+print(obd.is_connected())                          # True
+
+# Discover what the ECU supports
+cmds = obd.supported_commands()   # ["RPM", "SPEED", "COOLANT_TEMP", ...]
+
+# Query individual PIDs by name
+rpm   = obd.query("RPM")          # "3000.0 revolutions_per_minute"
+speed = obd.query("SPEED")        # "60.0 kph"
+temp  = obd.query("COOLANT_TEMP") # "90.0 degC"
+
+# Clearing trouble codes is a separate, explicit call (see note below)
+obd.clear_dtc()
+```
+
+`query()` returns `None` when the ECU does not answer the command (unsupported PID
+or no vehicle on the bus). It is read-only: it refuses destructive commands such as
+`CLEAR_DTC` (OBD-II mode 04, which erases stored trouble codes and resets emissions
+readiness monitors). To clear codes deliberately, call `clear_dtc()` instead.
+
+## Troubleshooting
+
+**Port not found on macOS**
+Run `ls /dev/cu.*` before and after plugging in the cable to spot the new device.
+Install a CH340 or CP2102 USB-serial kernel extension if no new port appears.
+
+**Permission denied on Linux**
+Add your user to the `dialout` group and log out/in:
+```shell
+sudo usermod -aG dialout $USER
+```
+Alternatively, create a udev rule for the adapter's USB vendor/product ID.
+
+**"No OBD-II adapters found"**
+Make sure the cable is seated in the OBD-II port (typically under the dashboard on the driver's side)
+and that the vehicle ignition is in the ON or ACC position.
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_obd.driver.OBD()
+    :members:
+
+.. autoclass:: jumpstarter_driver_obd.client.OBDClient()
+    :members:
+
+.. autoclass:: jumpstarter_driver_obd.driver.OBDConnectionStatus()
+    :members:
+```

--- a/python/packages/jumpstarter-driver-obd/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-obd/examples/exporter.yaml
@@ -1,0 +1,10 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: obd
+export:
+  obd:
+    type: jumpstarter_driver_obd.driver.OBD
+    config:
+      port: null

--- a/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/__init__.py
+++ b/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/__init__.py
@@ -1,0 +1,4 @@
+from .client import OBDClient
+from .driver import OBD, OBDConnectionStatus
+
+__all__ = ["OBD", "OBDClient", "OBDConnectionStatus"]

--- a/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/client.py
+++ b/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/client.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from .driver import OBDConnectionStatus
+from jumpstarter.client import DriverClient
+
+
+@dataclass(kw_only=True)
+class OBDClient(DriverClient):
+    """Client for the OBD-II driver."""
+
+    def query(self, command_name: str) -> Optional[str]:
+        """Query a PID by name (e.g. 'RPM'); returns None if the ECU doesn't answer."""
+        return self.call("query", command_name)
+
+    def clear_dtc(self) -> None:
+        """Clear stored DTCs and freeze-frame data (mode 04).
+
+        Destructive: also resets readiness monitors.
+        """
+        return self.call("clear_dtc")
+
+    def status(self) -> OBDConnectionStatus:
+        """Connection state."""
+        return OBDConnectionStatus(self.call("status"))
+
+    def supported_commands(self) -> list[str]:
+        """Sorted PID names the connected ECU advertises."""
+        return self.call("supported_commands")
+
+    def is_connected(self) -> bool:
+        """True when a vehicle ECU is on the bus, not just the adapter."""
+        return self.call("is_connected")

--- a/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/driver.py
+++ b/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/driver.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Optional
+
+import obd
+
+from jumpstarter.client.core import DriverInvalidArgument
+from jumpstarter.driver import Driver, export
+
+
+class OBDConnectionStatus(StrEnum):
+    NOT_CONNECTED = "Not Connected"
+    ELM_CONNECTED = "ELM Connected"
+    OBD_CONNECTED = "OBD Connected"
+    CAR_CONNECTED = "Car Connected"
+
+# CLEAR_DTC (mode 04) erases stored codes and resets readiness monitors, so it
+# is reachable only through clear_dtc(), never the generic query().
+DESTRUCTIVE_COMMANDS = frozenset({"CLEAR_DTC"})
+
+
+@dataclass(kw_only=True)
+class OBD(Driver):
+    """OBD-II vehicle diagnostics via an ELM327 adapter, wrapping python-obd.
+
+    ``port=None`` (the default) auto-detects the adapter; otherwise pass the
+    serial path, e.g. ``/dev/ttyUSB0``.
+    """
+
+    port: Optional[str] = field(default=None)
+    baudrate: int = field(default=38400)
+    # fast mode is quicker but flaky on cheap clone adapters, so it defaults off
+    fast: bool = field(default=False)
+
+    _connection: Optional[obd.OBD] = field(init=False, default=None)
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_obd.client.OBDClient"
+
+    def __post_init__(self):
+        super().__post_init__()
+        conn = obd.OBD(portstr=self.port, baudrate=self.baudrate, fast=self.fast)
+        if conn.status() == obd.OBDStatus.NOT_CONNECTED:
+            conn.close()
+            raise ConnectionError(f"No ELM327 adapter found on port {self.port!r}")
+        self._connection = conn
+
+    def close(self):
+        if self._connection is not None:
+            self._connection.close()
+        super().close()
+
+    @export
+    def query(self, command_name: str) -> Optional[str]:
+        """Query a PID by name (e.g. 'RPM', 'SPEED', 'COOLANT_TEMP').
+
+        Returns None if the ECU doesn't answer. Destructive commands such as
+        CLEAR_DTC are rejected here; use clear_dtc() instead.
+        """
+        if command_name in DESTRUCTIVE_COMMANDS:
+            raise DriverInvalidArgument(
+                f"{command_name} is destructive (clears stored DTCs and resets "
+                f"readiness monitors) and cannot be sent via query(); use clear_dtc()"
+            )
+        if not obd.commands.has_name(command_name):
+            raise DriverInvalidArgument(f"Unknown OBD command: {command_name}")
+        cmd = obd.commands[command_name]
+        response = self._connection.query(cmd)
+        if response.is_null():
+            return None
+        return self._serialize(response.value)
+
+    @export
+    def clear_dtc(self) -> None:
+        """Clear stored DTCs and freeze-frame data (mode 04).
+
+        Destructive: also resets readiness monitors, which then need drive
+        cycles to re-complete. Use only as a deliberate reset.
+        """
+        # obd.commands is populated dynamically; index it by name
+        self._connection.query(obd.commands["CLEAR_DTC"], force=True)
+
+    @staticmethod
+    def _serialize(value) -> str:
+        """Stringify a python-obd value.
+
+        Most values stringify fine, but VIN/CALIBRATION_ID are bytearrays and
+        STATUS is an object with no __str__ (and a None key in __dict__). Handle
+        those so callers never get raw bytes or a '<object at 0x...>' address.
+        """
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode("ascii", errors="replace")
+        if type(value).__str__ is object.__str__:
+            try:
+                fields = {k: v for k, v in vars(value).items() if isinstance(k, str) and not k.startswith("_")}
+            except TypeError:
+                fields = None
+            if fields:
+                return ", ".join(f"{k}={v}" for k, v in fields.items())
+        return str(value)
+
+    @export
+    def status(self) -> OBDConnectionStatus:
+        """Connection state."""
+        return OBDConnectionStatus(str(self._connection.status()))
+
+    @export
+    def supported_commands(self) -> list[str]:
+        """Sorted PID names the connected ECU advertises."""
+        return sorted(cmd.name for cmd in self._connection.supported_commands)
+
+    @export
+    def is_connected(self) -> bool:
+        """True when a vehicle ECU is on the bus, not just the adapter."""
+        return self._connection.is_connected()

--- a/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/driver_test.py
+++ b/python/packages/jumpstarter-driver-obd/jumpstarter_driver_obd/driver_test.py
@@ -1,0 +1,145 @@
+"""Tests for the OBD-II driver.
+
+obd.OBD is patched with a mock ECU so the tests run without hardware,
+exercising the @export RPC round-trip and query()'s value/error paths.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import obd
+import pytest
+
+from .driver import OBD, OBDConnectionStatus
+from jumpstarter.client.core import DriverInvalidArgument
+from jumpstarter.common.utils import serve
+
+
+class _FakeStatus:
+    """Stand-in for obd's Status: no __str__, plus a None key in __dict__
+    (python-obd stores reserved test bits there) that broke serialize() on real hardware."""
+
+    def __init__(self):
+        self.MIL = False
+        self.DTC_count = 0
+        self.ignition_type = "spark"
+        self.__dict__[None] = "reserved"  # the real-hardware crash trigger
+
+
+def _make_mock_connection(status=obd.OBDStatus.CAR_CONNECTED):
+    """Return a mock obd.OBD that looks like a connected car ECU."""
+    conn = MagicMock()
+    conn.status.return_value = status
+    conn.is_connected.return_value = status == obd.OBDStatus.CAR_CONNECTED
+
+    # obd.commands is populated dynamically; index by name
+    rpm_cmd = obd.commands["RPM"]
+    speed_cmd = obd.commands["SPEED"]
+    vin_cmd = obd.commands["VIN"]
+    status_cmd = obd.commands["STATUS"]
+
+    conn.supported_commands = {rpm_cmd, speed_cmd, vin_cmd, status_cmd}
+
+    def fake_query(cmd, *args, **kwargs):  # clear_dtc passes force=True
+        # cover the value types query() must serialize: Quantity, bytearray, no-__str__ object
+        resp = MagicMock()
+        resp.is_null.return_value = False
+        if cmd is rpm_cmd:
+            resp.value = 3000 * obd.Unit.rpm
+        elif cmd is speed_cmd:
+            resp.value = 60 * obd.Unit.kph
+        elif cmd is vin_cmd:
+            resp.value = bytearray(b"1HGBH41JXMN109186")
+        elif cmd is status_cmd:
+            resp.value = _FakeStatus()
+        else:
+            resp.is_null.return_value = True
+            resp.value = None
+        return resp
+
+    conn.query.side_effect = fake_query
+    return conn
+
+
+@pytest.fixture
+def obd_client():
+    """Yield an OBDClient connected to a mocked OBD driver."""
+    mock_conn = _make_mock_connection()
+    with patch("jumpstarter_driver_obd.driver.obd.OBD", return_value=mock_conn):
+        with serve(OBD()) as client:
+            yield client
+
+
+def test_obd_status(obd_client):
+    result = obd_client.status()
+    assert result == OBDConnectionStatus.CAR_CONNECTED
+
+
+def test_obd_supported_commands(obd_client):
+    commands = obd_client.supported_commands()
+    assert isinstance(commands, list)
+    assert len(commands) > 0
+
+
+def test_obd_query_rpm(obd_client):
+    value = obd_client.query("RPM")
+    assert value is not None
+    assert float(value.split()[0]) == 3000
+
+
+def test_obd_query_speed(obd_client):
+    value = obd_client.query("SPEED")
+    assert value is not None
+    assert float(value.split()[0]) == 60
+
+
+def test_obd_is_connected(obd_client):
+    assert obd_client.is_connected() is True
+
+
+def test_obd_query_unknown_command(obd_client):
+    with pytest.raises(DriverInvalidArgument, match="Unknown OBD command"):
+        obd_client.query("DOES_NOT_EXIST")
+
+
+def test_obd_query_null_response(obd_client):
+    # COOLANT_TEMP exists in obd.commands but the mock returns is_null=True for it
+    value = obd_client.query("COOLANT_TEMP")
+    assert value is None
+
+
+def test_obd_query_bytearray_decoded(obd_client):
+    # VIN comes back as a bytearray; query() must decode it, not str() the repr.
+    value = obd_client.query("VIN")
+    assert value == "1HGBH41JXMN109186"
+
+
+def test_obd_query_object_without_str_serialized(obd_client):
+    # STATUS has no __str__; query() must render fields, not a '<object at 0x...>' address
+    value = obd_client.query("STATUS")
+    assert "0x" not in value
+    assert "object at" not in value
+    assert "MIL=False" in value and "DTC_count=0" in value
+
+
+def test_obd_query_rejects_destructive(obd_client):
+    # CLEAR_DTC (mode 04) erases codes + resets monitors; query() must refuse it.
+    with pytest.raises(DriverInvalidArgument, match="destructive"):
+        obd_client.query("CLEAR_DTC")
+
+
+def test_obd_clear_dtc_invokes_mode_04():
+    # The dedicated method must actually send CLEAR_DTC to the adapter.
+    mock_conn = _make_mock_connection()
+    with patch("jumpstarter_driver_obd.driver.obd.OBD", return_value=mock_conn):
+        with serve(OBD()) as client:
+            assert client.clear_dtc() is None
+    sent = [call.args[0] for call in mock_conn.query.call_args_list]
+    assert obd.commands["CLEAR_DTC"] in sent
+
+
+def test_obd_no_adapter_raises():
+    """Driver must raise ConnectionError when no ELM327 adapter is found."""
+    mock_conn = _make_mock_connection(status=obd.OBDStatus.NOT_CONNECTED)
+    with patch("jumpstarter_driver_obd.driver.obd.OBD", return_value=mock_conn):
+        with pytest.raises(ConnectionError, match="No ELM327 adapter found"):
+            OBD()

--- a/python/packages/jumpstarter-driver-obd/pyproject.toml
+++ b/python/packages/jumpstarter-driver-obd/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "jumpstarter-driver-obd"
+dynamic = ["version", "urls"]
+description = "OBD-II vehicle diagnostics driver for Jumpstarter"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "Marek Mahut", email = "marek@mahut.dev" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "jumpstarter",
+    "obd>=0.7.1",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+OBD = "jumpstarter_driver_obd.driver:OBD"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../'}
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=html --cov-report=xml"
+log_cli = true
+log_cli_level = "INFO"
+testpaths = ["jumpstarter_driver_obd"]
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,7 @@ jumpstarter-driver-http-power = { workspace = true }
 jumpstarter-driver-gpiod = { workspace = true }
 jumpstarter-driver-ridesx = { workspace = true }
 jumpstarter-driver-network = { workspace = true }
+jumpstarter-driver-obd = { workspace = true }
 jumpstarter-driver-opendal = { workspace = true }
 jumpstarter-driver-power = { workspace = true }
 jumpstarter-driver-pi-pico = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -35,6 +35,7 @@ members = [
     "jumpstarter-driver-mitmproxy",
     "jumpstarter-driver-network",
     "jumpstarter-driver-noyito-relay",
+    "jumpstarter-driver-obd",
     "jumpstarter-driver-opendal",
     "jumpstarter-driver-pi-pico",
     "jumpstarter-driver-power",
@@ -1410,6 +1411,30 @@ wheels = [
 ]
 
 [[package]]
+name = "flexcache"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816, upload-time = "2024-03-09T03:21:07.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263, upload-time = "2024-03-09T03:21:05.635Z" },
+]
+
+[[package]]
+name = "flexparser"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/99/b4de7e39e8eaf8207ba1a8fa2241dd98b2ba72ae6e16960d8351736d8702/flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2", size = 31799, upload-time = "2024-11-07T02:00:56.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846", size = 27625, upload-time = "2024-11-07T02:00:54.523Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2013,6 +2038,7 @@ dependencies = [
     { name = "jumpstarter-driver-gpiod" },
     { name = "jumpstarter-driver-http" },
     { name = "jumpstarter-driver-network" },
+    { name = "jumpstarter-driver-obd" },
     { name = "jumpstarter-driver-opendal" },
     { name = "jumpstarter-driver-pi-pico" },
     { name = "jumpstarter-driver-power" },
@@ -2061,6 +2087,7 @@ requires-dist = [
     { name = "jumpstarter-driver-gpiod", editable = "packages/jumpstarter-driver-gpiod" },
     { name = "jumpstarter-driver-http", editable = "packages/jumpstarter-driver-http" },
     { name = "jumpstarter-driver-network", editable = "packages/jumpstarter-driver-network" },
+    { name = "jumpstarter-driver-obd", editable = "packages/jumpstarter-driver-obd" },
     { name = "jumpstarter-driver-opendal", editable = "packages/jumpstarter-driver-opendal" },
     { name = "jumpstarter-driver-pi-pico", editable = "packages/jumpstarter-driver-pi-pico" },
     { name = "jumpstarter-driver-power", editable = "packages/jumpstarter-driver-power" },
@@ -2860,6 +2887,32 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-obd"
+source = { editable = "packages/jumpstarter-driver-obd" }
+dependencies = [
+    { name = "jumpstarter" },
+    { name = "obd" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "obd", specifier = ">=0.7.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -4645,6 +4698,19 @@ wheels = [
 ]
 
 [[package]]
+name = "obd"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pint" },
+    { name = "pyserial" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/37/3ae6fd261f911fb3292249a876061786a54486cd5899d49b1406c3483921/obd-0.7.3.tar.gz", hash = "sha256:27b8f043376ca700edb98bf5216e2912295ecde0e735b260999f2d9ddf342522", size = 72967, upload-time = "2025-04-07T05:21:25.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/47/8ef35b33fc80db40d4a42632b0a22b2b2ed7671832dbc9bda9d912a826b0/obd-0.7.3-py3-none-any.whl", hash = "sha256:f26da700f13683a27855e6a439db72f7025fff6f1fd47ad4c6c33089d9fe7cab", size = 72130, upload-time = "2025-04-07T05:21:24.094Z" },
+]
+
+[[package]]
 name = "opendal"
 version = "0.45.20"
 source = { registry = "https://pypi.org/simple" }
@@ -4843,6 +4909,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/20/5c0a0aa83b213b7a07ec01e71a3d6ea2cf4ad1d2c686cc0168173b6089e7/pillow-11.2.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:036e53f4170e270ddb8797d4c590e6dd14d28e15c7da375c18978045f7e6c37b", size = 3527165, upload-time = "2025-04-12T17:49:55.164Z" },
     { url = "https://files.pythonhosted.org/packages/58/0e/2abab98a72202d91146abc839e10c14f7cf36166f12838ea0c4db3ca6ecb/pillow-11.2.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:14f73f7c291279bd65fda51ee87affd7c1e097709f7fdd0188957a16c264601f", size = 3571586, upload-time = "2025-04-12T17:49:57.171Z" },
     { url = "https://files.pythonhosted.org/packages/21/2c/5e05f58658cf49b6667762cca03d6e7d85cededde2caf2ab37b81f80e574/pillow-11.2.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:208653868d5c9ecc2b327f9b9ef34e0e42a4cdd172c2988fd81d62d2bc9bc044", size = 2674751, upload-time = "2025-04-12T17:49:59.628Z" },
+]
+
+[[package]]
+name = "pint"
+version = "0.24.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flexcache" },
+    { name = "flexparser" },
+    { name = "platformdirs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/bb/52b15ddf7b7706ed591134a895dbf6e41c8348171fb635e655e0a4bbb0ea/pint-0.24.4.tar.gz", hash = "sha256:35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80", size = 342225, upload-time = "2024-11-07T16:29:46.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/16/bd2f5904557265882108dc2e04f18abc05ab0c2b7082ae9430091daf1d5c/Pint-0.24.4-py3-none-any.whl", hash = "sha256:aa54926c8772159fcf65f82cc0d34de6768c151b32ad1deb0331291c38fe7659", size = 302029, upload-time = "2024-11-07T16:29:43.976Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds an OBD-II driver for live diagnostics off a real vehicle through one of those cheap ELM327 USB adapters. It wraps [python-obd](https://python-obd.readthedocs.io/) and was tested in my garage! :) Ignition off through engine running, a full sweep of all ~100 PIDs it advertised, and DTC reads tested.

<img width="450" height="600" alt="obd-car-rpi" src="https://github.com/user-attachments/assets/24f1669e-1296-4fda-84a8-550a99ec6c3c" align="center" />
  
 What it can do:

  | Method | What it does |
  |--------|--------------|
  | `query(name)` | Read a PID by name (`RPM`, `SPEED`, …); `None` if the ECU doesn't answer |
  | `clear_dtc()` | Clear stored fault codes / freeze frame - destructive, see below |
  | `status()` | Connection state (`Car Connected`, `ELM Connected`, …) |
  | `supported_commands()` | Sorted list of PIDs the ECU advertises |
  | `is_connected()` | True only when a car is actually on the bus |

  A few decisions worth flagging for review:

  - **`query()` is read-only.** Clearing codes is OBD mode 04 — it wipes stored DTCs *and* resets the emissions readiness monitors, so it's behind its own `clear_dtc()` rather than reachable by passing `"CLEAR_DTC"` to `query()`.
  - A couple of PIDs don't stringify nicely — `VIN` comes back as a bytearray and `STATUS` as an object with no `__str__`; so those are handled explicitly.
 - `fast` mode is off by default: it's quicker but flaky on the clone adapters most people actually have (like the cheap one I have). If you have a professional one, you can still use the fast mode.