### PR TITLE
fix(container): pin UV binary to build platform in cross-compilation stages

### DIFF
--- a/python/.devfile/Containerfile.client
+++ b/python/.devfile/Containerfile.client
@@ -1,5 +1,6 @@
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.11.21@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 AS uv-bin
 FROM --platform=$BUILDPLATFORM registry.fedoraproject.org/fedora:44 AS builder
-COPY --from=ghcr.io/astral-sh/uv:0.11.21@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=uv-bin /uv /uvx /bin/
 RUN dnf install -y make git && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -169,4 +169,7 @@ cython_debug/
 
 # Ruff cache
 .ruff_cache/
+
+# Per-package uv cache (parallel test isolation)
+.uv-cache/
 mitmproxy-ca-cert.pem

--- a/python/Containerfile
+++ b/python/Containerfile
@@ -1,5 +1,6 @@
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.11.21@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 AS uv-bin
 FROM --platform=$BUILDPLATFORM registry.fedoraproject.org/fedora:44 AS builder
-COPY --from=ghcr.io/astral-sh/uv:0.11.21@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=uv-bin /uv /uvx /bin/
 RUN dnf install -y make git && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/python/Makefile
+++ b/python/Makefile
@@ -85,7 +85,7 @@ pkg-test-%: packages/%
 	@mkdir -p $(LOGS_DIR)
 	@rm -f $(LOGS_DIR)/$*.failed
 	@bash -c 'set -o pipefail; \
-	PYTHONUNBUFFERED=1 uv run --isolated --directory $< pytest 2>&1 | tee $(LOGS_DIR)/$*.log; \
+	UV_CACHE_DIR="$(CURDIR)/.uv-cache/$*" PYTHONUNBUFFERED=1 uv run --isolated --directory $< pytest 2>&1 | tee $(LOGS_DIR)/$*.log; \
 	rc=$$?; \
 	if [ $$rc -ne 0 ] && [ $$rc -ne 5 ]; then \
 		touch $(LOGS_DIR)/$*.failed; \
@@ -93,7 +93,7 @@ pkg-test-%: packages/%
 	true'
 else
 pkg-test-%: packages/%
-	uv run --isolated --directory $< pytest || [ $$? -eq 5 ]
+	UV_CACHE_DIR="$(CURDIR)/.uv-cache/$*" uv run --isolated --directory $< pytest || [ $$? -eq 5 ]
 endif
 
 pkg-ty-%: packages/%
@@ -147,6 +147,7 @@ clean-test:
 	-rm -f .coverage
 	-rm -f coverage.xml
 	-rm -rf htmlcov
+	-rm -rf .uv-cache
 
 clean-docs:
 	uv run --isolated --all-packages --group docs $(MAKE) -C docs clean


### PR DESCRIPTION
## Summary

- Fixes multi-platform Docker builds failing with `qemu-aarch64: Could not open '/lib/ld-linux-aarch64.so.1'`
- `COPY --from=<multi-platform-image>` resolves the source image against the **target** platform, not the stage platform. In builder stages pinned to `$BUILDPLATFORM`, this copies an aarch64 UV binary into an amd64 container. The statically-linked UV binary runs via QEMU, but the dynamically-linked Python it downloads cannot find the aarch64 dynamic linker.
- Uses a named stage pinned to `$BUILDPLATFORM` for the UV image so COPY always gets the native-architecture binary

Failing CI run: https://github.com/jumpstarter-dev/jumpstarter/actions/runs/27947151753/job/82694686925

## Test plan

- [ ] CI multi-platform image build passes without QEMU dynamic linker errors
- [ ] Add `build-pr-images` label to trigger the image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)