### PR TITLE
fix(hooks): release lease when beforeLease hook fails with onFailure=exit

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -586,6 +586,17 @@ class HookExecutor:
             LogSource.AFTER_LEASE_HOOK,
         )
 
+    async def _safe_release_lease(
+        self,
+        request_lease_release: Callable[[], Awaitable[None]] | None,
+    ) -> None:
+        """Call request_lease_release if provided, logging any errors."""
+        if request_lease_release:
+            try:
+                await request_lease_release()
+            except Exception as e:
+                logger.error("Failed to request lease release: %s", e, exc_info=True)
+
     async def run_before_lease_hook(
         self,
         lease_scope: "LeaseContext",
@@ -656,7 +667,7 @@ class HookExecutor:
 
         except HookExecutionError as e:
             if e.should_shutdown_exporter():
-                # on_failure='exit' - defer shutdown until client handles the failure
+                # on_failure='exit' - release the lease, then defer shutdown
                 logger.error("beforeLease hook failed with on_failure='exit': %s", e)
                 lease_scope.skip_after_lease_hook = True
                 await report_status(
@@ -667,6 +678,12 @@ class HookExecutor:
                     ExporterStatus.OFFLINE,
                     "Exporter shutting down due to beforeLease hook failure",
                 )
+                # Release the lease so the controller sends leased=False,
+                # which unblocks the serve() loop to check _stop_requested.
+                # Without this, the exporter hangs waiting for a lease end
+                # that never comes.
+                await anyio.sleep(1.0)
+                await self._safe_release_lease(request_lease_release)
                 # Defer shutdown: sets _stop_requested=True, actual stop after lease cleanup
                 shutdown(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
             else:

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -484,8 +484,8 @@ class TestHookExecutor:
             assert any("DEBIAN_FRONTEND=noninteractive" in call for call in info_calls)
             assert any("GIT_TERMINAL_PROMPT=0" in call for call in info_calls)
 
-    async def test_before_lease_hook_exit_sets_skip_flag(self, lease_scope) -> None:
-        """Test that beforeLease hook failure with on_failure=exit sets skip_after_lease_hook flag."""
+    async def test_before_lease_hook_exit_sets_skip_flag_and_releases_lease(self, lease_scope) -> None:
+        """Test that beforeLease hook failure with on_failure=exit sets skip flag and releases lease."""
         hook_config = HookConfigV1Alpha1(
             before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="exit"),
         )
@@ -493,6 +493,7 @@ class TestHookExecutor:
 
         mock_report_status = AsyncMock()
         mock_shutdown = MagicMock()
+        mock_request_lease_release = AsyncMock()
 
         assert lease_scope.skip_after_lease_hook is False
 
@@ -500,9 +501,34 @@ class TestHookExecutor:
             lease_scope,
             mock_report_status,
             mock_shutdown,
+            mock_request_lease_release,
         )
 
         assert lease_scope.skip_after_lease_hook is True
+        mock_request_lease_release.assert_called_once()
+        mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
+
+    async def test_before_lease_hook_exit_handles_release_error(self, lease_scope) -> None:
+        """Test that beforeLease hook with on_failure=exit handles release errors gracefully."""
+        hook_config = HookConfigV1Alpha1(
+            before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="exit"),
+        )
+        executor = HookExecutor(config=hook_config)
+
+        mock_report_status = AsyncMock()
+        mock_shutdown = MagicMock()
+        mock_request_lease_release = AsyncMock(side_effect=RuntimeError("controller unavailable"))
+
+        await executor.run_before_lease_hook(
+            lease_scope,
+            mock_report_status,
+            mock_shutdown,
+            mock_request_lease_release,
+        )
+
+        assert lease_scope.skip_after_lease_hook is True
+        mock_request_lease_release.assert_called_once()
+        # shutdown should still be called even if release fails
         mock_shutdown.assert_called_once_with(exit_code=1, wait_for_lease_exit=True, should_unregister=True)
 
     async def test_before_lease_hook_endlease_does_not_set_skip_flag(self, lease_scope) -> None:


### PR DESCRIPTION
**Superseded by #823**, which now fixes both #639 (endLease) and #640 (exit) in a single PR.

The `exit` fix was incorporated into #823 with the correct semantics: `shutdown(wait_for_lease_exit=False)` for immediate exit without releasing the lease (the lease stays active so the client can observe the failure status)."