### PR TITLE
ci: stop re-running validation workflows on push to main

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,9 +2,6 @@ name: End-to-end tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 
@@ -42,7 +39,7 @@ jobs:
         id: matrix
         run: |
           # PRs: run only amd64 e2e tests to save CI time.
-          # Merge queue, push to main, and workflow_dispatch run both architectures.
+          # Merge queue and workflow_dispatch run both architectures.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo 'e2e-matrix=[{"os": "ubuntu-24.04", "arch": "amd64"}]' >> "$GITHUB_OUTPUT"
           else
@@ -55,7 +52,7 @@ jobs:
 
   build-controller-image:
     needs: changes
-    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include: ${{ fromJson(needs.changes.outputs.e2e-matrix) }}
@@ -94,7 +91,7 @@ jobs:
 
   build-operator-image:
     needs: changes
-    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include: ${{ fromJson(needs.changes.outputs.e2e-matrix) }}
@@ -138,7 +135,7 @@ jobs:
 
   build-python-wheels:
     needs: changes
-    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -243,7 +240,7 @@ jobs:
 
   e2e-compat-old-controller:
     needs: changes
-    # Skip on PRs — compat tests run in merge queue, push to main, and workflow_dispatch.
+    # Skip on PRs — compat tests run in merge queue and workflow_dispatch.
     if: >-
       github.event_name != 'pull_request'
       && (needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')
@@ -285,7 +282,7 @@ jobs:
 
   e2e-compat-old-client:
     needs: [changes, build-controller-image, build-operator-image, build-python-wheels]
-    # Skip on PRs — compat tests run in merge queue, push to main, and workflow_dispatch.
+    # Skip on PRs — compat tests run in merge queue and workflow_dispatch.
     if: >-
       github.event_name != 'pull_request'
       && (needs.changes.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,10 +2,6 @@ name: Linters
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - 'release-*'
   pull_request:
   merge_group:
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -2,10 +2,6 @@ name: Python Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - release-*
   pull_request:
   merge_group:
 
@@ -42,7 +38,7 @@ jobs:
         id: matrix
         run: |
           # PRs: test only Python 3.12 on Linux to save CI time.
-          # Merge queue, push to main, and workflow_dispatch run the full matrix
+          # Merge queue and workflow_dispatch run the full matrix
           # (all Python versions on both Linux and macOS).
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo 'python-versions=["3.12"]' >> "$GITHUB_OUTPUT"
@@ -62,7 +58,7 @@ jobs:
         # Floor: oldest Python in supported platforms (RHEL 9 appstream)
         # Ceiling: newest Python in latest Fedora
         # Review on each RHEL/Fedora release
-        # PRs run only 3.12 on Linux; merge queue / push run all versions
+        # PRs run only 3.12 on Linux; merge queue runs all versions
         # on both Linux and macOS.
         python-version: ${{ fromJson(needs.changes.outputs.python-versions) }}
     steps:


### PR DESCRIPTION
## Problem

Every merge to `main` re-runs all validation workflows (e2e tests, linters, python tests) even though the merge queue already validated them. This wastes CI resources and clutters the commit status.

## Changes

Remove `push` triggers from validation-only workflows:

| Workflow | Was triggered on push? | Action |
|----------|:---:|--------|
| `e2e.yaml` | `push: main` | Removed — validation only |
| `lint.yaml` | `push: main, release-*` | Removed — validation only |
| `python-tests.yaml` | `push: main, release-*` | Removed — validation only |

## What still runs on push to main

These workflows perform **release/deploy actions** that can only happen after merge:

| Workflow | Purpose |
|----------|---------|
| `build-images.yaml` | Builds + pushes container images to quay.io with `latest` tag |
| `documentation.yaml` | Deploys docs to GitHub Pages |
| `trigger-packages.yaml` | Triggers package index rebuild |

## Safety net

All three validation workflows retain `workflow_dispatch` for manual runs if needed. The merge queue provides full validation coverage before any code reaches `main`.