### PR TITLE
ci: reduce PR test matrix, run full matrix in merge queue

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.e2e }}
+      e2e-matrix: ${{ steps.matrix.outputs.e2e-matrix }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -37,6 +38,16 @@ jobs:
               - '!python/**/*.md'
               - '.github/workflows/e2e.yaml'
               - 'Makefile'
+      - name: Compute e2e architecture matrix
+        id: matrix
+        run: |
+          # PRs: run only amd64 e2e tests to save CI time.
+          # Merge queue, push to main, and workflow_dispatch run both architectures.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo 'e2e-matrix=[{"os": "ubuntu-24.04", "arch": "amd64"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'e2e-matrix=[{"os": "ubuntu-24.04", "arch": "amd64"}, {"os": "ubuntu-24.04-arm", "arch": "arm64"}]' >> "$GITHUB_OUTPUT"
+          fi
 
   # ===========================================================================
   # Build jobs: container images and Python wheels built in parallel
@@ -47,11 +58,7 @@ jobs:
     if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        include:
-          - os: ubuntu-24.04
-            arch: amd64
-          - os: ubuntu-24.04-arm
-            arch: arm64
+        include: ${{ fromJson(needs.changes.outputs.e2e-matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -90,11 +97,7 @@ jobs:
     if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        include:
-          - os: ubuntu-24.04
-            arch: amd64
-          - os: ubuntu-24.04-arm
-            arch: arm64
+        include: ${{ fromJson(needs.changes.outputs.e2e-matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -176,14 +179,10 @@ jobs:
   # ===========================================================================
 
   e2e-tests:
-    needs: [build-controller-image, build-operator-image, build-python-wheels]
+    needs: [changes, build-controller-image, build-operator-image, build-python-wheels]
     strategy:
       matrix:
-        include:
-          - os: ubuntu-24.04
-            arch: amd64
-          - os: ubuntu-24.04-arm
-            arch: arm64
+        include: ${{ fromJson(needs.changes.outputs.e2e-matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -243,7 +243,10 @@ jobs:
 
   e2e-compat-old-controller:
     needs: changes
-    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
+    # Skip on PRs — compat tests run in merge queue, push to main, and workflow_dispatch.
+    if: >-
+      github.event_name != 'pull_request'
+      && (needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -282,7 +285,10 @@ jobs:
 
   e2e-compat-old-client:
     needs: [changes, build-controller-image, build-operator-image, build-python-wheels]
-    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
+    # Skip on PRs — compat tests run in merge queue, push to main, and workflow_dispatch.
+    if: >-
+      github.event_name != 'pull_request'
+      && (needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -332,3 +332,19 @@ jobs:
         uses: ./.github/actions/collect-e2e-logs
         with:
           artifact-name: e2e-logs-compat-old-client
+
+  # https://github.com/orgs/community/discussions/26822
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [changes, e2e-tests, e2e-compat-old-controller, e2e-compat-old-client]
+    if: ${{ always() }}
+    steps:
+      - run: exit 1
+        # Fail on failures or cancellations. Also fail if e2e-tests was skipped
+        # when it should have run (compat jobs are intentionally skipped on PRs).
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || (needs.e2e-tests.result == 'skipped' && needs.changes.outputs.should_run == 'true')
+          }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -20,6 +20,8 @@ jobs:
     outputs:
       should_run: ${{ steps.filter.outputs.python }}
       renode_driver: ${{ steps.filter.outputs.renode_driver }}
+      python-versions: ${{ steps.matrix.outputs.python-versions }}
+      runners: ${{ steps.matrix.outputs.runners }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -36,6 +38,19 @@ jobs:
               - '.github/workflows/python-tests.yaml'
             renode_driver:
               - 'python/packages/jumpstarter-driver-renode/**'
+      - name: Compute test matrix
+        id: matrix
+        run: |
+          # PRs: test only Python 3.12 on Linux to save CI time.
+          # Merge queue, push to main, and workflow_dispatch run the full matrix
+          # (all Python versions on both Linux and macOS).
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo 'python-versions=["3.12"]' >> "$GITHUB_OUTPUT"
+            echo 'runners=["ubuntu-24.04"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'python-versions=["3.11", "3.12", "3.13"]' >> "$GITHUB_OUTPUT"
+            echo 'runners=["ubuntu-24.04", "macos-15"]' >> "$GITHUB_OUTPUT"
+          fi
 
   pytest-matrix:
     needs: changes
@@ -43,11 +58,13 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        runs-on: [ubuntu-24.04, macos-15]
+        runs-on: ${{ fromJson(needs.changes.outputs.runners) }}
         # Floor: oldest Python in supported platforms (RHEL 9 appstream)
         # Ceiling: newest Python in latest Fedora
         # Review on each RHEL/Fedora release
-        python-version: ["3.11", "3.12", "3.13"]
+        # PRs run only 3.12 on Linux; merge queue / push run all versions
+        # on both Linux and macOS.
+        python-version: ${{ fromJson(needs.changes.outputs.python-versions) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:


### PR DESCRIPTION
## Problem

PR CI runs the full test matrix (3 Python versions x 2 OSes = 6 pytest jobs, plus 2 architectures for e2e), which is slow and expensive. Most of this coverage is redundant for validating a PR — the full matrix only needs to pass before merging.

## Changes

### Python tests (`python-tests.yaml`)
- **PRs:** Run only Python 3.12 on Ubuntu (1 job, down from 6)
- **Merge queue / push / dispatch:** Full matrix — 3.11, 3.12, 3.13 on both Ubuntu and macOS

### E2E tests (`e2e.yaml`)
- **PRs:** Build and test only amd64 (down from amd64 + arm64)
- **Merge queue / push / dispatch:** Both architectures

### Implementation
Both workflows compute the matrix dynamically in the `changes` job based on `github.event_name`, outputting JSON arrays consumed by `fromJson()` in the matrix strategy.

## Impact

| | PRs (before) | PRs (after) | Merge queue |
|---|---|---|---|
| pytest-matrix | 6 jobs | 1 job | 6 jobs |
| e2e builds | 4 jobs (2 images x 2 arch) | 2 jobs (2 images x 1 arch) | 4 jobs |
| e2e tests | 2 jobs | 1 job | 2 jobs |
| **Total** | **~12 jobs** | **~4 jobs** | **~12 jobs** |

No reduction in pre-merge coverage — the merge queue runs everything.