### PR TITLE
fix(renovate): drop extractVersionTemplate for uv github-releases

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -57,7 +57,6 @@
       ],
       "depNameTemplate": "astral-sh/uv",
       "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$",
       "versioningTemplate": "semver"
     }
   ],


### PR DESCRIPTION
## Summary

- Remove `extractVersionTemplate` from the `.uv-version` custom regex manager

The template `^v(?<version>.*)$` expects v-prefixed tags, but `astral-sh/uv` GitHub releases use bare semver tags (`0.11.21`, not `v0.11.21`). Every release is rejected by the filter, so the `github-releases` datasource returns zero versions and `.uv-version` is silently excluded from the `uv-toolchain` group PR (e.g. [#799](https://github.com/jumpstarter-dev/jumpstarter/pull/799) bumps Containerfiles but not `.uv-version`).

Verified with a local Renovate v43 dry-run against a fork: after removing the template, `.uv-version` appears in the `renovate/uv-toolchain` branch upgrades alongside the Containerfile updates.

## Test plan

- [ ] After merge, trigger a Renovate run and verify the next `uv-toolchain` PR includes both `.uv-version` and Containerfile changes
- [ ] Verify [Renovate config validation](https://developer.mend.io/github/jumpstarter-dev/jumpstarter) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)