### PR TITLE
ride4: add support for fastboot erase

### DIFF
--- a/python/packages/jumpstarter-driver-ridesx/README.md
+++ b/python/packages/jumpstarter-driver-ridesx/README.md
@@ -61,6 +61,7 @@ Example configuration for the RideSX driver:
 $ jmp shell -l board=qc-ridesx4
 # Flash the device using the artifacts from automotive-image-builder, this uses 3 partition file systems
 $$ j storage flash --target system_a:rootfs.simg --target system_b:qm_var.simg --target boot_a:aboot.img
+$$ j storage erase recoveryinfo
 $$ j power on
 $$ j serial start-console
 ```
@@ -118,6 +119,13 @@ The driver automatically handles compressed images (`.gz`, `.gzip`, `.xz`):
 ridesx_client.flash("/path/to/boot.img.gz", target="boot")
 ```
 
+### Erase Partition
+
+```{code-block} python
+# Erase a partition (boots to fastboot, erases, leaves device in fastboot)
+ridesx_client.erase_partition("recoveryinfo")
+```
+
 ### Power Control
 
 ```{code-block} python
@@ -137,7 +145,7 @@ power_client.cycle(wait=5)  # Wait 5 seconds between off/on
 
 ```{eval-rst}
 .. autoclass:: jumpstarter_driver_ridesx.client.RideSXClient()
-    :members: flash, flash_images, boot_to_fastboot, cli
+    :members: flash, flash_images, erase_partition, boot_to_fastboot, cli
 ```
 
 ### RideSXPowerClient

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/client.py
@@ -33,6 +33,23 @@ class RideSXClient(FlasherClient, CompositeClient):
     def boot_to_fastboot(self):
         return self.call("boot_to_fastboot")
 
+    def erase_partition(self, partition: str) -> dict[str, str]:
+        """Erase a partition on the device via fastboot.
+
+        Args:
+            partition: The partition name to erase (e.g., 'recoveryinfo')
+        """
+        self.logger.info(f"Starting erase operation for partition '{partition}'")
+        self.boot_to_fastboot()
+
+        detection_result = self.call("detect_fastboot_device", 5, 2.0)
+        if detection_result["status"] != "device_found":
+            raise click.ClickException("No fastboot devices found. Make sure device is in fastboot mode.")
+
+        device_id = detection_result["device_id"]
+        self.logger.info(f"Found fastboot device: {device_id}")
+        return self.call("erase_partition", device_id, partition)
+
     def _upload_file_if_needed(self, file_path: str, operator: Operator | None = None) -> str:
         if not file_path or not file_path.strip():
             raise ValueError("File path cannot be empty. Please provide a valid file path.")
@@ -476,6 +493,19 @@ class RideSXClient(FlasherClient, CompositeClient):
         def boot_to_fastboot():
             """Boot to fastboot"""
             self.boot_to_fastboot()
+
+        @base.command()
+        @click.argument("partition")
+        def erase(partition):
+            """Erase a partition using fastboot.
+
+            \b
+            Examples:
+              j storage erase recoveryinfo
+              j storage erase userdata
+            """
+            result = self.erase_partition(partition)
+            click.echo(f"Erased partition '{partition}': {result.get('status')}")
 
         return base
 

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver.py
@@ -20,6 +20,7 @@ class RideSXDriver(Driver):
     decompression_timeout: int = field(default=15 * 60)  # 15 minutes
     flash_timeout: int = field(default=30 * 60)  # 30 minutes
     continue_timeout: int = field(default=20 * 60)  # 20 minutes
+    erase_timeout: int = field(default=120)  # 2 minutes
     storage_dir: str = field(default="/var/lib/jumpstarter/ridesx")
 
     # FLS configuration
@@ -325,6 +326,40 @@ class RideSXDriver(Driver):
         except FileNotFoundError:
             self.logger.error("FLS command not found - ensure FLS is installed and in PATH")
             raise RuntimeError("FLS command not found") from None
+
+    @export
+    def erase_partition(self, device_id: str, partition: str) -> dict[str, str]:
+        """Erase a partition using fastboot
+
+        Args:
+            device_id: The fastboot device ID
+            partition: The partition name to erase (e.g., 'recoveryinfo')
+        """
+        if not partition or not partition.strip():
+            raise ValueError("Partition name cannot be empty")
+
+        self.logger.info(f"Erasing partition '{partition}' on device {device_id}")
+
+        cmd = ["fastboot", "-s", device_id, "erase", partition]
+        self.logger.debug(f"Running command: {' '.join(cmd)}")
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=self.erase_timeout)
+            self.logger.info(f"Successfully erased partition '{partition}'")
+            self.logger.debug(f"Erase stdout: {result.stdout}")
+            if result.stderr:
+                self.logger.debug(f"Erase stderr: {result.stderr}")
+            return {"status": "success", "partition": partition, "output": result.stdout}
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"Failed to erase partition '{partition}' - return code: {e.returncode}")
+            self.logger.error(f"stdout: {e.stdout}")
+            self.logger.error(f"stderr: {e.stderr}")
+            raise RuntimeError(f"Failed to erase partition '{partition}': {e.stderr or e.stdout}") from e
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"Timeout while erasing partition '{partition}'")
+            raise RuntimeError(f"Timeout while erasing partition '{partition}'") from None
+        except FileNotFoundError:
+            raise RuntimeError("fastboot command not found") from None
 
     @export
     async def boot_to_fastboot(self):

--- a/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver_test.py
+++ b/python/packages/jumpstarter-driver-ridesx/jumpstarter_driver_ridesx/driver_test.py
@@ -407,6 +407,67 @@ def test_flash_with_fastboot_continue_failure(temp_storage_dir, ridesx_driver):
             assert mock_subprocess.call_count == 2
 
 
+# Erase Partition Tests
+
+
+def test_erase_partition_success(ridesx_driver):
+    with serve(ridesx_driver) as client:
+        with patch("subprocess.run") as mock_subprocess:
+            mock_result = MagicMock()
+            mock_result.stdout = "Finished. Total time: 0.042s"
+            mock_result.stderr = ""
+            mock_result.returncode = 0
+            mock_subprocess.return_value = mock_result
+
+            result = client.call("erase_partition", "ABC123", "recoveryinfo")
+
+            assert result["status"] == "success"
+            assert result["partition"] == "recoveryinfo"
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args[0][0]
+            assert call_args == ["fastboot", "-s", "ABC123", "erase", "recoveryinfo"]
+
+
+def test_erase_partition_failure(ridesx_driver):
+    with serve(ridesx_driver) as client:
+        from jumpstarter.client.core import DriverError
+
+        with patch("subprocess.run") as mock_subprocess:
+            error = subprocess.CalledProcessError(1, "fastboot")
+            error.stdout = ""
+            error.stderr = "FAILED (remote: Partition not found)"
+            mock_subprocess.side_effect = error
+
+            with pytest.raises(DriverError, match="Failed to erase partition"):
+                client.call("erase_partition", "ABC123", "recoveryinfo")
+
+
+def test_erase_partition_timeout(ridesx_driver):
+    with serve(ridesx_driver) as client:
+        from jumpstarter.client.core import DriverError
+
+        with patch("subprocess.run") as mock_subprocess:
+            mock_subprocess.side_effect = subprocess.TimeoutExpired("fastboot", 120)
+
+            with pytest.raises(DriverError, match="Timeout while erasing"):
+                client.call("erase_partition", "ABC123", "recoveryinfo")
+
+
+def test_erase_partition_fastboot_not_found(ridesx_driver):
+    with serve(ridesx_driver) as client:
+        from jumpstarter.client.core import DriverError
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("fastboot not found")):
+            with pytest.raises(DriverError, match="fastboot command not found"):
+                client.call("erase_partition", "ABC123", "recoveryinfo")
+
+
+def test_erase_partition_empty_name(ridesx_driver):
+    with serve(ridesx_driver) as client:
+        with pytest.raises(ValueError, match="Partition name cannot be empty"):
+            client.call("erase_partition", "ABC123", "")
+
+
 def test_power_missing_serial():
     with pytest.raises(ConfigurationError):
         RideSXPowerDriver(children={})
@@ -542,9 +603,7 @@ def test_flash_oci_image_with_credentials(temp_storage_dir, ridesx_driver):
                 mock_result.returncode = 0
                 mock_subprocess.return_value = mock_result
 
-                result = client.call(
-                    "flash_oci_image", "oci://quay.io/private/image:tag", None, "myuser", "mypass"
-                )
+                result = client.call("flash_oci_image", "oci://quay.io/private/image:tag", None, "myuser", "mypass")
 
                 assert result["status"] == "success"
                 # Credentials should NOT appear in the command args


### PR DESCRIPTION
Support `fastboot erase` operation via the ride4 driver.
This allows erasing partitions the following way:

```shell
j storage erase recoveryinfo
```
