### PR TITLE
fix(ci): use merge commit ref in backport workflow for fork PRs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Create backport PRs


### PR DESCRIPTION
## Summary
- The backport workflow uses `pull_request_target`, which runs with the base repo's privileges (secrets, tokens, cache)
- Recent `actions/checkout` versions now block checking out fork PR code in this context to prevent ["pwn request"](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) attacks
- Since the backport only runs on already-merged PRs, this switches from `head.sha` (fork code) to `merge_commit_sha` (base repo code) -- avoiding the security issue entirely

## Test plan
- [ ] Merge a fork PR with a `backport/*` label and verify the backport PR is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)