### PR TITLE
fix(renovate): enable gomodTidy for Go dependency PRs

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -8,6 +8,9 @@
   // prune untagged manifests (e.g. Fedora) must opt out via pinDigests:false
   // in their packageRule to avoid broken builds when the old digest disappears.
   "pinDigests": true,
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "timezone": "Etc/UTC",
   "schedule": [
     "before 5am on monday"


### PR DESCRIPTION
## Summary
- Adds `"gomodTidy"` to Renovate's `postUpdateOptions` so that `go mod tidy` runs automatically after Go module updates
- Without this, Renovate updates direct dependency versions but does not reconcile indirect dependencies or update `go.sum` with new transitive checksums
- Fixes the root cause of CI failures on PR #764 (`go.mod` out of sync, missing `go.sum` entries)

## Test plan
- [x] Renovate validate-config passes CI
- [ ] After merge, Renovate recreates or rebases #764 with tidied `go.mod`/`go.sum`
- [ ] CI on the recreated Go dependency PR passes the `tests` and `build-operator-image` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)