### PR TITLE
feat: driver/sdwire: add Badgerd SDWire3 auto-detection and macOS support

### DIFF
--- a/python/packages/jumpstarter-driver-sdwire/README.md
+++ b/python/packages/jumpstarter-driver-sdwire/README.md
@@ -1,8 +1,58 @@
 # SD Wire Driver
 
-`jumpstarter-driver-sdwire` provides functionality for using the SDWire storage
-multiplexer. This device multiplexes an SD card between the DUT and the exporter
-host.
+`jumpstarter-driver-sdwire` provides functionality for using SD Wire storage
+multiplexers. These devices route an SD card between the DUT and the exporter
+host so you can flash or read the card from the host, then switch it to the DUT.
+
+The same `SDWire` driver class supports all variants below. **No model selector is
+required** — the driver picks the correct protocol from the USB identity of the
+attached device.
+
+## Supported devices
+
+| Variant | Typical hardware | USB identity | Mux control | Init / setup |
+|---------|------------------|--------------|-------------|--------------|
+| **Original SD Wire** (3mdeb / Tizen) | FT200X + internal SMSC reader | `0x04E8:0x6001`, product `sd-wire` | FTDI CBUS bitbang | Run `sd-mux-ctrl --init` once |
+| **SDWireC** (Badgerd) | Same FT200X design as above | `0x04E8:0x6001`, product `sd-wire` | FTDI CBUS bitbang | Run `sd-mux-ctrl --init` once |
+| **Unprogrammed FT200X** | Factory-default EEPROM | `0x0403:0x6015` | FTDI CBUS bitbang | Set `serial` in config; one-time CBUS0 GPIO fix (see below) |
+| **SDWire3** (Badgerd Gen2) | Realtek USB3 reader + mux | `0x0BDA:0x0316`, product `USB3.0-CRW` | Kernel driver attach/detach + USB reset | Plug and play |
+
+### How switching differs
+
+**FT200X-based devices** (original SD Wire, SDWireC, unprogrammed FT200X):
+
+- The FT200X is a separate USB function from the SMSC SD card reader behind an
+  internal hub.
+- The driver sends FTDI vendor requests (`select(0xF1)` = host, `select(0xF0)` =
+  DUT).
+- On macOS, `host()` also power-cycles the reader's hub port so the card
+  re-enumerates after an eject.
+
+**SDWire3**:
+
+- The card reader and mux control share **one** USB mass-storage interface.
+- **Host:** attach kernel mass-storage driver + USB reset → card visible to the
+  host (`/dev/disk…` / `/dev/disk/by-diskseq/…`).
+- **DUT:** detach kernel driver + USB reset → card routed to the DUT slot.
+- No SMSC hub, no FTDI EEPROM programming, no `sd-mux-ctrl`.
+
+The exported API is the same for all variants: `host()`, `dut()`, `off()`,
+`read()`, and `write()`.
+
+### Backwards compatibility
+
+Existing exporter configs and FT200X-based hardware **keep working unchanged**:
+
+- Detection order prefers SDWire3 when `0x0BDA:0x0316` is present, then
+  programmed `sd-wire` devices, then unprogrammed FT200X (only when `serial` is
+  set).
+- All previous config fields (`serial`, `storage_device`, timeouts) apply to
+  every variant where relevant.
+- FT200X `query()` still uses the FTDI status request; SDWire3 `query()` uses
+  whether the kernel mass-storage driver is attached.
+
+If you have **both** an SDWire3 and an FT200X SD Wire on the same machine, set
+`serial` so the driver binds the intended unit.
 
 ## Installation
 
@@ -19,6 +69,42 @@ Example configuration:
 :language: yaml
 ```
 
+### Config fields
+
+| Field | Required | Applies to | Purpose |
+|-------|----------|------------|---------|
+| `serial` | Optional (required for unprogrammed FT200X; recommended with multiple devices) | All | Pin a specific unit when several are attached |
+| `storage_device` | Optional | All | Block device path; skips auto-discovery when set |
+| `storage_timeout` | Optional | All | Seconds to wait for the card to appear after switching to host |
+| `storage_leeway` | Optional | All | Write safety margin (see `StorageMuxClient`) |
+| `storage_fsync_timeout` | Optional | All | `fsync` timeout for writes |
+
+There is **no** `device_type` or `model` setting. Auto-detection is intentional
+so one exporter config works across lab hardware generations.
+
+### `serial` values by variant
+
+- **Programmed FT200X** (`sd-wire`): the string from `sd-mux-ctrl --init` /
+  `usb.util.get_string(iSerialNumber)`, e.g. `sd-wire_11`.
+- **Unprogrammed FT200X**: the factory FTDI serial from `lsusb` / `dmesg`; the
+  driver will not bind an unprogrammed FT200X unless this is set.
+- **SDWire3**: any of:
+  - USB serial string (e.g. `20120501030900000`)
+  - Composite identity `<serial>.<usb.port.path>` (e.g. `20120501030900000.1`)
+  - Bus and address `<bus>.<address>` (e.g. `2.2`)
+
+### `storage_device` auto-discovery
+
+When unset, the driver resolves the block device automatically:
+
+| Variant | Linux | macOS |
+|---------|-------|-------|
+| FT200X | pyudev: SMSC reader sibling of the FT200X | `system_profiler`: reader next to FT200X in USB tree |
+| SDWire3 | pyudev: block device under the same USB device | `ioreg`: whole disk under `USB3.0-CRW@…` (fallback when `system_profiler` is empty) |
+
+Set `storage_device` explicitly if auto-discovery is ambiguous or you want a
+stable path such as `/dev/disk/by-diskseq/N`.
+
 ```{doctest}
 :hide:
 >>> from jumpstarter.config.exporter import ExporterConfigV1Alpha1DriverInstance
@@ -28,7 +114,7 @@ Traceback (most recent call last):
 FileNotFoundError: failed to find sd-wire device...
 ```
 
-## Unprogrammed (factory-default) SD Wire devices
+## Unprogrammed (factory-default) FT200X devices
 
 SD Wires are normally initialized with `sd-mux-ctrl --init`, which rewrites the
 FTDI FT200X EEPROM to the Samsung VID/PID (`0x04E8`/`0x6001`, product `sd-wire`)
@@ -69,24 +155,44 @@ is also supported, but with two requirements:
 
 ## macOS notes
 
-On macOS (`Darwin`) the driver does extra work that is unnecessary on Linux:
+On macOS (`Darwin`) the driver does extra work that is unnecessary on Linux.
 
-- **`dut()` ejects the card before switching.** The mux only switches when the
-  SD bus is fully idle; while macOS holds the SMSC reader open it keeps polling
-  the card. The driver runs `diskutil eject` (SCSI `STOP UNIT`) first. If the
-  disk cannot be determined, `dut()` aborts rather than risk corrupting a mounted
-  volume.
-- **Power on the DUT immediately after `dut()` (< ~500 ms).** The mux has a
-  protection circuit that reverts to HOST if it sees no SD activity on the DUT
-  side shortly after switching.
-- **`host()` power-cycles the reader's hub port.** Because the prior `eject`
-  leaves the SMSC reader stopped, `host()` routes the card back and *then*
-  power-cycles port 1 of *this* SD Wire's internal hub to force a clean
-  re-enumeration (correlated by USB topology so other attached SD Wires are not
-  disturbed).
-- **Storage discovery uses `system_profiler`** (pyudev is Linux-only) and may
-  take a moment to re-enumerate after a switch, so reads/writes retry discovery
-  up to `storage_timeout`.
+**All variants — `dut()`:**
+
+- Ejects the card with `diskutil eject` before switching so the SD bus is idle.
+  If the disk cannot be determined, `dut()` aborts rather than risk corrupting a
+  mounted volume.
+
+**FT200X-based devices only:**
+
+- **Power on the DUT within ~500 ms after `dut()`.** The mux protection circuit
+  reverts to HOST if it sees no SD activity on the DUT side shortly after
+  switching.
+- **`host()` power-cycles the reader's hub port** after routing the card back,
+  so the SMSC reader re-enumerates cleanly after the prior eject.
+
+**SDWire3 only:**
+
+- Switching uses libusb to detach/attach the kernel mass-storage driver. **Run
+  the exporter with root on macOS:**
+
+  ```console
+  sudo uv run jmp shell --exporter-config packages/jumpstarter-driver-sdwire/examples/exporter.yaml
+  ```
+
+- Storage discovery uses `ioreg` (recent macOS versions often return an empty
+  USB tree from `system_profiler`).
+
+**All variants — reads/writes:**
+
+- Storage may take a moment to re-enumerate after a switch; `read()` / `write()`
+  retry discovery up to `storage_timeout`.
+
+**SDWire3 at startup:**
+
+- If the mux is already on the DUT side, no host disk is visible during init.
+  The driver logs a warning and continues; `host()` / `read()` / `write()` wait
+  until the card appears.
 
 ## API Reference
 

--- a/python/packages/jumpstarter-driver-sdwire/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-sdwire/examples/exporter.yaml
@@ -1,0 +1,24 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: sdwire-exporter
+endpoint: grpc.jumpstarter.example.com:443
+token: "<token>"
+export:
+  sdwire:
+    type: jumpstarter_driver_sdwire.driver.SDWire
+    # config:
+    #   # Optional: pin a specific SD Wire when several are attached.
+    #   # Required for factory-default (unprogrammed) FT200X devices.
+    #   # For SDWire3, use the USB serial, composite identity, or bus.address.
+    #   serial: "sdw-00001"
+    #
+    #   # Optional: block device path for the SD card reader behind the mux.
+    #   # Auto-detected on Linux and macOS when unset.
+    #   storage_device: "/dev/disk/by-diskseq/1"
+    #
+    #   # Optional: timeouts (seconds) for storage discovery and writes.
+    #   storage_timeout: 10
+    #   storage_leeway: 6
+    #   storage_fsync_timeout: 900

--- a/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver.py
+++ b/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import errno
 import platform
+import re
 import subprocess
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 
 import anyio
 import anyio.to_thread
@@ -24,6 +27,11 @@ _PROGRAMMED_PRODUCT = "sd-wire"
 _FTDI_VID = 0x0403
 _FT200X_PID = 0x6015
 
+# Badgerd SDWire3 (Realtek-based USB3 reader + mux on one interface).
+_SDWIRE3_VID = 0x0BDA
+_SDWIRE3_PID = 0x0316
+_SDWIRE3_MASS_STORAGE_INTERFACE = 0
+
 # SD Wire internal USB hub; the SD reader sits on port 1.
 _SMSC_HUB_VID = 0x0424
 _SMSC_HUB_PID = 0x2640
@@ -34,8 +42,41 @@ _SMSC_READER_VID = 0x0424
 _SMSC_READER_PID = 0x4050
 
 
+class _DeviceKind(Enum):
+    FT200X = "ft200x"
+    SDWIRE3 = "sdwire3"
+
+
 def _hex_id(value: int) -> str:
     return f"0x{value:04x}"
+
+
+def _usb_serial(dev: usb.core.Device) -> str | None:
+    try:
+        if dev.iSerialNumber:
+            return usb.util.get_string(dev, dev.iSerialNumber)
+    except usb.core.USBError:
+        pass
+    return None
+
+
+def _sdwire3_identity(dev: usb.core.Device) -> str:
+    serial = _usb_serial(dev) or "unknown"
+    port_numbers = getattr(dev, "port_numbers", None)
+    if port_numbers:
+        return f"{serial}.{'.'.join(map(str, port_numbers))}"
+    return f"{serial}:{dev.bus}.{dev.address}"
+
+
+def _serial_matches(dev: usb.core.Device, configured: str, kind: _DeviceKind) -> bool:
+    if configured == _sdwire3_identity(dev):
+        return True
+    usb_serial = _usb_serial(dev)
+    if usb_serial is not None and configured == usb_serial:
+        return True
+    if kind == _DeviceKind.SDWIRE3 and configured == f"{dev.bus}.{dev.address}":
+        return True
+    return False
 
 
 def _find_smsc_hub(dev: usb.core.Device) -> usb.core.Device | None:
@@ -81,7 +122,20 @@ def _power_cycle_smsc_port(dev: usb.core.Device, logger=None) -> None:
         pass  # best-effort; caller raises if the disk never appears
 
 
-def _find_storage_device_linux(dev: usb.core.Device) -> str | None:
+def _iter_block_links(udevice) -> str | None:
+    for child in udevice.children:
+        if child.subsystem == "block":
+            for storage_device in filter(
+                lambda link: link.startswith("/dev/disk/by-diskseq/"), child.device_links
+            ):
+                return storage_device
+        found = _iter_block_links(child)
+        if found is not None:
+            return found
+    return None
+
+
+def _find_storage_device_linux(dev: usb.core.Device, *, kind: _DeviceKind) -> str | None:
     try:
         import pyudev
 
@@ -91,15 +145,23 @@ def _find_storage_device_linux(dev: usb.core.Device) -> str | None:
             .match_attribute("busnum", dev.bus)
             .match_attribute("devnum", dev.address)
         ):
+            if kind == _DeviceKind.SDWIRE3:
+                found = _iter_block_links(udevice)
+                if found is not None:
+                    return found
+                continue
+
             for block in filter(lambda d: d.subsystem == "block", udevice.parent.children):
-                for storage_device in filter(lambda link: link.startswith("/dev/disk/by-diskseq/"), block.device_links):
+                for storage_device in filter(
+                    lambda link: link.startswith("/dev/disk/by-diskseq/"), block.device_links
+                ):
                     return storage_device
     except (ImportError, OSError, AttributeError):
         pass
     return None
 
 
-def _node_is_controller(node: dict, serial: str | None) -> bool:
+def _node_is_ft200x_controller(node: dict, serial: str | None) -> bool:
     if serial is not None:
         return node.get("serial_num") == serial
     vid = node.get("vendor_id", "").lower()
@@ -107,6 +169,23 @@ def _node_is_controller(node: dict, serial: str | None) -> bool:
     return (_hex_id(_PROGRAMMED_VID) in vid and _hex_id(_PROGRAMMED_PID) in pid) or (
         _hex_id(_FTDI_VID) in vid and _hex_id(_FT200X_PID) in pid
     )
+
+
+def _node_is_sdwire3(node: dict, serial: str | None, bus: int | None, address: int | None) -> bool:
+    vid = node.get("vendor_id", "").lower()
+    pid = node.get("product_id", "").lower()
+    if not (_hex_id(_SDWIRE3_VID) in vid and _hex_id(_SDWIRE3_PID) in pid):
+        return False
+    if serial is None:
+        return True
+    node_serial = node.get("serial_num")
+    if node_serial == serial:
+        return True
+    if bus is not None and address is not None:
+        location_id = node.get("location_id", "")
+        if location_id.endswith(f"/ {address}"):
+            return serial.endswith(f":{bus}.{address}") or serial.endswith(f".{bus}.{address}")
+    return False
 
 
 def _reader_bsd(node: dict) -> str | None:
@@ -122,9 +201,15 @@ def _reader_bsd(node: dict) -> str | None:
     return None
 
 
-def _find_storage_device_macos(serial: str | None) -> str | None:
-    # pyudev is Linux-only; on macOS walk system_profiler and pick the SD reader
-    # that is a sibling of this SD Wire's FT200X.
+def _sdwire3_bsd(node: dict) -> str | None:
+    for media in node.get("Media", []):
+        bsd = media.get("bsd_name")
+        if bsd:
+            return f"/dev/{bsd}"
+    return None
+
+
+def _load_macos_usb_tree() -> list[dict] | None:
     try:
         import json
 
@@ -136,19 +221,28 @@ def _find_storage_device_macos(serial: str | None) -> str | None:
         data = json.loads(out)
     except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
         return None
+    return data.get("SPUSBDataType", [])
+
+
+def _find_storage_device_macos(serial: str | None) -> str | None:
+    # pyudev is Linux-only; on macOS walk system_profiler and pick the SD reader
+    # that is a sibling of this SD Wire's FT200X.
+    tree = _load_macos_usb_tree()
+    if tree is None:
+        return None
 
     results: list[str] = []
 
     def walk(items: list[dict]) -> None:
         for node in items:
-            if _node_is_controller(node, serial):
+            if _node_is_ft200x_controller(node, serial):
                 for sibling in items:
                     bsd = _reader_bsd(sibling)
                     if bsd:
                         results.append(bsd)
             walk(node.get("_items", []))
 
-    walk(data.get("SPUSBDataType", []))
+    walk(tree)
 
     unique = list(dict.fromkeys(results))
     if not unique:
@@ -160,12 +254,161 @@ def _find_storage_device_macos(serial: str | None) -> str | None:
     return unique[0]
 
 
+def _ioreg_sdwire3_hosts() -> list[tuple[str, str | None]]:
+    # Returns [(ioreg_name, usb_serial), ...] for each attached SDWire3.
+    try:
+        out = subprocess.check_output(
+            ["ioreg", "-p", "IOUSB", "-l", "-w", "0"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+    hosts: list[tuple[str, str | None]] = []
+    for name in dict.fromkeys(re.findall(r"\+-o (USB3\.0-CRW@[0-9a-fA-F]+)", out)):
+        serial = None
+        try:
+            detail = subprocess.check_output(
+                ["ioreg", "-r", "-n", name, "-l", "-w", "0"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=15,
+            )
+        except (OSError, subprocess.SubprocessError):
+            hosts.append((name, serial))
+            continue
+
+        match = re.search(r'"kUSBSerialNumberString" = "([^"]*)"', detail)
+        if match and match.group(1):
+            serial = match.group(1)
+        hosts.append((name, serial))
+
+    return hosts
+
+
+def _ioreg_whole_disk(ioreg_name: str) -> str | None:
+    try:
+        out = subprocess.check_output(
+            ["ioreg", "-r", "-n", ioreg_name, "-l", "-w", "0"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    whole = False
+    for line in out.splitlines():
+        if '"Whole" = Yes' in line:
+            whole = True
+            continue
+        if whole and (match := re.search(r'"BSD Name" = "([^"]+)"', line)) is not None:
+            return f"/dev/{match.group(1)}"
+        if '"Whole" = No' in line:
+            whole = False
+    return None
+
+
+def _sdwire3_host_matches(
+    dev: usb.core.Device,
+    configured_serial: str | None,
+    ioreg_name: str,
+    usb_serial: str | None,
+) -> bool:
+    if configured_serial is None:
+        return True
+    if configured_serial == usb_serial:
+        return True
+    location = ioreg_name.split("@", 1)[-1]
+    identity = _sdwire3_identity(dev)
+    if configured_serial in {identity, f"{usb_serial}.{location}", f"{usb_serial}:{dev.bus}.{dev.address}"}:
+        return True
+    return configured_serial == f"{dev.bus}.{dev.address}"
+
+
+def _find_sdwire3_storage_device_macos(
+    dev: usb.core.Device,
+    serial: str | None,
+) -> str | None:
+    tree = _load_macos_usb_tree()
+    if tree is not None:
+        results: list[str] = []
+
+        def walk(items: list[dict]) -> None:
+            for node in items:
+                if _node_is_sdwire3(node, serial, dev.bus, dev.address):
+                    bsd = _sdwire3_bsd(node)
+                    if bsd:
+                        results.append(bsd)
+                walk(node.get("_items", []))
+
+        walk(tree)
+
+        unique = list(dict.fromkeys(results))
+        if unique:
+            if len(unique) > 1:
+                raise RuntimeError(
+                    "found multiple SDWire3 storage devices on macOS; "
+                    "specify storage_device or serial to disambiguate"
+                )
+            return unique[0]
+
+    hosts = _ioreg_sdwire3_hosts()
+    matches = [
+        (name, usb_serial)
+        for name, usb_serial in hosts
+        if _sdwire3_host_matches(dev, serial, name, usb_serial)
+    ]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise RuntimeError(
+            "found multiple SDWire3 storage devices on macOS; specify storage_device or serial to disambiguate"
+        )
+
+    return _ioreg_whole_disk(matches[0][0])
+
+
+def _sdwire3_usb_error(exc: usb.core.USBError, action: str) -> RuntimeError:
+    if platform.system() == "Darwin" and exc.errno in {errno.EACCES, 13}:
+        return RuntimeError(
+            f"SDWire3 {action} failed: macOS requires root privileges to capture the USB "
+            f"mass-storage interface (run the exporter with sudo)"
+        )
+    return RuntimeError(f"SDWire3 {action} failed: {exc}")
+
+
+def _sdwire3_host(dev: usb.core.Device) -> None:
+    try:
+        dev.attach_kernel_driver(_SDWIRE3_MASS_STORAGE_INTERFACE)
+    except usb.core.USBError as exc:
+        raise _sdwire3_usb_error(exc, "host switch") from exc
+    try:
+        dev.reset()
+    except usb.core.USBError as exc:
+        raise _sdwire3_usb_error(exc, "host reset") from exc
+
+
+def _sdwire3_dut(dev: usb.core.Device) -> None:
+    try:
+        dev.detach_kernel_driver(_SDWIRE3_MASS_STORAGE_INTERFACE)
+    except usb.core.USBError as exc:
+        raise _sdwire3_usb_error(exc, "DUT switch") from exc
+    try:
+        dev.reset()
+    except usb.core.USBError as exc:
+        raise _sdwire3_usb_error(exc, "DUT reset") from exc
+
+
 @dataclass(kw_only=True)
 class SDWire(StorageMuxFlasherInterface, Driver):
     serial: str | None = field(default=None)
     dev: usb.core.Device = field(init=False)
-    itf: usb.core.Interface = field(init=False)
+    itf: usb.core.Interface | None = field(init=False, default=None)
     _serial: str | None = field(init=False, default=None)
+    _kind: _DeviceKind = field(init=False)
 
     storage_device: str | None = field(default=None)
     storage_timeout: int = field(default=10)
@@ -176,8 +419,10 @@ class SDWire(StorageMuxFlasherInterface, Driver):
         if self.storage_device is not None:
             return self.storage_device
         if platform.system() == "Darwin":
+            if self._kind == _DeviceKind.SDWIRE3:
+                return _find_sdwire3_storage_device_macos(self.dev, self._serial)
             return _find_storage_device_macos(self._serial)
-        return _find_storage_device_linux(self.dev)
+        return _find_storage_device_linux(self.dev, kind=self._kind)
 
     def _poll_storage_device(self, timeout: int) -> str | None:
         # macOS re-enumerates the reader after a switch, so retry discovery.
@@ -200,8 +445,13 @@ class SDWire(StorageMuxFlasherInterface, Driver):
                 return None
             await anyio.sleep(1)
 
-    def _find_device(self) -> tuple[usb.core.Device, str | None] | None:
-        candidates: list[tuple[usb.core.Device, str | None]] = []
+    def _find_device(self) -> tuple[usb.core.Device, str | None, _DeviceKind] | None:
+        candidates: list[tuple[usb.core.Device, str | None, _DeviceKind]] = []
+
+        for dev in usb.core.find(idVendor=_SDWIRE3_VID, idProduct=_SDWIRE3_PID, find_all=True):
+            identity = _sdwire3_identity(dev)
+            if self.serial is None or _serial_matches(dev, self.serial, _DeviceKind.SDWIRE3):
+                candidates.append((dev, identity, _DeviceKind.SDWIRE3))
 
         # Programmed: Samsung VID + product "sd-wire".
         for dev in usb.core.find(idVendor=_PROGRAMMED_VID, idProduct=_PROGRAMMED_PID, find_all=True):
@@ -212,7 +462,7 @@ class SDWire(StorageMuxFlasherInterface, Driver):
                 self.logger.warning(f"failed to read USB descriptors at bus {dev.bus} addr {dev.address}: {e}")
                 continue
             if product == _PROGRAMMED_PRODUCT and (self.serial is None or self.serial == serial):
-                candidates.append((dev, serial))
+                candidates.append((dev, serial, _DeviceKind.FT200X))
 
         # Unprogrammed FT200X: only by explicit serial, since any FT200X looks alike.
         if self.serial is not None:
@@ -223,7 +473,7 @@ class SDWire(StorageMuxFlasherInterface, Driver):
                     self.logger.warning(f"failed to read USB descriptors at bus {dev.bus} addr {dev.address}: {e}")
                     continue
                 if self.serial == serial:
-                    candidates.append((dev, serial))
+                    candidates.append((dev, serial, _DeviceKind.FT200X))
 
         if self.serial is None and len(candidates) > 1:
             raise RuntimeError("found multiple sd-wire devices; specify a serial to disambiguate")
@@ -238,23 +488,34 @@ class SDWire(StorageMuxFlasherInterface, Driver):
         if found is None:
             raise FileNotFoundError(
                 "failed to find sd-wire device "
-                "(checked programmed EEPROM VID/PID 0x04E8/0x6001 and "
+                "(checked SDWire3 0x0BDA/0x0316, programmed EEPROM 0x04E8/0x6001, and "
                 "unprogrammed FTDI FT200X 0x0403/0x6015)"
             )
 
-        dev, self._serial = found
+        dev, self._serial, self._kind = found
         self.dev = dev
-        self.itf = usb.util.find_descriptor(
-            dev.get_active_configuration(),
-            bInterfaceClass=0xFF,
-            bInterfaceSubClass=0xFF,
-            bInterfaceProtocol=0xFF,
-        )
 
-        if self.effective_storage_device() is None:
+        if self._kind == _DeviceKind.FT200X:
+            self.itf = usb.util.find_descriptor(
+                dev.get_active_configuration(),
+                bInterfaceClass=0xFF,
+                bInterfaceSubClass=0xFF,
+                bInterfaceProtocol=0xFF,
+            )
+        else:
+            self.itf = None
+
+        if self.effective_storage_device() is None and self._kind == _DeviceKind.FT200X:
             raise FileNotFoundError("failed to find sdcard storage device on sd-wire")
+        if self.effective_storage_device() is None and self._kind == _DeviceKind.SDWIRE3:
+            self.logger.warning(
+                "SDWire3 detected but no SD card disk is visible on host yet; "
+                "storage operations will wait until the card appears after switching to host"
+            )
 
     def select(self, target):
+        if self._kind != _DeviceKind.FT200X:
+            raise RuntimeError("select() is only supported on FT200X-based SD Wire devices")
         # CBUS bitbang: wValue = 0x20<<8 | (0xF0 DUT / 0xF1 HOST). Needs CBUS0=GPIO.
         self.dev.ctrl_transfer(
             bmRequestType=usb.ENDPOINT_OUT | usb.TYPE_VENDOR | usb.RECIP_DEVICE,
@@ -264,6 +525,12 @@ class SDWire(StorageMuxFlasherInterface, Driver):
         )
 
     def query(self):
+        if self._kind == _DeviceKind.SDWIRE3:
+            try:
+                return "host" if self.dev.is_kernel_driver_active(_SDWIRE3_MASS_STORAGE_INTERFACE) else "dut"
+            except usb.core.USBError as exc:
+                raise RuntimeError(f"failed to query SDWire3 mux state: {exc}") from exc
+
         return (
             "host"
             if self.dev.ctrl_transfer(
@@ -277,8 +544,40 @@ class SDWire(StorageMuxFlasherInterface, Driver):
             else "dut"
         )
 
+    def _eject_storage_for_dut(self) -> None:
+        if platform.system() != "Darwin":
+            return
+
+        storage = self._poll_storage_device(self.storage_timeout)
+        if storage is None:
+            raise RuntimeError(
+                "could not determine the SD card disk on macOS; refusing to switch to DUT "
+                "(switching without a clean eject risks filesystem corruption)"
+            )
+        try:
+            subprocess.run(
+                ["diskutil", "eject", storage],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"failed to eject {storage}: {e.stderr}")
+            raise RuntimeError(
+                f"failed to eject {storage} before switching to DUT; "
+                f"the volume may be busy: {(e.stderr or '').strip()}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"timed out ejecting {storage} before switching to DUT") from e
+        time.sleep(1)
+
     @export
     def host(self):
+        if self._kind == _DeviceKind.SDWIRE3:
+            _sdwire3_host(self.dev)
+            return
+
         # Route the card back first, then (macOS) power-cycle so the re-enumeration
         # sees the card present.
         self.select(0xF1)
@@ -287,32 +586,14 @@ class SDWire(StorageMuxFlasherInterface, Driver):
 
     @export
     def dut(self):
-        # macOS: the mux only switches when the SD bus is idle, so eject first.
-        # Power on the DUT within ~500 ms or the mux protection reverts to HOST.
         if platform.system() == "Darwin":
-            storage = self._poll_storage_device(self.storage_timeout)
-            if storage is None:
-                raise RuntimeError(
-                    "could not determine the SD card disk on macOS; refusing to switch to DUT "
-                    "(switching without a clean eject risks filesystem corruption)"
-                )
-            try:
-                subprocess.run(
-                    ["diskutil", "eject", storage],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    timeout=30,
-                )
-            except subprocess.CalledProcessError as e:
-                self.logger.error(f"failed to eject {storage}: {e.stderr}")
-                raise RuntimeError(
-                    f"failed to eject {storage} before switching to DUT; "
-                    f"the volume may be busy: {(e.stderr or '').strip()}"
-                ) from e
-            except subprocess.TimeoutExpired as e:
-                raise RuntimeError(f"timed out ejecting {storage} before switching to DUT") from e
-            time.sleep(1)
+            self._eject_storage_for_dut()
+
+        if self._kind == _DeviceKind.SDWIRE3:
+            _sdwire3_dut(self.dev)
+            return
+
+        # Power on the DUT within ~500 ms or the mux protection reverts to HOST.
         self.select(0xF0)
 
     @export

--- a/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver_test.py
+++ b/python/packages/jumpstarter-driver-sdwire/jumpstarter_driver_sdwire/driver_test.py
@@ -90,6 +90,8 @@ class _FakeUSBDev:
         self.bus = 1
         self.address = 2
         self.port_numbers = ()
+        self.idVendor = 0
+        self.idProduct = 0
 
 
 def test_ft200x_requires_explicit_serial(monkeypatch):
@@ -178,8 +180,96 @@ def test_await_storage_device_retries(monkeypatch):
     assert anyio.run(sdwire._await_storage_device, 10) == "/dev/disk6"
 
 
+def _sdwire3_node(serial, disk, address=1):
+    return {
+        "_name": "USB3.0-CRW",
+        "vendor_id": "0x0bda  (Realtek Semiconductor Corp.)",
+        "product_id": "0x0316",
+        "serial_num": serial,
+        "location_id": f"0x02100000 / {address}",
+        "Media": [{"_name": "Ultra HS-SD/MMC", "bsd_name": disk}],
+    }
+
+
+def test_sdwire3_macos_storage_by_serial(monkeypatch):
+    tree = {"SPUSBDataType": [{"_name": "USB31Bus", "_items": [_sdwire3_node("ABC123", "disk4")]}]}
+    _patch_system_profiler(monkeypatch, tree)
+    dev = _FakeUSBDev("ABC123")
+    dev.bus = 2
+    dev.address = 1
+    assert sdwire_driver._find_sdwire3_storage_device_macos(dev, "ABC123") == "/dev/disk4"
+
+
+def test_sdwire3_find_device(monkeypatch):
+    sdwire3 = _FakeUSBDev("ABC123")
+    sdwire3.idVendor = sdwire_driver._SDWIRE3_VID
+    sdwire3.idProduct = sdwire_driver._SDWIRE3_PID
+    sdwire3.bus = 2
+    sdwire3.address = 1
+    sdwire3.port_numbers = (1, 2)
+
+    def fake_find(idVendor, idProduct, find_all):
+        if (idVendor, idProduct) == (sdwire_driver._SDWIRE3_VID, sdwire_driver._SDWIRE3_PID):
+            return iter([sdwire3])
+        return iter([])
+
+    monkeypatch.setattr(sdwire_driver.usb.core, "find", fake_find)
+    monkeypatch.setattr(sdwire_driver, "_usb_serial", lambda dev: "ABC123")
+
+    sdwire = object.__new__(SDWire)
+    sdwire.serial = None
+    sdwire.logger = logging.getLogger("test-sdwire")
+    found = sdwire._find_device()
+    assert found is not None
+    assert found[0] is sdwire3
+    assert found[2] == sdwire_driver._DeviceKind.SDWIRE3
+
+
+def test_sdwire3_host_and_dut(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.SDWIRE3
+    sdwire.dev = _FakeUSBDev("ABC123")
+    sdwire.logger = logging.getLogger("test-sdwire")
+
+    calls = []
+
+    def fake_host(dev):
+        calls.append("host")
+
+    def fake_dut(dev):
+        calls.append("dut")
+
+    monkeypatch.setattr(sdwire_driver, "_sdwire3_host", fake_host)
+    monkeypatch.setattr(sdwire_driver, "_sdwire3_dut", fake_dut)
+    monkeypatch.setattr(sdwire_driver.platform, "system", lambda: "Linux")
+
+    sdwire.host()
+    sdwire.dut()
+    assert calls == ["host", "dut"]
+
+
+def test_sdwire3_query(monkeypatch):
+    sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.SDWIRE3
+
+    class _Dev:
+        def is_kernel_driver_active(self, intf):
+            return intf == 0
+
+    sdwire.dev = _Dev()
+    assert sdwire.query() == "host"
+
+    class _DevDut:
+        def is_kernel_driver_active(self, intf):
+            return False
+
+    sdwire.dev = _DevDut()
+    assert sdwire.query() == "dut"
+
+
 def test_dut_aborts_when_eject_fails(monkeypatch):
     sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.FT200X
     sdwire.storage_device = "/dev/disk4"
     sdwire.storage_timeout = 10
     sdwire.logger = logging.getLogger("test-sdwire")
@@ -202,6 +292,7 @@ def test_dut_aborts_when_eject_fails(monkeypatch):
 
 def test_dut_switches_after_successful_eject(monkeypatch):
     sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.FT200X
     sdwire.storage_device = "/dev/disk4"
     sdwire.storage_timeout = 10
     sdwire.logger = logging.getLogger("test-sdwire")
@@ -219,6 +310,7 @@ def test_dut_switches_after_successful_eject(monkeypatch):
 
 def test_dut_aborts_when_disk_unknown(monkeypatch):
     sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.FT200X
     sdwire.storage_timeout = 0  # do not actually wait
     sdwire.logger = logging.getLogger("test-sdwire")
 
@@ -268,6 +360,7 @@ class _FakeHub:
 
 def test_host_selects_before_power_cycle(monkeypatch):
     sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.FT200X
     sdwire.logger = logging.getLogger("test-sdwire")
     sdwire.dev = object()
 
@@ -289,6 +382,7 @@ def test_host_selects_before_power_cycle(monkeypatch):
 
 def test_host_no_power_cycle_off_darwin(monkeypatch):
     sdwire = object.__new__(SDWire)
+    sdwire._kind = sdwire_driver._DeviceKind.FT200X
     sdwire.logger = logging.getLogger("test-sdwire")
     sdwire.dev = object()
 
@@ -351,6 +445,8 @@ def test_power_cycle_skips_when_no_topology_match(monkeypatch):
 
 
 def test_drivers_sdwire():
+    import os
+
     try:
         instance = SDWire()
     except FileNotFoundError:
@@ -363,5 +459,11 @@ def test_drivers_sdwire():
     with serve(instance) as client:
         client.host()
         assert instance.query() == "host"
+        if (
+            instance._kind == sdwire_driver._DeviceKind.SDWIRE3
+            and sdwire_driver.platform.system() == "Darwin"
+            and os.geteuid() != 0
+        ):
+            pytest.skip("SDWire3 DUT switching on macOS requires root")  # ty: ignore[call-non-callable]
         client.dut()
         assert instance.query() == "dut"


### PR DESCRIPTION
## Summary
- Add auto-detection and mux control for Badgerd SDWire3 (`0x0BDA:0x0316`) alongside existing FT200X-based SD Wire devices, without a separate driver class or config model selector.
- Implement SDWire3 switching via kernel mass-storage driver attach/detach + USB reset, with macOS storage discovery via `ioreg` when `system_profiler` returns no USB tree.
- Document supported device variants, shared config fields, backwards compatibility, and macOS requirements (including `sudo` for SDWire3 mux switching).

Stacked on #748.

## Test plan
- [x] `make pkg-test-jumpstarter-driver-sdwire`
- [x] Verified SDWire3 init/query on macOS with connected hardware (`0x0BDA:0x0316` → `/dev/disk4`)
- [ ] Verify SDWire3 DUT/host switching on macOS with `sudo uv run jmp shell ...`
- [ ] Confirm existing FT200X / programmed `sd-wire` behaviour unchanged on Linux


Made with [Cursor](https://cursor.com)