### PR TITLE
fix: serve fls binary from exporter instead of downloading from GitHub

### DIFF
--- a/python/Containerfile
+++ b/python/Containerfile
@@ -20,7 +20,14 @@ RUN ARCH=$(uname -m) && \
     TEMP_FILE="/tmp/fls-${ARCH}-${SUFFIX}.tmp" && \
     curl -fsSL "${URL}" -o "${TEMP_FILE}" && \
     mv "${TEMP_FILE}" /usr/local/bin/fls && \
-    chmod +x /usr/local/bin/fls
+    chmod +x /usr/local/bin/fls && \
+    if [ "$ARCH" != "aarch64" ]; then \
+        curl -fsSL "https://github.com/jumpstarter-dev/fls/releases/download/${FLS_VERSION}/fls-aarch64-linux-musl" \
+            -o /usr/local/bin/fls-aarch64 && \
+        chmod +x /usr/local/bin/fls-aarch64; \
+    else \
+        ln -s /usr/local/bin/fls /usr/local/bin/fls-aarch64; \
+    fi
 
 FROM builder AS wheels
 ADD . /src

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/client.py
@@ -39,7 +39,7 @@ from jumpstarter_driver_flashers.bundle import FlasherBundleManifestV1Alpha1
 
 from jumpstarter.client.core import DriverMethodNotImplemented
 from jumpstarter.client.decorators import driver_click_group
-from jumpstarter.common.exceptions import ArgumentError, JumpstarterException
+from jumpstarter.common.exceptions import ArgumentError, ConfigurationError, JumpstarterException
 from jumpstarter.common.fls import get_fls_github_url
 
 
@@ -305,6 +305,11 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
         # CancelledError is a special case that should be treated as non-retryable
         if isinstance(exception, CancelledError):
             return FlashNonRetryableError("Operation cancelled")
+
+        # ConfigurationError is deterministic and should not be retried
+        config_error = self._find_exception_in_chain(exception, ConfigurationError)
+        if config_error is not None:
+            return FlashNonRetryableError(str(config_error))
 
         # Unknown exception - log full stack trace and wrap as retryable
         self.logger.exception(
@@ -701,9 +706,13 @@ class BaseFlasherClient(FlasherClient, CompositeClient):
             self._download_fls_binary(console, prompt, fls_binary_url, f"Failed to download FLS from {fls_binary_url}")
         elif fls_version != "":
             self.logger.info(f"Downloading FLS version {fls_version} from GitHub releases")
-            # Download fls binary to the target device (always aarch64 for target devices)
             fls_url = get_fls_github_url(fls_version, arch="aarch64")
             self._download_fls_binary(console, prompt, fls_url, f"Failed to download FLS from {fls_url}")
+        else:
+            self.logger.info("Serving FLS binary from exporter container")
+            self.call("setup_fls_binary")
+            fls_url = self.http.get_url() + "/fls"
+            self._download_fls_binary(console, prompt, fls_url, "Failed to download FLS from exporter")
 
         # Flash the image
         creds_file = None

--- a/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver.py
+++ b/python/packages/jumpstarter-driver-flashers/jumpstarter_driver_flashers/driver.py
@@ -79,6 +79,16 @@ class BaseFlasher(Driver):
             return f.read()
 
     @export
+    async def setup_fls_binary(self):
+        """Copy local fls binary to HTTP server root for DUT download"""
+        fls_path = Path("/usr/local/bin/fls-aarch64")
+        if not fls_path.exists():
+            fls_path = Path("/usr/local/bin/fls")
+        if not fls_path.exists():
+            raise ConfigurationError("fls binary not found at /usr/local/bin/fls-aarch64 or /usr/local/bin/fls")
+        await self.http.storage.copy_exporter_file(fls_path, "fls")
+
+    @export
     async def setup_flasher_bundle(self, force_flash_bundle: str | None = None):
         """Setup flasher bundle
 


### PR DESCRIPTION
Serve the fls binary already installed in the exporter container via its HTTP server, Users can still override with --fls-version or --fls-binary-url.

This would help to avoid scenarios in which github is not available for example