### PR TITLE
fix: use shared uv cache for package tests

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -85,7 +85,7 @@ pkg-test-%: packages/%
 	@mkdir -p $(LOGS_DIR)
 	@rm -f $(LOGS_DIR)/$*.failed
 	@bash -c 'set -o pipefail; \
-	UV_CACHE_DIR="$(CURDIR)/.uv-cache/$*" PYTHONUNBUFFERED=1 uv run --isolated --directory $< pytest 2>&1 | tee $(LOGS_DIR)/$*.log; \
+	PYTHONUNBUFFERED=1 uv run --isolated --directory $< pytest 2>&1 | tee $(LOGS_DIR)/$*.log; \
 	rc=$$?; \
 	if [ $$rc -ne 0 ] && [ $$rc -ne 5 ]; then \
 		touch $(LOGS_DIR)/$*.failed; \
@@ -93,7 +93,7 @@ pkg-test-%: packages/%
 	true'
 else
 pkg-test-%: packages/%
-	UV_CACHE_DIR="$(CURDIR)/.uv-cache/$*" uv run --isolated --directory $< pytest || [ $$? -eq 5 ]
+	uv run --isolated --directory $< pytest || [ $$? -eq 5 ]
 endif
 
 pkg-ty-%: packages/%

--- a/python/Makefile
+++ b/python/Makefile
@@ -99,7 +99,7 @@ endif
 pkg-ty-%: packages/%
 	uv run --isolated --directory $< ty check .
 
-pkg-test-all: $(addprefix pkg-test-,$(PKG_TARGETS))
+pkg-test-all: sync $(addprefix pkg-test-,$(PKG_TARGETS))
 
 ifdef LOGS_DIR
 test-report:


### PR DESCRIPTION
## Problem

The Makefile test targets (`pkg-test-%`) set `UV_CACHE_DIR` to a **separate directory per package** (`.uv-cache/<pkg>`). This means each package's test venv downloads and builds its own copy of shared dependencies like `grpcio`, `protobuf`, etc., even though they're identical across packages.

## Fix

Remove the `UV_CACHE_DIR` override entirely, letting `uv` use its default shared cache (`~/.cache/uv` on Linux, `~/Library/Caches/uv` on macOS). This way all package test runs share cached downloads and built wheels, avoiding redundant work.

## Impact

- Faster local test runs: common dependencies are downloaded/built once and reused across all packages
- CI can still override `UV_CACHE_DIR` via environment if a custom cache path is needed for persistence