### PR TITLE
feat: operator auto-detects version for controller/router image defaults

### DIFF
--- a/controller/deploy/operator/cmd/main.go
+++ b/controller/deploy/operator/cmd/main.go
@@ -228,6 +228,7 @@ func main() {
 		Scheme:             mgr.GetScheme(),
 		EndpointReconciler: endpoints.NewReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetConfig()),
 		Recorder:           mgr.GetEventRecorderFor("jumpstarter-operator"),
+		Version:            version,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Jumpstarter")
 		os.Exit(1)

--- a/controller/deploy/operator/internal/controller/jumpstarter/jumpstarter_controller.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/jumpstarter_controller.go
@@ -63,6 +63,21 @@ type JumpstarterReconciler struct {
 	Scheme             *runtime.Scheme
 	EndpointReconciler *endpoints.Reconciler
 	Recorder           record.EventRecorder
+	Version            string
+}
+
+// resolveImage replaces the :latest tag with the operator's own version tag.
+// If the operator version is unknown ("dev") or the image uses a non-latest tag
+// (admin override), the image is returned unchanged.
+func (r *JumpstarterReconciler) resolveImage(image string) string {
+	if r.Version == "" || r.Version == "dev" {
+		return image
+	}
+	version := strings.TrimPrefix(r.Version, "v")
+	if base, ok := strings.CutSuffix(image, ":latest"); ok {
+		return base + ":" + version
+	}
+	return image
 }
 
 // +kubebuilder:rbac:groups=operator.jumpstarter.dev,resources=jumpstarters,verbs=get;list;watch;create;update;patch;delete
@@ -816,7 +831,7 @@ func (r *JumpstarterReconciler) createControllerDeployment(jumpstarter *operator
 					Containers: []corev1.Container{
 						{
 							Name:            "manager",
-							Image:           jumpstarter.Spec.Controller.Image,
+							Image:           r.resolveImage(jumpstarter.Spec.Controller.Image),
 							ImagePullPolicy: jumpstarter.Spec.Controller.ImagePullPolicy,
 							Args: []string{
 								"--leader-elect",
@@ -1013,7 +1028,7 @@ func (r *JumpstarterReconciler) createRouterDeployment(jumpstarter *operatorv1al
 					Containers: []corev1.Container{
 						{
 							Name:            "router",
-							Image:           jumpstarter.Spec.Routers.Image,
+							Image:           r.resolveImage(jumpstarter.Spec.Routers.Image),
 							ImagePullPolicy: jumpstarter.Spec.Routers.ImagePullPolicy,
 							Command:         []string{"/router"},
 							Env:             envVars,


### PR DESCRIPTION
## Summary
- The operator now resolves `:latest` image defaults to its own version tag at runtime (e.g. `:0.9.0`, `:0.9.0-rc.1`)
- Uses the existing build-time version injected via ldflags (`-X main.version=$(GIT_VERSION)`)
- Admin overrides with explicit image tags pass through unchanged
- Dev builds (`version="dev"`) preserve `:latest` as-is
- Eliminates the need to manually update kubebuilder defaults in `jumpstarter_types.go` during releases

## Test plan
- [ ] Verify operator logs its version at startup
- [ ] Deploy with a tagged operator image → controller/router deployments should use matching version tag
- [ ] Deploy with `:latest` operator (dev build) → controller/router should also use `:latest`
- [ ] Set explicit image override in CR → operator should respect the override, not replace it

🤖 Generated with [Claude Code](https://claude.com/claude-code)