### PR TITLE
ci: move linkcheck to weekly scheduled workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -99,28 +99,6 @@ jobs:
       - name: Build the documentation for the current version (no warnings allowed)
         run: make sync && make docs
 
-  linkcheck:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - id: uv
-        run: echo "version=$(cat .uv-version)" >> "$GITHUB_OUTPUT"
-        working-directory: .
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          version: ${{ steps.uv.outputs.version }}
-          python-version-file: .py-version
-
-      - name: Check documentation links
-        run: make sync && make docs-linkcheck
-
   # Deployment job
   deploy:
     environment:

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,34 @@
+name: Link Check
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+    working-directory: python
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: uv
+        run: echo "version=$(cat .uv-version)" >> "$GITHUB_OUTPUT"
+        working-directory: .
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: ${{ steps.uv.outputs.version }}
+          python-version-file: .py-version
+
+      - name: Check documentation links
+        run: make sync && make docs-linkcheck


### PR DESCRIPTION
Move the `linkcheck` job out of the `Documentation` workflow (which runs on pull requests) into a dedicated weekly scheduled workflow.

## Changes

- **`.github/workflows/documentation.yaml`**: remove the `linkcheck` job
- **`.github/workflows/linkcheck.yaml`**: new workflow that runs the same link check every Monday at 06:00 UTC, plus `workflow_dispatch` for manual runs

## Motivation

Link checks are slow (~15 min), depend on external sites, and are already `continue-on-error: true` — meaning they don't block PRs anyway. Running them on every PR adds unnecessary noise and CI time. A weekly schedule is sufficient to catch broken links.