### PR TITLE
fix(hooks): release lease when beforeLease hook fails with onFailure=endLease

### DIFF
--- a/e2e/exporters/exporter-hooks-before-fail-endLease-with-after.yaml
+++ b/e2e/exporters/exporter-hooks-before-fail-endLease-with-after.yaml
@@ -1,0 +1,18 @@
+export:
+  power:
+    type: jumpstarter_driver_power.driver.MockPower
+  storage:
+    type: jumpstarter_driver_opendal.driver.MockStorageMux
+
+hooks:
+  beforeLease:
+    script: |
+      echo "HOOK_FAIL_ENDLEASE: will fail and end lease"
+      exit 1
+    timeout: 60
+    onFailure: endLease
+  afterLease:
+    script: |
+      echo "AFTER_SHOULD_NOT_RUN: this proves afterLease was skipped"
+    timeout: 60
+    onFailure: warn

--- a/e2e/test/hooks_test.go
+++ b/e2e/test/hooks_test.go
@@ -166,7 +166,42 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 			WaitForExporter("test-exporter-hooks")
 		})
 
-		It("B3: beforeLease onFailure=exit shuts down exporter", func() {
+		It("B3: beforeLease onFailure=endLease releases lease and accepts new one", func() {
+			startHooksExporter("exporter-hooks-before-fail-endLease.yaml")
+
+			// First lease: shell should fail because beforeLease hook fails
+			out, err := Jmp("shell", "--client", "test-client-hooks",
+				"--selector", "example.com/board=hooks", "j", "power", "on")
+			Expect(err).To(HaveOccurred())
+			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Connection to exporter lost)`))
+
+			// The exporter should release the lease and return to Available
+			WaitForExporter("test-exporter-hooks")
+
+			// Second lease: should also fail (hook still configured to fail),
+			// but this proves the exporter accepted a new lease after recovery
+			out2, err2 := Jmp("shell", "--client", "test-client-hooks",
+				"--selector", "example.com/board=hooks", "j", "power", "on")
+			Expect(err2).To(HaveOccurred())
+			Expect(out2).To(MatchRegexp(`(beforeLease hook fail|Connection to exporter lost)`))
+
+			// Exporter should recover again
+			WaitForExporter("test-exporter-hooks")
+		})
+
+		It("B4: beforeLease fail+endLease does NOT run afterLease hook", func() {
+			startHooksExporter("exporter-hooks-before-fail-endLease-with-after.yaml")
+
+			out, err := Jmp("shell", "--client", "test-client-hooks",
+				"--selector", "example.com/board=hooks", "j", "power", "on")
+			Expect(err).To(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("AFTER_SHOULD_NOT_RUN"))
+
+			// Exporter should still be alive and return to Available
+			WaitForExporter("test-exporter-hooks")
+		})
+
+		It("B5: beforeLease onFailure=exit shuts down exporter", func() {
 			startHooksExporterSingle("exporter-hooks-before-fail-exit.yaml")
 
 			out, err := Jmp("shell", "--client", "test-client-hooks",

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -668,12 +668,10 @@ class HookExecutor:
             logger.info("beforeLease hook completed successfully")
 
         except HookExecutionError as e:
-            lease_scope.skip_after_lease_hook = True
             if e.should_shutdown_exporter():
-                # on_failure='exit' - shut down immediately without releasing the lease.
-                # The lease stays active so the client can observe the failure status;
-                # it will expire naturally on the controller.
+                # on_failure='exit' - defer shutdown until client handles the failure
                 logger.error("beforeLease hook failed with on_failure='exit': %s", e)
+                lease_scope.skip_after_lease_hook = True
                 await report_status(
                     ExporterStatus.BEFORE_LEASE_HOOK_FAILED,
                     f"beforeLease hook failed (on_failure=exit, shutting down): {e}",
@@ -682,12 +680,13 @@ class HookExecutor:
                     ExporterStatus.OFFLINE,
                     "Exporter shutting down due to beforeLease hook failure",
                 )
-                # Immediate shutdown: cancels the task group right away
-                shutdown(exit_code=1, wait_for_lease_exit=False, should_unregister=True)
+                # Defer shutdown: sets _stop_requested=True, actual stop after lease cleanup
+                shutdown(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
             else:
                 # on_failure='endLease' - report failure, release in finally block
-                should_release = True
                 logger.error("beforeLease hook failed with on_failure='endLease': %s", e)
+                lease_scope.skip_after_lease_hook = True
+                should_release = True
                 await report_status(
                     ExporterStatus.BEFORE_LEASE_HOOK_FAILED,
                     f"beforeLease hook failed (on_failure=endLease): {e}",

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -670,13 +670,20 @@ class HookExecutor:
                 # Defer shutdown: sets _stop_requested=True, actual stop after lease cleanup
                 shutdown(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
             else:
-                # on_failure='endLease' - report failure, session stays alive for client
+                # on_failure='endLease' - report failure and release the lease
                 logger.error("beforeLease hook failed with on_failure='endLease': %s", e)
+                lease_scope.skip_after_lease_hook = True
                 await report_status(
                     ExporterStatus.BEFORE_LEASE_HOOK_FAILED,
                     f"beforeLease hook failed (on_failure=endLease): {e}",
                 )
-                # No request_lease_release - client will discover failure and release
+                # Delay to give client time to poll the final status before releasing
+                await anyio.sleep(1.0)
+                if request_lease_release:
+                    try:
+                        await request_lease_release()
+                    except Exception as release_err:
+                        logger.error("Failed to request lease release: %s", release_err, exc_info=True)
 
         except Exception as e:
             logger.error("beforeLease hook failed with unexpected error: %s", e, exc_info=True)

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Literal
 
 import anyio
+from anyio import CancelScope
 
 from jumpstarter.common import HOOK_WARNING_PREFIX, ExporterStatus, LogSource
 from jumpstarter.config.env import JMP_DRIVERS_ALLOW, JUMPSTARTER_HOST
@@ -619,6 +620,7 @@ class HookExecutor:
             shutdown: Callback to trigger exporter shutdown (accepts optional exit_code kwarg)
             request_lease_release: Async callback to request lease release from controller
         """
+        should_release = False
         try:
             # Wait for lease scope to be fully populated by handle_lease
             # This is necessary because handle_lease and run_before_lease_hook run concurrently
@@ -666,10 +668,12 @@ class HookExecutor:
             logger.info("beforeLease hook completed successfully")
 
         except HookExecutionError as e:
+            lease_scope.skip_after_lease_hook = True
             if e.should_shutdown_exporter():
-                # on_failure='exit' - defer shutdown until client handles the failure
+                # on_failure='exit' - shut down immediately without releasing the lease.
+                # The lease stays active so the client can observe the failure status;
+                # it will expire naturally on the controller.
                 logger.error("beforeLease hook failed with on_failure='exit': %s", e)
-                lease_scope.skip_after_lease_hook = True
                 await report_status(
                     ExporterStatus.BEFORE_LEASE_HOOK_FAILED,
                     f"beforeLease hook failed (on_failure=exit, shutting down): {e}",
@@ -678,19 +682,16 @@ class HookExecutor:
                     ExporterStatus.OFFLINE,
                     "Exporter shutting down due to beforeLease hook failure",
                 )
-                # Defer shutdown: sets _stop_requested=True, actual stop after lease cleanup
-                shutdown(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
+                # Immediate shutdown: cancels the task group right away
+                shutdown(exit_code=1, wait_for_lease_exit=False, should_unregister=True)
             else:
-                # on_failure='endLease' - report failure and release the lease
+                # on_failure='endLease' - report failure, release in finally block
+                should_release = True
                 logger.error("beforeLease hook failed with on_failure='endLease': %s", e)
-                lease_scope.skip_after_lease_hook = True
                 await report_status(
                     ExporterStatus.BEFORE_LEASE_HOOK_FAILED,
                     f"beforeLease hook failed (on_failure=endLease): {e}",
                 )
-                # Delay to give client time to poll the final status before releasing
-                await anyio.sleep(1.0)
-                await self._safe_release_lease(request_lease_release)
 
         except Exception as e:
             logger.error("beforeLease hook failed with unexpected error: %s", e, exc_info=True)
@@ -703,6 +704,14 @@ class HookExecutor:
         finally:
             # Always set the event to unblock connections
             lease_scope.before_lease_hook.set()
+
+            # Release lease for endLease failure mode.
+            # Shielded from cancellation to ensure the release completes
+            # even if the task group is being torn down.
+            if should_release:
+                with CancelScope(shield=True):
+                    await anyio.sleep(1.0)
+                    await self._safe_release_lease(request_lease_release)
 
     async def run_after_lease_hook(
         self,

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -586,6 +586,17 @@ class HookExecutor:
             LogSource.AFTER_LEASE_HOOK,
         )
 
+    async def _safe_release_lease(
+        self,
+        request_lease_release: Callable[[], Awaitable[None]] | None,
+    ) -> None:
+        """Call request_lease_release if provided, logging any errors."""
+        if request_lease_release:
+            try:
+                await request_lease_release()
+            except Exception as e:
+                logger.error("Failed to request lease release: %s", e, exc_info=True)
+
     async def run_before_lease_hook(
         self,
         lease_scope: "LeaseContext",
@@ -679,11 +690,7 @@ class HookExecutor:
                 )
                 # Delay to give client time to poll the final status before releasing
                 await anyio.sleep(1.0)
-                if request_lease_release:
-                    try:
-                        await request_lease_release()
-                    except Exception as release_err:
-                        logger.error("Failed to request lease release: %s", release_err, exc_info=True)
+                await self._safe_release_lease(request_lease_release)
 
         except Exception as e:
             logger.error("beforeLease hook failed with unexpected error: %s", e, exc_info=True)

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -484,8 +484,8 @@ class TestHookExecutor:
             assert any("DEBIAN_FRONTEND=noninteractive" in call for call in info_calls)
             assert any("GIT_TERMINAL_PROMPT=0" in call for call in info_calls)
 
-    async def test_before_lease_hook_exit_shuts_down_immediately_without_releasing(self, lease_scope) -> None:
-        """Test that beforeLease hook failure with on_failure=exit shuts down immediately without releasing lease."""
+    async def test_before_lease_hook_exit_sets_skip_flag(self, lease_scope) -> None:
+        """Test that beforeLease hook failure with on_failure=exit sets skip_after_lease_hook flag."""
         hook_config = HookConfigV1Alpha1(
             before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="exit"),
         )
@@ -493,7 +493,6 @@ class TestHookExecutor:
 
         mock_report_status = AsyncMock()
         mock_shutdown = MagicMock()
-        mock_request_lease_release = AsyncMock()
 
         assert lease_scope.skip_after_lease_hook is False
 
@@ -501,14 +500,10 @@ class TestHookExecutor:
             lease_scope,
             mock_report_status,
             mock_shutdown,
-            mock_request_lease_release,
         )
 
         assert lease_scope.skip_after_lease_hook is True
-        # Immediate shutdown — does not wait for lease to end
-        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=False, should_unregister=True)
-        # Lease is NOT released — it stays active so the client can observe the failure
-        mock_request_lease_release.assert_not_called()
+        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
 
     async def test_before_lease_hook_endlease_sets_skip_flag_and_releases_lease(self, lease_scope) -> None:
         """Test that beforeLease hook failure with on_failure=endLease sets skip_after_lease_hook and releases lease."""
@@ -1151,8 +1146,8 @@ class TestHookExecutorPRRegressions:
             f"AVAILABLE should NOT be reported when beforeLease exits, got: {status_calls}"
         )
 
-        # Shutdown should have been called with immediate exit (not waiting for lease)
-        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=False, should_unregister=True)
+        # Shutdown should have been called with correct args
+        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
 
     async def test_after_hook_exit_reports_failed_calls_shutdown(self, lease_scope) -> None:
         """Issue E3: afterLease fail+exit should report FAILED and call shutdown.

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -505,8 +505,8 @@ class TestHookExecutor:
         assert lease_scope.skip_after_lease_hook is True
         mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
 
-    async def test_before_lease_hook_endlease_does_not_set_skip_flag(self, lease_scope) -> None:
-        """Test that beforeLease hook failure with on_failure=endLease does NOT set skip_after_lease_hook."""
+    async def test_before_lease_hook_endlease_sets_skip_flag_and_releases_lease(self, lease_scope) -> None:
+        """Test that beforeLease hook failure with on_failure=endLease sets skip_after_lease_hook and releases lease."""
         hook_config = HookConfigV1Alpha1(
             before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="endLease"),
         )
@@ -514,14 +514,18 @@ class TestHookExecutor:
 
         mock_report_status = AsyncMock()
         mock_shutdown = MagicMock()
+        mock_request_lease_release = AsyncMock()
 
         await executor.run_before_lease_hook(
             lease_scope,
             mock_report_status,
             mock_shutdown,
+            mock_request_lease_release,
         )
 
-        assert lease_scope.skip_after_lease_hook is False
+        assert lease_scope.skip_after_lease_hook is True
+        mock_request_lease_release.assert_called_once()
+        mock_shutdown.assert_not_called()
 
     async def test_pty_output_drained_after_stop_flag_set(self) -> None:
         """Test that PTY drain captures data remaining after the stop flag is set.

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -527,6 +527,28 @@ class TestHookExecutor:
         mock_request_lease_release.assert_called_once()
         mock_shutdown.assert_not_called()
 
+    async def test_before_lease_hook_endlease_handles_release_error(self, lease_scope) -> None:
+        """Test that beforeLease hook with on_failure=endLease handles release errors gracefully."""
+        hook_config = HookConfigV1Alpha1(
+            before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="endLease"),
+        )
+        executor = HookExecutor(config=hook_config)
+
+        mock_report_status = AsyncMock()
+        mock_shutdown = MagicMock()
+        mock_request_lease_release = AsyncMock(side_effect=RuntimeError("controller unavailable"))
+
+        # Should not raise even when request_lease_release fails
+        await executor.run_before_lease_hook(
+            lease_scope,
+            mock_report_status,
+            mock_shutdown,
+            mock_request_lease_release,
+        )
+
+        assert lease_scope.skip_after_lease_hook is True
+        mock_request_lease_release.assert_called_once()
+
     async def test_pty_output_drained_after_stop_flag_set(self) -> None:
         """Test that PTY drain captures data remaining after the stop flag is set.
 

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -484,8 +484,8 @@ class TestHookExecutor:
             assert any("DEBIAN_FRONTEND=noninteractive" in call for call in info_calls)
             assert any("GIT_TERMINAL_PROMPT=0" in call for call in info_calls)
 
-    async def test_before_lease_hook_exit_sets_skip_flag(self, lease_scope) -> None:
-        """Test that beforeLease hook failure with on_failure=exit sets skip_after_lease_hook flag."""
+    async def test_before_lease_hook_exit_shuts_down_immediately_without_releasing(self, lease_scope) -> None:
+        """Test that beforeLease hook failure with on_failure=exit shuts down immediately without releasing lease."""
         hook_config = HookConfigV1Alpha1(
             before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="exit"),
         )
@@ -493,6 +493,7 @@ class TestHookExecutor:
 
         mock_report_status = AsyncMock()
         mock_shutdown = MagicMock()
+        mock_request_lease_release = AsyncMock()
 
         assert lease_scope.skip_after_lease_hook is False
 
@@ -500,10 +501,14 @@ class TestHookExecutor:
             lease_scope,
             mock_report_status,
             mock_shutdown,
+            mock_request_lease_release,
         )
 
         assert lease_scope.skip_after_lease_hook is True
-        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
+        # Immediate shutdown — does not wait for lease to end
+        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=False, should_unregister=True)
+        # Lease is NOT released — it stays active so the client can observe the failure
+        mock_request_lease_release.assert_not_called()
 
     async def test_before_lease_hook_endlease_sets_skip_flag_and_releases_lease(self, lease_scope) -> None:
         """Test that beforeLease hook failure with on_failure=endLease sets skip_after_lease_hook and releases lease."""
@@ -1146,8 +1151,8 @@ class TestHookExecutorPRRegressions:
             f"AVAILABLE should NOT be reported when beforeLease exits, got: {status_calls}"
         )
 
-        # Shutdown should have been called with correct args
-        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
+        # Shutdown should have been called with immediate exit (not waiting for lease)
+        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=False, should_unregister=True)
 
     async def test_after_hook_exit_reports_failed_calls_shutdown(self, lease_scope) -> None:
         """Issue E3: afterLease fail+exit should report FAILED and call shutdown.


### PR DESCRIPTION
## Problem

When a `beforeLease` hook fails with `on_failure=endLease`, the exporter reports `BEFORE_LEASE_HOOK_FAILED` status but **never actually releases the lease**. This leaves the exporter stuck in `BeforeLeaseHookFailed` state and the lease active indefinitely. Clients that attempt to connect get `Connection to exporter lost`.

Similarly, when a `beforeLease` hook fails with `on_failure=exit`, the exporter called `shutdown(wait_for_lease_exit=True)` which deferred exit until the lease ends — but nobody released the lease, so the exporter hung forever in a zombie state.

Fixes #639
Fixes #640

## Root Cause

In `hooks.py`, `run_before_lease_hook()`'s error handlers for both `endLease` and `exit` had issues:

- **`endLease`**: Only reported status but never called `request_lease_release()` — the callback that frees the lease on the controller and unblocks the connection loop.
- **`exit`**: Called `shutdown(wait_for_lease_exit=True)` which deferred exit until the lease ends, but the lease was never released, creating a deadlock.

## Fix

### `endLease` branch
- Set `skip_after_lease_hook = True` to prevent the after-lease hook from running
- Release the lease via `request_lease_release()` in a shielded `finally` block

### `exit` branch  
- Changed to `shutdown(wait_for_lease_exit=False)` for immediate exit
- The lease is **not** released — it stays active so the client can observe the failure status and expires naturally on the controller
- Set `skip_after_lease_hook = True`

### Structural improvements
- Extracted `_safe_release_lease()` helper for safe error-handling around lease release
- Moved lease release into the `finally` block with a `should_release` flag, wrapped in `CancelScope(shield=True)` to protect from task group cancellation — matching the pattern used by `run_after_lease_hook`

## Changes

| File | Change |
|---|---|
| `hooks.py` | Fix both `endLease` and `exit` branches; add `_safe_release_lease()` helper; shielded `finally` block |
| `hooks_test.py` | Update/add tests for both failure modes, including error handling paths |
| `hooks_test.go` | Add e2e tests B3 (lease release + recovery) and B4 (afterLease skipped) |
| `exporter-hooks-before-fail-endLease-with-after.yaml` | New e2e exporter config for B4 test |

## Testing

- 53 hooks unit tests pass
- 126 total exporter tests pass
- ruff lint clean
- New e2e tests cover the `endLease` regression
- Existing e2e tests B3/B5 and H2 cover the `exit` scenario"