### PR TITLE
fix(controller): fix Containerfile build with rootless Podman

### DIFF
--- a/controller/Containerfile
+++ b/controller/Containerfile
@@ -6,9 +6,17 @@ ARG GIT_VERSION=unknown
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 
+# Create a build directory owned by the build user (1001:0).
+# This avoids permission issues with rootless Podman where COPY
+# changes the working directory ownership to root.
+WORKDIR /build
+USER 0
+RUN chown 1001:0 /build
+USER 1001
+
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY --chown=1001:0 go.mod go.mod
+COPY --chown=1001:0 go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 # Cache module downloads across builds
@@ -17,9 +25,9 @@ RUN --mount=type=cache,target=/opt/app-root/src/go/pkg/mod,sharing=locked,uid=10
         go mod download
 
 # Copy the go source
-COPY cmd/ cmd/
-COPY api/ api/
-COPY internal/ internal/
+COPY --chown=1001:0 cmd/ cmd/
+COPY --chown=1001:0 api/ api/
+COPY --chown=1001:0 internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
@@ -41,8 +49,8 @@ RUN  --mount=type=cache,target=/opt/app-root/src/go/pkg/mod,sharing=locked,uid=1
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.8-1779858820@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 WORKDIR /
-COPY --from=builder /opt/app-root/src/manager .
-COPY --from=builder /opt/app-root/src/router  .
+COPY --from=builder /build/manager .
+COPY --from=builder /build/router  .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Problem

The controller Containerfile fails to build with rootless Podman:

```
go build command-line-arguments: copying /tmp/go-build.../exe/a.out: open manager: permission denied
```

This breaks `make e2e-setup` (and any local development using rootless Podman).

## Root Cause

The `ubi10/go-toolset:1.26.3` base image runs as UID 1001 (`default`) with the working directory `/opt/app-root/src/` owned by `default:root`.

With rootless Podman, multiple `COPY` instructions change the working directory ownership in the overlay filesystem to `root:root`. After several COPY layers, UID 1001 can no longer create new files in the directory, causing `go build -o manager` to fail with "permission denied".

This does not affect Docker builds (which run as root by default) but breaks rootless Podman environments.

## Fix

- Use a dedicated `/build` directory with explicitly set ownership (`chown 1001:0`) instead of relying on the base image's `/opt/app-root/src/`
- Add `--chown=1001:0` to all `COPY` instructions to prevent file ownership from reverting to root
- Update the final stage `COPY --from=builder` paths to reference `/build/`

## Testing

Verified the fix builds successfully with rootless Podman:
```
podman build --no-cache -t quay.io/jumpstarter-dev/jumpstarter-controller:latest \
  -f controller/Containerfile controller/
# Successfully tagged quay.io/jumpstarter-dev/jumpstarter-controller:latest
```
