### PR TITLE
feat: add description field to access policy rules

### DIFF
--- a/controller/api/v1alpha1/exporteraccesspolicy_types.go
+++ b/controller/api/v1alpha1/exporteraccesspolicy_types.go
@@ -28,6 +28,8 @@ type From struct {
 
 // Policy defines an access policy rule for exporter access.
 type Policy struct {
+	// Description is a human-readable explanation of this policy rule.
+	Description string `json:"description,omitempty"`
 	// Priority is the priority of this policy rule. Higher values indicate higher priority.
 	Priority int `json:"priority,omitempty"`
 	// From is the list of client selectors that this policy applies to.
@@ -47,17 +49,15 @@ type ExporterAccessPolicySpec struct {
 }
 
 // ExporterAccessPolicyStatus defines the observed state of ExporterAccessPolicy.
-type ExporterAccessPolicyStatus struct {
-	// Status field for the exporter access policies
-}
+type ExporterAccessPolicyStatus struct{}
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
 // ExporterAccessPolicy is the Schema for the exporteraccesspolicies API.
+// ExporterAccessPolicies are used to define the access policies for the exporters.
+// They help organize, prioritize and restrict access to the exporters by clients.
 type ExporterAccessPolicy struct {
-	// ExporterAccessPolicies are used to define the access policies for the exporters.
-	// they help organize, prioritize and restrict access to the exporters by clients.
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/controller/config/samples/v1alpha1_exporteraccesspolicy.yaml
+++ b/controller/config/samples/v1alpha1_exporteraccesspolicy.yaml
@@ -10,18 +10,21 @@ spec:
     matchLabels:
       dut: fancy-hardware
   policies:
-    - priority: 20 # Administrators come first, highest priority
+    - description: "Administrators — unrestricted access, highest priority"
+      priority: 20
       from:
         - clientSelector:
             matchLabels:
               client-type: administrator
-    - priority: 10 # Developers come next, maximum 2days
+    - description: "Developers — maximum 24h lease duration"
+      priority: 10
       maximumDuration: 24h
       from:
         - clientSelector:
             matchLabels:
               client-type: developer
-    - priority: 5 # CI comes next, but only spot instances, can be deallocated
+    - description: "CI — spot instances only, maximum 12h, can be preempted"
+      priority: 5
       maximumDuration: 12h
       spotAccess: true
       from:

--- a/controller/deploy/operator/config/crd/bases/jumpstarter.dev_exporteraccesspolicies.yaml
+++ b/controller/deploy/operator/config/crd/bases/jumpstarter.dev_exporteraccesspolicies.yaml
@@ -41,10 +41,8 @@ spec:
             description: ExporterAccessPolicySpec defines the desired state of ExporterAccessPolicy.
             properties:
               exporterSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
+                description: ExporterSelector is a label selector that matches the
+                  exporters this policy applies to.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -94,18 +92,20 @@ spec:
                 items:
                   description: Policy defines an access policy rule for exporter access.
                   properties:
+                    description:
+                      description: Description is a human-readable explanation of
+                        this policy rule.
+                      type: string
                     from:
-                      description: From is the list of client selectors that this policy
-                        applies to.
+                      description: From is the list of client selectors that this
+                        policy applies to.
                       items:
                         description: From defines a source matcher for clients allowed
                           access.
                         properties:
                           clientSelector:
-                            description: |-
-                              A label selector is a label query over a set of resources. The result of matchLabels and
-                              matchExpressions are ANDed. An empty label selector matches all objects. A null
-                              label selector matches no objects.
+                            description: ClientSelector is a label selector that matches
+                              clients this rule applies to.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector

--- a/controller/deploy/operator/config/crd/bases/jumpstarter.dev_exporters.yaml
+++ b/controller/deploy/operator/config/crd/bases/jumpstarter.dev_exporters.yaml
@@ -132,12 +132,14 @@ spec:
                 description: Devices is the list of driver instances currently reported
                   by the exporter.
                 items:
-                  description: Device represents a driver instance reported by an exporter.
+                  description: Device represents a driver instance reported by an
+                    exporter.
                   properties:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels are key-value pairs associated with the device.
+                      description: Labels are key-value pairs associated with the
+                        device.
                       type: object
                     parent_uuid:
                       description: ParentUuid is the UUID of the parent device, if
@@ -150,8 +152,8 @@ spec:
                   type: object
                 type: array
               endpoint:
-                description: Endpoint is the gRPC endpoint URL where the exporter is
-                  reachable.
+                description: Endpoint is the gRPC endpoint URL where the exporter
+                  is reachable.
                 type: string
               exporterStatus:
                 description: ExporterStatusValue is the current operational status
@@ -188,7 +190,7 @@ spec:
                 x-kubernetes-map-type: atomic
               statusMessage:
                 description: StatusMessage is an optional human-readable message describing
-                  the current state.
+                  the current state
                 type: string
             type: object
         type: object

--- a/controller/deploy/operator/config/crd/bases/jumpstarter.dev_leases.yaml
+++ b/controller/deploy/operator/config/crd/bases/jumpstarter.dev_leases.yaml
@@ -254,8 +254,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               priority:
-                description: Priority is the effective priority of the lease from the
-                  access policy.
+                description: Priority is the effective priority of the lease from
+                  the access policy.
                 type: integer
               spotAccess:
                 description: SpotAccess indicates whether this lease was granted with

--- a/controller/deploy/operator/config/manager/kustomization.yaml
+++ b/controller/deploy/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: quay.io/jumpstarter-dev/jumpstarter-operator
   newName: quay.io/jumpstarter-dev/jumpstarter-operator
-  newTag: latest
+  newTag: 0.8.1-rc.1

--- a/controller/internal/controller/lease_controller.go
+++ b/controller/internal/controller/lease_controller.go
@@ -255,17 +255,27 @@ func (r *LeaseReconciler) reconcileStatusExporterRef(
 			matchingExporters = listed.Items
 		}
 
-		approvedExporters, err := r.attachMatchingPolicies(ctx, lease, matchingExporters)
+		approvedExporters, unmatchedDescriptions, err := r.attachMatchingPolicies(ctx, lease, matchingExporters)
 		if err != nil {
 			return fmt.Errorf("reconcileStatusExporterRef: failed to handle policy approval: %w", err)
 		}
 
 		if len(approvedExporters) == 0 {
-			lease.SetStatusUnsatisfiable(
-				"NoAccess",
-				"While there are %d exporters matching the selector, none of them are approved by any policy for your client",
-				len(matchingExporters),
-			)
+			if len(unmatchedDescriptions) > 0 {
+				desc := strings.Join(unmatchedDescriptions, "; ")
+				if len(desc) > 4096 {
+					desc = desc[:4096] + "..."
+				}
+				lease.SetStatusUnsatisfiable("NoAccess",
+					"While there are %d exporters matching the selector, none of them are approved by any policy for your client. Matching policies: %s",
+					len(matchingExporters), desc,
+				)
+			} else {
+				lease.SetStatusUnsatisfiable("NoAccess",
+					"While there are %d exporters matching the selector, none of them are approved by any policy for your client",
+					len(matchingExporters),
+				)
+			}
 			return nil
 		}
 
@@ -353,14 +363,14 @@ func (r *LeaseReconciler) reconcileStatusExporterRef(
 // attachMatchingPolicies attaches the matching policies to the list of online exporters
 // if the exporter matches the policy and the client matches the policy's client selector
 // the exporter is approved for leasing
-func (r *LeaseReconciler) attachMatchingPolicies(ctx context.Context, lease *jumpstarterdevv1alpha1.Lease, onlineExporters []jumpstarterdevv1alpha1.Exporter) ([]ApprovedExporter, error) {
+func (r *LeaseReconciler) attachMatchingPolicies(ctx context.Context, lease *jumpstarterdevv1alpha1.Lease, onlineExporters []jumpstarterdevv1alpha1.Exporter) ([]ApprovedExporter, []string, error) {
 	var approvedExporters []ApprovedExporter
 
 	var policies jumpstarterdevv1alpha1.ExporterAccessPolicyList
 	if err := r.List(ctx, &policies,
 		client.InNamespace(lease.Namespace),
 	); err != nil {
-		return nil, fmt.Errorf("reconcileStatusExporterRef: failed to list exporter access policies: %w", err)
+		return nil, nil, fmt.Errorf("reconcileStatusExporterRef: failed to list exporter access policies: %w", err)
 	}
 
 	// If there are no policies, we just approve all online exporters
@@ -374,7 +384,7 @@ func (r *LeaseReconciler) attachMatchingPolicies(ctx context.Context, lease *jum
 				},
 			})
 		}
-		return approvedExporters, nil
+		return approvedExporters, nil, nil
 	}
 	// If policies exist: get the client to obtain the metadata necessary for policy matching
 	var jclient jumpstarterdevv1alpha1.Client
@@ -382,23 +392,28 @@ func (r *LeaseReconciler) attachMatchingPolicies(ctx context.Context, lease *jum
 		Namespace: lease.Namespace,
 		Name:      lease.Spec.ClientRef.Name,
 	}, &jclient); err != nil {
-		return nil, fmt.Errorf("reconcileStatusExporterRef: failed to get client: %w", err)
+		return nil, nil, fmt.Errorf("reconcileStatusExporterRef: failed to get client: %w", err)
 	}
+
+	seenDescriptions := make(map[string]bool)
+	var unmatchedDescriptions []string
 
 	for _, exporter := range onlineExporters {
 		for _, policy := range policies.Items {
 			exporterSelector, err := metav1.LabelSelectorAsSelector(&policy.Spec.ExporterSelector)
 			if err != nil {
-				return nil, fmt.Errorf("reconcileStatusExporterRef: failed to convert exporter selector: %w", err)
+				return nil, nil, fmt.Errorf("reconcileStatusExporterRef: failed to convert exporter selector: %w", err)
 			}
 			if exporterSelector.Matches(labels.Set(exporter.Labels)) {
 				for _, p := range policy.Spec.Policies {
+					clientMatched := false
 					for _, from := range p.From {
 						clientSelector, err := metav1.LabelSelectorAsSelector(&from.ClientSelector)
 						if err != nil {
-							return nil, fmt.Errorf("reconcileStatusExporterRef: failed to convert client selector: %w", err)
+							return nil, nil, fmt.Errorf("reconcileStatusExporterRef: failed to convert client selector: %w", err)
 						}
 						if clientSelector.Matches(labels.Set(jclient.Labels)) {
+							clientMatched = true
 							if p.MaximumDuration != nil {
 								// Calculate requested duration (may be from explicit Duration or computed from times)
 								requestedDuration := time.Duration(0)
@@ -420,11 +435,15 @@ func (r *LeaseReconciler) attachMatchingPolicies(ctx context.Context, lease *jum
 							})
 						}
 					}
+					if !clientMatched && p.Description != "" && !seenDescriptions[p.Description] {
+						seenDescriptions[p.Description] = true
+						unmatchedDescriptions = append(unmatchedDescriptions, p.Description)
+					}
 				}
 			}
 		}
 	}
-	return approvedExporters, nil
+	return approvedExporters, unmatchedDescriptions, nil
 }
 
 // ListMatchingExporters returns a list of exporters that match the selector of the lease

--- a/controller/internal/controller/lease_controller_test.go
+++ b/controller/internal/controller/lease_controller_test.go
@@ -326,7 +326,8 @@ var _ = Describe("Lease Controller", func() {
 					},
 					Policies: []jumpstarterdevv1alpha1.Policy{
 						{
-							Priority: 0,
+							Description: "Requires different-client label",
+							Priority:    0,
 							From: []jumpstarterdevv1alpha1.From{
 								{
 									ClientSelector: metav1.LabelSelector{
@@ -358,9 +359,203 @@ var _ = Describe("Lease Controller", func() {
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Reason).To(Equal("NoAccess"))
 			Expect(condition.Message).To(ContainSubstring("none of them are approved by any policy"))
+			Expect(condition.Message).To(ContainSubstring("Requires different-client label"))
 
 			// Clean up
 			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+		})
+	})
+
+	When("trying to lease with multiple policies containing descriptions, none matching client", func() {
+		It("should include all policy descriptions in the unsatisfiable message", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+
+			ctx := context.Background()
+
+			// Create two policies with different descriptions, neither matching testClient
+			policy1 := &jumpstarterdevv1alpha1.ExporterAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy-admin",
+					Namespace: "default",
+				},
+				Spec: jumpstarterdevv1alpha1.ExporterAccessPolicySpec{
+					ExporterSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"dut": "a"},
+					},
+					Policies: []jumpstarterdevv1alpha1.Policy{
+						{
+							Description: "Administrators only",
+							Priority:    20,
+							From: []jumpstarterdevv1alpha1.From{{
+								ClientSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"role": "admin"},
+								},
+							}},
+						},
+					},
+				},
+			}
+			policy2 := &jumpstarterdevv1alpha1.ExporterAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy-ci",
+					Namespace: "default",
+				},
+				Spec: jumpstarterdevv1alpha1.ExporterAccessPolicySpec{
+					ExporterSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"dut": "a"},
+					},
+					Policies: []jumpstarterdevv1alpha1.Policy{
+						{
+							Description: "CI pipelines only",
+							Priority:    5,
+							From: []jumpstarterdevv1alpha1.From{{
+								ClientSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"role": "ci"},
+								},
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy1)).To(Succeed())
+			Expect(k8sClient.Create(ctx, policy2)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.ExporterRef).To(BeNil())
+
+			condition := meta.FindStatusCondition(updatedLease.Status.Conditions, string(jumpstarterdevv1alpha1.LeaseConditionTypeUnsatisfiable))
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal("NoAccess"))
+			Expect(condition.Message).To(ContainSubstring("Administrators only"))
+			Expect(condition.Message).To(ContainSubstring("CI pipelines only"))
+			Expect(condition.Message).To(ContainSubstring(";"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, policy1)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, policy2)).To(Succeed())
+		})
+	})
+
+	When("trying to lease with policies where some have empty descriptions", func() {
+		It("should only include non-empty descriptions in the unsatisfiable message", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+
+			ctx := context.Background()
+
+			policy := &jumpstarterdevv1alpha1.ExporterAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy-mixed",
+					Namespace: "default",
+				},
+				Spec: jumpstarterdevv1alpha1.ExporterAccessPolicySpec{
+					ExporterSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"dut": "a"},
+					},
+					Policies: []jumpstarterdevv1alpha1.Policy{
+						{
+							Description: "VIP access rule",
+							Priority:    10,
+							From: []jumpstarterdevv1alpha1.From{{
+								ClientSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"role": "vip"},
+								},
+							}},
+						},
+						{
+							// No description
+							Priority: 1,
+							From: []jumpstarterdevv1alpha1.From{{
+								ClientSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"role": "other"},
+								},
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			condition := meta.FindStatusCondition(updatedLease.Status.Conditions, string(jumpstarterdevv1alpha1.LeaseConditionTypeUnsatisfiable))
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal("NoAccess"))
+			Expect(condition.Message).To(ContainSubstring("VIP access rule"))
+			// The message should contain "Matching policies:" since at least one description exists
+			Expect(condition.Message).To(ContainSubstring("Matching policies:"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+		})
+	})
+
+	When("trying to lease with a policy that has descriptions and matches the client", func() {
+		It("should acquire the lease successfully regardless of description", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+
+			ctx := context.Background()
+
+			policy := &jumpstarterdevv1alpha1.ExporterAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy-matching",
+					Namespace: "default",
+				},
+				Spec: jumpstarterdevv1alpha1.ExporterAccessPolicySpec{
+					ExporterSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"dut": "a"},
+					},
+					Policies: []jumpstarterdevv1alpha1.Policy{
+						{
+							Description: "Standard access for registered clients",
+							Priority:    10,
+							From: []jumpstarterdevv1alpha1.From{{
+								ClientSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{"name": "client"}, // Matches testClient
+								},
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.ExporterRef).NotTo(BeNil())
+			Expect(updatedLease.Status.Priority).To(Equal(10))
+			Expect(meta.IsStatusConditionTrue(
+				updatedLease.Status.Conditions,
+				string(jumpstarterdevv1alpha1.LeaseConditionTypeReady),
+			)).To(BeTrue())
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+		})
+	})
+
+	When("trying to lease with no policies at all and no matching exporters", func() {
+		It("should show NoAccess message without policy descriptions", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+			lease.Spec.Selector.MatchLabels["dut"] = "does-not-exist"
+
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.ExporterRef).To(BeNil())
+
+			condition := meta.FindStatusCondition(updatedLease.Status.Conditions, string(jumpstarterdevv1alpha1.LeaseConditionTypeUnsatisfiable))
+			Expect(condition).NotTo(BeNil())
+			// Without policies, the message should not contain "Matching policies:"
+			Expect(condition.Message).NotTo(ContainSubstring("Matching policies:"))
 		})
 	})
 
@@ -755,9 +950,9 @@ var _ = Describe("orderApprovedExporters", func() {
 				},
 			}
 			ordered := orderApprovedExporters(approvedExporters)
-			Expect(ordered[0].Policy.Priority).To(Equal(int(100)))
-			Expect(ordered[1].Policy.Priority).To(Equal(int(10)))
-			Expect(ordered[2].Policy.Priority).To(Equal(int(5)))
+			Expect(ordered[0].Policy.Priority).To(Equal(100))
+			Expect(ordered[1].Policy.Priority).To(Equal(10))
+			Expect(ordered[2].Policy.Priority).To(Equal(5))
 
 		})
 	})


### PR DESCRIPTION
Surface policy descriptions in NoAccess lease errors so clients can see which policies blocked their access and why.

```shell
jmp shell --client repro-client -l pool=demos
[06/17/26 10:14:49] INFO     [jumpstarter.client.lease] Acquiring lease 019ed46e-c223-7b5f-b9b9-5c11bf6f6f2a for selector pool=demos for duration 0:30:00
                    INFO     Releasing Lease 019ed46e-c223-7b5f-b9b9-5c11bf6f6f2a
Error: the lease cannot be satisfied: While there are 1 exporters matching the selector, none of them are approved by any policy for your client. Matching policies: Requires demo-team=true label on your client. Contact admins if you need the label
```