### PR TITLE
fix: construct image URL after HTTP server starts

### DIFF
--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -183,7 +183,6 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
                     path = path_with_query(parsed)
                 else:
                     path, operator, operator_scheme = operator_for_path(path)
-            image_url = self.http.get_url() + "/" + self._filename(path)
 
         # start counting time for the flash operation
         start_time = time.time()
@@ -219,6 +218,9 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
             raise error_queue.get()
 
         with self._services_up():
+            if should_download_to_httpd:
+                image_url = self.http.get_url() + "/" + self._filename(path)
+
             # Retry logic at the highest level - retry entire console setup and flash operation
             for attempt in range(retries + 1):  # +1 for initial attempt
                 try:


### PR DESCRIPTION
get_url() now returns _bound_port (since #740) which is 0 until start() is called. The flash client was calling get_url() before _services_up() started the server, producing http://host:0/image URLs.

Move image_url construction inside the _services_up() context so get_url() runs after the server binds and _bound_port is set.
