### PR TITLE
Address review comments on auth logging (into PR #812 branch)

### DIFF
--- a/controller/internal/log/peer.go
+++ b/controller/internal/log/peer.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"context"
+	"net"
+
+	"google.golang.org/grpc/peer"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// PeerAddr returns the remote IP address from the gRPC peer info stored in ctx,
+// or "unknown" if unavailable. Port number and transport paths (e.g. Unix socket
+// paths) are intentionally stripped to avoid leaking internal details.
+func PeerAddr(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr == nil {
+		return "unknown"
+	}
+	host, _, err := net.SplitHostPort(p.Addr.String())
+	if err != nil {
+		return "unknown"
+	}
+	return host
+}
+
+// LogContext returns ctx with its logger enriched with the peer address under
+// the "peer" key ("unknown" when no usable address is available, so all log
+// lines share a uniform shape). The gRPC interceptors apply this to every RPC;
+// it owns the peer enrichment, so loggers derived from ctx (including the auth
+// package's failure logs) must not add "peer" again.
+func LogContext(ctx context.Context) context.Context {
+	return ctrllog.IntoContext(ctx, ctrllog.FromContext(ctx, "peer", PeerAddr(ctx)))
+}

--- a/controller/internal/log/peer_test.go
+++ b/controller/internal/log/peer_test.go
@@ -1,0 +1,210 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	grpcpeer "google.golang.org/grpc/peer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// fakeAddr implements net.Addr for injecting peer addresses into context.
+type fakeAddr struct {
+	network string
+	addr    string
+}
+
+func (a fakeAddr) Network() string { return a.network }
+func (a fakeAddr) String() string  { return a.addr }
+
+// ctxWithPeer creates a context with a gRPC peer carrying the given address.
+func ctxWithPeer(addr string) context.Context {
+	return grpcpeer.NewContext(context.Background(), &grpcpeer.Peer{
+		Addr: fakeAddr{network: "tcp", addr: addr},
+	})
+}
+
+// withCapturedLog creates a buffer-backed logr.Logger for use in tests and
+// returns the buffer plus a context enriched with that logger. It does NOT
+// mutate the global logf.Log, so tests are isolated from each other.
+func withCapturedLog(t *testing.T) (*bytes.Buffer, context.Context) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := ctrlzap.New(ctrlzap.UseDevMode(true), ctrlzap.WriteTo(&buf))
+	ctx := logf.IntoContext(context.Background(), logger)
+	return &buf, ctx
+}
+
+// peerAddrUnknown is the expected return value when PeerAddr cannot determine
+// the remote IP (no peer, nil Addr, unparsable address, etc.).
+const peerAddrUnknown = "unknown"
+
+// ---------------------------------------------------------------------------
+// PeerAddr tests
+// ---------------------------------------------------------------------------
+
+func TestPeerAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		expected string
+	}{
+		{
+			name:     "no peer in context returns unknown",
+			ctx:      context.Background(),
+			expected: peerAddrUnknown,
+		},
+		{
+			name:     "peer with host:port returns host only",
+			ctx:      ctxWithPeer("10.0.0.5:43210"),
+			expected: "10.0.0.5",
+		},
+		{
+			name:     "peer with IPv6 [host]:port returns host only",
+			ctx:      ctxWithPeer("[::1]:8080"),
+			expected: "::1",
+		},
+		{
+			name:     "peer with bare address (no port) returns unknown",
+			ctx:      ctxWithPeer("no-port-here"),
+			expected: peerAddrUnknown,
+		},
+		{
+			name:     "peer with empty address returns unknown",
+			ctx:      ctxWithPeer(""),
+			expected: peerAddrUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PeerAddr(tc.ctx)
+			if got != tc.expected {
+				t.Errorf("PeerAddr() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestPeerAddr_NilAddr covers the edge case of a peer with a nil Addr.
+func TestPeerAddr_NilAddr(t *testing.T) {
+	ctx := grpcpeer.NewContext(context.Background(), &grpcpeer.Peer{
+		Addr: nil,
+	})
+	// PeerAddr must not panic when p.Addr is nil and should return "unknown".
+	got := PeerAddr(ctx)
+	if got != peerAddrUnknown {
+		t.Errorf("PeerAddr with nil Addr = %q, want %q", got, peerAddrUnknown)
+	}
+}
+
+// TestPeerAddr_UnixSocket covers peers connected over a unix socket.
+func TestPeerAddr_UnixSocket(t *testing.T) {
+	ctx := grpcpeer.NewContext(context.Background(), &grpcpeer.Peer{
+		Addr: &net.UnixAddr{Name: "/var/run/jumpstarter.sock", Net: "unix"},
+	})
+	got := PeerAddr(ctx)
+	// A Unix socket path should not be returned; it should return "unknown"
+	// because SplitHostPort will fail on "/var/run/jumpstarter.sock".
+	if got != peerAddrUnknown {
+		t.Errorf("PeerAddr for unix socket = %q, want %q", got, peerAddrUnknown)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LogContext tests
+// ---------------------------------------------------------------------------
+
+func TestLogContext_WithPeer_EnrichesContextWithPeerIP(t *testing.T) {
+	buf, ctx := withCapturedLog(t)
+
+	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
+		Addr: fakeAddr{network: "tcp", addr: "10.20.30.40:9090"},
+	})
+
+	enriched := LogContext(ctx)
+
+	// Use the enriched context's logger and emit a message.
+	logf.FromContext(enriched).Info("test message")
+
+	logged := buf.String()
+	if !strings.Contains(logged, "10.20.30.40") {
+		t.Errorf("expected peer IP '10.20.30.40' in log output, got:\n%s", logged)
+	}
+	// Port should be stripped.
+	if strings.Contains(logged, "9090") {
+		t.Errorf("expected port to be stripped from peer address, got:\n%s", logged)
+	}
+}
+
+func TestLogContext_WithoutPeer_LogsUnknownPeer(t *testing.T) {
+	buf, ctx := withCapturedLog(t)
+
+	enriched := LogContext(ctx)
+
+	logf.FromContext(enriched).Info("test message")
+
+	logged := buf.String()
+	// The peer key is always present; without peer info it falls back to
+	// "unknown" so all log lines share a uniform shape.
+	if !strings.Contains(logged, "peer") || !strings.Contains(logged, "unknown") {
+		t.Errorf("expected 'peer' key with value 'unknown' without peer info, got:\n%s", logged)
+	}
+}
+
+func TestLogContext_IPv6Peer_StripsPort(t *testing.T) {
+	buf, ctx := withCapturedLog(t)
+
+	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
+		Addr: fakeAddr{network: "tcp", addr: "[::1]:8082"},
+	})
+
+	enriched := LogContext(ctx)
+	logf.FromContext(enriched).Info("ipv6 test")
+
+	logged := buf.String()
+	if !strings.Contains(logged, "::1") {
+		t.Errorf("expected IPv6 address '::1' in log, got:\n%s", logged)
+	}
+}
+
+func TestLogContext_NilAddr_LogsUnknownPeer(t *testing.T) {
+	buf, ctx := withCapturedLog(t)
+
+	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{Addr: nil})
+
+	// Should not panic and should fall back to peer="unknown".
+	enriched := LogContext(ctx)
+	logf.FromContext(enriched).Info("nil addr test")
+
+	logged := buf.String()
+	if !strings.Contains(logged, "peer") || !strings.Contains(logged, "unknown") {
+		t.Errorf("expected 'peer' key with value 'unknown' for nil Addr, got:\n%s", logged)
+	}
+}
+
+func TestLogContext_UnixSocket_ReturnsUnknownPeer(t *testing.T) {
+	buf, ctx := withCapturedLog(t)
+
+	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
+		Addr: &net.UnixAddr{Name: "/var/run/test.sock", Net: "unix"},
+	})
+
+	enriched := LogContext(ctx)
+	logf.FromContext(enriched).Info("unix socket test")
+
+	logged := buf.String()
+	// The peer key should be present but with value "unknown" because
+	// SplitHostPort fails on unix paths.
+	if !strings.Contains(logged, "unknown") {
+		t.Errorf("expected 'unknown' peer for unix socket, got:\n%s", logged)
+	}
+	// The socket path itself should NOT appear.
+	if strings.Contains(logged, "/var/run/test.sock") {
+		t.Errorf("unix socket path should not leak into log, got:\n%s", logged)
+	}
+}

--- a/controller/internal/service/auth/auth.go
+++ b/controller/internal/service/auth/auth.go
@@ -2,43 +2,17 @@ package auth
 
 import (
 	"context"
-	"net"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter-controller/internal/authentication"
 	"github.com/jumpstarter-dev/jumpstarter-controller/internal/authorization"
 	"github.com/jumpstarter-dev/jumpstarter-controller/internal/oidc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-// PeerAddr returns the remote IP address from the gRPC peer info stored in ctx,
-// or "unknown" if unavailable. Port number and transport paths (e.g. Unix socket
-// paths) are intentionally stripped to avoid leaking internal details.
-func PeerAddr(ctx context.Context) string {
-	p, ok := peer.FromContext(ctx)
-	if !ok || p.Addr == nil {
-		return "unknown"
-	}
-	host, _, err := net.SplitHostPort(p.Addr.String())
-	if err != nil {
-		return "unknown"
-	}
-	return host
-}
-
-// LogContext returns ctx with its logger enriched with the peer address under
-// the "peer" key ("unknown" when no usable address is available, so all log
-// lines share a uniform shape). The gRPC interceptors apply this to every RPC;
-// it owns the peer enrichment, so loggers derived from ctx (including the
-// auth-failure logs below) must not add "peer" again.
-func LogContext(ctx context.Context) context.Context {
-	return log.IntoContext(ctx, log.FromContext(ctx, "peer", PeerAddr(ctx)))
-}
 
 type Auth struct {
 	client kclient.Client
@@ -64,7 +38,8 @@ func NewAuth(
 // VerifyClient authenticates the client token in ctx and returns the matching
 // Client object without enforcing a namespace. Authentication failures are
 // logged via the context logger, which carries the peer address when the
-// caller applied LogContext (as the gRPC interceptors do).
+// caller applied the shared log package's LogContext (as the gRPC
+// interceptors do).
 func (s *Auth) VerifyClient(ctx context.Context) (*jumpstarterdevv1alpha1.Client, error) {
 	jclient, err := oidc.VerifyClientObjectToken(
 		ctx,
@@ -100,7 +75,8 @@ func (s *Auth) AuthClient(ctx context.Context, namespace string) (*jumpstarterde
 // VerifyExporter authenticates the exporter token in ctx and returns the
 // matching Exporter object without enforcing a namespace. Authentication
 // failures are logged via the context logger, which carries the peer address
-// when the caller applied LogContext (as the gRPC interceptors do).
+// when the caller applied the shared log package's LogContext (as the gRPC
+// interceptors do).
 func (s *Auth) VerifyExporter(ctx context.Context) (*jumpstarterdevv1alpha1.Exporter, error) {
 	jexporter, err := oidc.VerifyExporterObjectToken(
 		ctx,

--- a/controller/internal/service/auth/auth_test.go
+++ b/controller/internal/service/auth/auth_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"strings"
 	"testing"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter-controller/internal/authentication"
+	jlog "github.com/jumpstarter-dev/jumpstarter-controller/internal/log"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	grpcpeer "google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +38,19 @@ type stubAuthenticator struct {
 
 func (s *stubAuthenticator) AuthenticateContext(_ context.Context) (*authenticator.Response, bool, error) {
 	return s.resp, s.ok, s.err
+}
+
+// recordingTokenAuthenticator implements authenticator.Token. It records the
+// bearer token it is handed so tests can prove the token actually traversed
+// the production extraction path (metadata -> BearerTokenFromContext ->
+// AuthenticateToken), and fails with a generic error like the real verifier.
+type recordingTokenAuthenticator struct {
+	received string
+}
+
+func (r *recordingTokenAuthenticator) AuthenticateToken(_ context.Context, token string) (*authenticator.Response, bool, error) {
+	r.received = token
+	return nil, false, fmt.Errorf("token verification failed")
 }
 
 type stubAttributesGetter struct {
@@ -74,67 +89,16 @@ func ctxWithPeer(addr string) context.Context {
 }
 
 // captureLog sets up a buffer-backed logger and returns the buffer and a
-// context enriched with that logger, with LogContext applied on top exactly
-// like the gRPC interceptors do in production (that is what adds the "peer"
-// key to the auth-failure logs). The caller can inspect buf.String() after
-// the code under test runs. It does NOT mutate the global logf.Log, so tests
-// are isolated from each other and safe for t.Parallel().
+// context enriched with that logger, with jlog.LogContext applied on top
+// exactly like the gRPC interceptors do in production (that is what adds the
+// "peer" key to the auth-failure logs). The caller can inspect buf.String()
+// after the code under test runs. It does NOT mutate the global logf.Log, so
+// tests are isolated from each other and safe for t.Parallel().
 func captureLog(t *testing.T, ctx context.Context) (context.Context, *bytes.Buffer) {
 	t.Helper()
 	var buf bytes.Buffer
 	logger := ctrlzap.New(ctrlzap.UseDevMode(true), ctrlzap.WriteTo(&buf))
-	return LogContext(logf.IntoContext(ctx, logger)), &buf
-}
-
-// peerAddrUnknown is the expected return value when PeerAddr cannot determine
-// the remote IP (no peer, nil Addr, unparsable address, etc.).
-const peerAddrUnknown = "unknown"
-
-// ---------------------------------------------------------------------------
-// PeerAddr tests
-// ---------------------------------------------------------------------------
-
-func TestPeerAddr(t *testing.T) {
-	tests := []struct {
-		name     string
-		ctx      context.Context
-		expected string
-	}{
-		{
-			name:     "no peer in context returns unknown",
-			ctx:      context.Background(),
-			expected: peerAddrUnknown,
-		},
-		{
-			name:     "peer with host:port returns host only",
-			ctx:      ctxWithPeer("10.0.0.5:43210"),
-			expected: "10.0.0.5",
-		},
-		{
-			name:     "peer with IPv6 [host]:port returns host only",
-			ctx:      ctxWithPeer("[::1]:8080"),
-			expected: "::1",
-		},
-		{
-			name:     "peer with bare address (no port) returns unknown",
-			ctx:      ctxWithPeer("no-port-here"),
-			expected: peerAddrUnknown,
-		},
-		{
-			name:     "peer with empty address returns unknown",
-			ctx:      ctxWithPeer(""),
-			expected: peerAddrUnknown,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := PeerAddr(tc.ctx)
-			if got != tc.expected {
-				t.Errorf("PeerAddr() = %q, want %q", got, tc.expected)
-			}
-		})
-	}
+	return jlog.LogContext(logf.IntoContext(ctx, logger)), &buf
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +118,7 @@ func newFakeClient(objs ...kclient.Object) kclient.Client {
 		Build()
 }
 
-func newAuth(authn *stubAuthenticator, authz *stubAuthorizer, attr *stubAttributesGetter, objs ...kclient.Object) *Auth {
+func newAuth(authn authentication.ContextAuthenticator, authz *stubAuthorizer, attr *stubAttributesGetter, objs ...kclient.Object) *Auth {
 	return NewAuth(newFakeClient(objs...), authn, authz, attr)
 }
 
@@ -455,104 +419,84 @@ func TestVerifyExporter_TokenVerificationFailure_LogsPeerAndError(t *testing.T) 
 }
 
 // ---------------------------------------------------------------------------
-// Auth logging: no duplicate log on error (controller-service level should not
-// re-log what auth already logs)
+// Token leak tests — verify that sensitive token values never appear in logs.
+//
+// The sensitive token is injected as real incoming gRPC metadata and the Auth
+// is built with the production BearerTokenAuthenticator, so the token travels
+// the same extraction path as production traffic (metadata ->
+// BearerTokenFromContext -> AuthenticateToken). The tests then prove the
+// token was actually seen by the verifier before asserting it is absent from
+// the log output — a regression that logs the authorization header or request
+// metadata would make them fail.
 // ---------------------------------------------------------------------------
 
-func TestAuthClient_ErrorLogIncludesNoDuplicateTokenInMessage(t *testing.T) {
-	// Ensure the error message itself doesn't echo back the token.
-	// The auth layer only logs "client authentication failed" + the error
-	// string from the verification layer.
-	authn := &stubAuthenticator{err: fmt.Errorf("token verification failed")}
-	attr := &stubAttributesGetter{}
-	authz := &stubAuthorizer{}
+// sensitiveToken is the bearer token value that must never appear in logs.
+const sensitiveToken = "header.payload.signature-secret-value"
 
-	ctx := ctxWithPeer("10.0.0.1:1234")
-	ctx, buf := captureLog(t, ctx)
-
-	a := newAuth(authn, authz, attr)
-	_, _ = a.AuthClient(ctx, "default")
-
-	logged := buf.String()
-	// The log should never contain the word "Bearer" or raw token material.
-	if strings.Contains(logged, "Bearer") {
-		t.Errorf("log should not contain raw bearer prefix:\n%s", logged)
-	}
+// ctxWithBearerToken returns ctx with incoming gRPC metadata carrying
+// "authorization: Bearer <token>", like a real authenticated request.
+func ctxWithBearerToken(ctx context.Context, token string) context.Context {
+	return metadata.NewIncomingContext(ctx, metadata.Pairs("authorization", "Bearer "+token))
 }
 
-// ---------------------------------------------------------------------------
-// Token leak tests — verify that sensitive token values never appear in logs.
-// Replicates the TestRouterAuthenticateNoTokenLeak pattern from
-// controller_service_test.go for the auth package.
-// ---------------------------------------------------------------------------
-
 func TestAuthClient_NoTokenLeak(t *testing.T) {
-	const sensitiveToken = "header.payload.signature-secret-value"
-
-	// The stub error does NOT include the token — this mirrors the real
-	// oidc.VerifyClientObjectToken which returns generic error messages.
-	authn := &stubAuthenticator{err: fmt.Errorf("token verification failed")}
+	rec := &recordingTokenAuthenticator{}
+	authn := authentication.NewBearerTokenAuthenticator(rec)
 	attr := &stubAttributesGetter{}
 	authz := &stubAuthorizer{}
 
-	ctx := ctxWithPeer("10.0.0.1:1234")
+	ctx := ctxWithBearerToken(ctxWithPeer("10.0.0.1:1234"), sensitiveToken)
 	ctx, buf := captureLog(t, ctx)
 
 	a := newAuth(authn, authz, attr)
-	_, _ = a.AuthClient(ctx, "default")
+	if _, err := a.AuthClient(ctx, "default"); err == nil {
+		t.Fatal("expected authentication to fail, got nil error")
+	}
+
+	// The token must have traversed the production extraction path — this is
+	// what makes the absence assertions below meaningful.
+	if rec.received != sensitiveToken {
+		t.Fatalf("token authenticator received %q, want %q", rec.received, sensitiveToken)
+	}
 
 	logged := buf.String()
+	if !strings.Contains(logged, "client authentication failed") {
+		t.Fatalf("expected 'client authentication failed' in log, got:\n%s", logged)
+	}
 	if strings.Contains(logged, sensitiveToken) {
 		t.Errorf("JWT token value leaked in auth log output:\n%s", logged)
+	}
+	if strings.Contains(logged, "Bearer") {
+		t.Errorf("raw bearer header leaked in auth log output:\n%s", logged)
 	}
 }
 
 func TestAuthExporter_NoTokenLeak(t *testing.T) {
-	const sensitiveToken = "header.payload.signature-secret-value"
-
-	authn := &stubAuthenticator{err: fmt.Errorf("token verification failed")}
+	rec := &recordingTokenAuthenticator{}
+	authn := authentication.NewBearerTokenAuthenticator(rec)
 	attr := &stubAttributesGetter{}
 	authz := &stubAuthorizer{}
 
-	ctx := ctxWithPeer("10.0.0.1:1234")
+	ctx := ctxWithBearerToken(ctxWithPeer("10.0.0.1:1234"), sensitiveToken)
 	ctx, buf := captureLog(t, ctx)
 
 	a := newAuth(authn, authz, attr)
-	_, _ = a.AuthExporter(ctx, "default")
+	if _, err := a.AuthExporter(ctx, "default"); err == nil {
+		t.Fatal("expected authentication to fail, got nil error")
+	}
+
+	if rec.received != sensitiveToken {
+		t.Fatalf("token authenticator received %q, want %q", rec.received, sensitiveToken)
+	}
 
 	logged := buf.String()
+	if !strings.Contains(logged, "exporter authentication failed") {
+		t.Fatalf("expected 'exporter authentication failed' in log, got:\n%s", logged)
+	}
 	if strings.Contains(logged, sensitiveToken) {
 		t.Errorf("JWT token value leaked in auth log output:\n%s", logged)
 	}
-}
-
-// ---------------------------------------------------------------------------
-// PeerAddr with nil Addr in peer (edge case)
-// ---------------------------------------------------------------------------
-
-func TestPeerAddr_NilAddr(t *testing.T) {
-	ctx := grpcpeer.NewContext(context.Background(), &grpcpeer.Peer{
-		Addr: nil,
-	})
-	// PeerAddr must not panic when p.Addr is nil and should return "unknown".
-	got := PeerAddr(ctx)
-	if got != peerAddrUnknown {
-		t.Errorf("PeerAddr with nil Addr = %q, want %q", got, peerAddrUnknown)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// PeerAddr with a unix socket address
-// ---------------------------------------------------------------------------
-
-func TestPeerAddr_UnixSocket(t *testing.T) {
-	ctx := grpcpeer.NewContext(context.Background(), &grpcpeer.Peer{
-		Addr: &net.UnixAddr{Name: "/var/run/jumpstarter.sock", Net: "unix"},
-	})
-	got := PeerAddr(ctx)
-	// A Unix socket path should not be returned; it should return "unknown"
-	// because SplitHostPort will fail on "/var/run/jumpstarter.sock".
-	if got != peerAddrUnknown {
-		t.Errorf("PeerAddr for unix socket = %q, want %q", got, peerAddrUnknown)
+	if strings.Contains(logged, "Bearer") {
+		t.Errorf("raw bearer header leaked in auth log output:\n%s", logged)
 	}
 }

--- a/controller/internal/service/controller_service.go
+++ b/controller/internal/service/controller_service.go
@@ -85,6 +85,8 @@ type ControllerService struct {
 	Signer        *oidc.Signer
 	listenQueues  sync.Map
 	leaseLocks    sync.Map
+	authOnce      sync.Once
+	auth          *auth.Auth
 }
 
 type listenQueue struct {
@@ -206,26 +208,30 @@ type wrappedStream struct {
 	grpc.ServerStream
 }
 
-// logContext enriches the context logger with the peer address so every log
-// line (including auth failures logged by the auth package) carries a "peer"
-// key. See auth.LogContext for the enrichment semantics.
-func logContext(ctx context.Context) context.Context {
-	return auth.LogContext(ctx)
+func (w *wrappedStream) Context() context.Context {
+	return jlog.LogContext(w.ServerStream.Context())
 }
 
-func (w *wrappedStream) Context() context.Context {
-	return logContext(w.ServerStream.Context())
+// getAuth lazily builds the shared *auth.Auth from the service's immutable
+// dependencies on first use. Lazy init (rather than init in Start) keeps bare
+// &ControllerService{...} construction working, which tests rely on to call
+// RPC methods without Start; sync.Once makes the first concurrent RPCs safe.
+func (s *ControllerService) getAuth() *auth.Auth {
+	s.authOnce.Do(func() {
+		s.auth = auth.NewAuth(s.Client, s.Authn, s.Authz, s.Attr)
+	})
+	return s.auth
 }
 
 // authenticateClient and authenticateExporter delegate to the auth package,
 // which owns auth-failure logging (with peer address) for all services.
 
 func (s *ControllerService) authenticateClient(ctx context.Context) (*jumpstarterdevv1alpha1.Client, error) {
-	return auth.NewAuth(s.Client, s.Authn, s.Authz, s.Attr).VerifyClient(ctx)
+	return s.getAuth().VerifyClient(ctx)
 }
 
 func (s *ControllerService) authenticateExporter(ctx context.Context) (*jumpstarterdevv1alpha1.Exporter, error) {
-	return auth.NewAuth(s.Client, s.Authn, s.Authz, s.Attr).VerifyExporter(ctx)
+	return s.getAuth().VerifyExporter(ctx)
 }
 
 func (s *ControllerService) Register(ctx context.Context, req *pb.RegisterRequest) (*pb.RegisterResponse, error) {
@@ -1116,7 +1122,7 @@ func (s *ControllerService) Start(ctx context.Context) error {
 			_ *grpc.UnaryServerInfo,
 			handler grpc.UnaryHandler,
 		) (resp any, err error) {
-			return handler(logContext(gctx), req)
+			return handler(jlog.LogContext(gctx), req)
 		}, recovery.UnaryServerInterceptor()),
 		grpc.ChainStreamInterceptor(func(
 			srv any,
@@ -1132,7 +1138,7 @@ func (s *ControllerService) Start(ctx context.Context) error {
 	pb.RegisterControllerServiceServer(server, s)
 	cpb.RegisterClientServiceServer(
 		server,
-		clientsvcv1.NewClientService(s.Client, *auth.NewAuth(s.Client, s.Authn, s.Authz, s.Attr), s.effectiveMaxTags(), s.Signer),
+		clientsvcv1.NewClientService(s.Client, *s.getAuth(), s.effectiveMaxTags(), s.Signer),
 	)
 
 	// Register the standard gRPC health checking service (grpc.health.v1.Health).

--- a/controller/internal/service/controller_service_test.go
+++ b/controller/internal/service/controller_service_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	jlog "github.com/jumpstarter-dev/jumpstarter-controller/internal/log"
 	pb "github.com/jumpstarter-dev/jumpstarter-controller/internal/protocol/jumpstarter/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1823,11 +1823,11 @@ func TestRouterAuthenticateNoTokenLeak(t *testing.T) {
 	})
 
 	// Reproduce the exact logging path from RouterService.Stream:
-	//   ctx = logContext(stream.Context())
+	//   ctx = jlog.LogContext(stream.Context())
 	//   logger := log.FromContext(ctx)
 	//   _, err := s.authenticate(ctx)
 	//   logger.Info("router authentication failed", "error", err.Error())
-	ctx = logContext(ctx)
+	ctx = jlog.LogContext(ctx)
 	logger := logf.FromContext(ctx)
 
 	svc := &RouterService{}
@@ -1907,100 +1907,6 @@ func (a fakeAddr) Network() string { return a.network }
 func (a fakeAddr) String() string  { return a.addr }
 
 // ---------------------------------------------------------------------------
-// logContext tests
-// ---------------------------------------------------------------------------
-
-func TestLogContext_WithPeer_EnrichesContextWithPeerIP(t *testing.T) {
-	buf, ctx := withCapturedLog(t)
-
-	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
-		Addr: fakeAddr{network: "tcp", addr: "10.20.30.40:9090"},
-	})
-
-	enriched := logContext(ctx)
-
-	// Use the enriched context's logger and emit a message.
-	logf.FromContext(enriched).Info("test message")
-
-	logged := buf.String()
-	if !strings.Contains(logged, "10.20.30.40") {
-		t.Errorf("expected peer IP '10.20.30.40' in log output, got:\n%s", logged)
-	}
-	// Port should be stripped.
-	if strings.Contains(logged, "9090") {
-		t.Errorf("expected port to be stripped from peer address, got:\n%s", logged)
-	}
-}
-
-func TestLogContext_WithoutPeer_LogsUnknownPeer(t *testing.T) {
-	buf, ctx := withCapturedLog(t)
-
-	enriched := logContext(ctx)
-
-	logf.FromContext(enriched).Info("test message")
-
-	logged := buf.String()
-	// The peer key is always present; without peer info it falls back to
-	// "unknown" so all log lines share a uniform shape.
-	if !strings.Contains(logged, "peer") || !strings.Contains(logged, "unknown") {
-		t.Errorf("expected 'peer' key with value 'unknown' without peer info, got:\n%s", logged)
-	}
-}
-
-func TestLogContext_IPv6Peer_StripsPort(t *testing.T) {
-	buf, ctx := withCapturedLog(t)
-
-	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
-		Addr: fakeAddr{network: "tcp", addr: "[::1]:8082"},
-	})
-
-	enriched := logContext(ctx)
-	logf.FromContext(enriched).Info("ipv6 test")
-
-	logged := buf.String()
-	if !strings.Contains(logged, "::1") {
-		t.Errorf("expected IPv6 address '::1' in log, got:\n%s", logged)
-	}
-}
-
-func TestLogContext_NilAddr_LogsUnknownPeer(t *testing.T) {
-	buf, ctx := withCapturedLog(t)
-
-	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{Addr: nil})
-
-	// Should not panic and should fall back to peer="unknown".
-	enriched := logContext(ctx)
-	logf.FromContext(enriched).Info("nil addr test")
-
-	logged := buf.String()
-	if !strings.Contains(logged, "peer") || !strings.Contains(logged, "unknown") {
-		t.Errorf("expected 'peer' key with value 'unknown' for nil Addr, got:\n%s", logged)
-	}
-}
-
-func TestLogContext_UnixSocket_ReturnsUnknownPeer(t *testing.T) {
-	buf, ctx := withCapturedLog(t)
-
-	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
-		Addr: &net.UnixAddr{Name: "/var/run/test.sock", Net: "unix"},
-	})
-
-	enriched := logContext(ctx)
-	logf.FromContext(enriched).Info("unix socket test")
-
-	logged := buf.String()
-	// The peer key should be present but with value "unknown" because
-	// SplitHostPort fails on unix paths.
-	if !strings.Contains(logged, "unknown") {
-		t.Errorf("expected 'unknown' peer for unix socket, got:\n%s", logged)
-	}
-	// The socket path itself should NOT appear.
-	if strings.Contains(logged, "/var/run/test.sock") {
-		t.Errorf("unix socket path should not leak into log, got:\n%s", logged)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Verify that controller-service methods do NOT double-log auth failures.
 // The auth helpers in auth/auth.go own the auth-failure logging; the
 // controller_service RPC methods should NOT add their own log lines.
@@ -2063,14 +1969,14 @@ func (noopAuthorizer) Authorize(_ context.Context, _ authorizer.Attributes) (aut
 
 // authFailureServiceCtx builds a ControllerService whose authentication always
 // fails, plus a context carrying a peer address, a captured logger, and the
-// logContext enrichment applied by the gRPC interceptors in production.
+// jlog.LogContext enrichment applied by the gRPC interceptors in production.
 func authFailureServiceCtx(t *testing.T, peerAddr string) (*ControllerService, context.Context, *bytes.Buffer) {
 	t.Helper()
 	buf, ctx := withCapturedLog(t)
 	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{
 		Addr: fakeAddr{network: "tcp", addr: peerAddr},
 	})
-	ctx = logContext(ctx)
+	ctx = jlog.LogContext(ctx)
 
 	svc := &ControllerService{
 		Authn: &failingAuthenticator{err: fmt.Errorf("token verification failed")},
@@ -2163,7 +2069,7 @@ func (f *fakeServerStream) Context() context.Context { return f.ctx }
 
 // TestWrappedStreamContext_EnrichesPeer verifies the stream-interceptor
 // wrapper enriches the stream context logger with the peer address, exactly
-// like the unary interceptor does via logContext.
+// like the unary interceptor does via jlog.LogContext.
 func TestWrappedStreamContext_EnrichesPeer(t *testing.T) {
 	buf, ctx := withCapturedLog(t)
 	ctx = grpcpeer.NewContext(ctx, &grpcpeer.Peer{

--- a/controller/internal/service/router_service.go
+++ b/controller/internal/service/router_service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"github.com/jumpstarter-dev/jumpstarter-controller/internal/authentication"
+	jlog "github.com/jumpstarter-dev/jumpstarter-controller/internal/log"
 	pb "github.com/jumpstarter-dev/jumpstarter-controller/internal/protocol/jumpstarter/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -82,7 +83,7 @@ func (s *RouterService) authenticate(ctx context.Context) (string, error) {
 }
 
 func (s *RouterService) Stream(stream pb.RouterService_StreamServer) error {
-	ctx := logContext(stream.Context())
+	ctx := jlog.LogContext(stream.Context())
 	logger := log.FromContext(ctx)
 
 	streamName, err := s.authenticate(ctx)

--- a/python/packages/jumpstarter/jumpstarter/exporter/session_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/session_test.py
@@ -450,6 +450,12 @@ async def test_serve_tcp_passphrase_rejected_logs_warning(caplog):
     assert "GetReport" in auth_warnings[0].message, (
         f"expected RPC method name 'GetReport' in warning, got: {auth_warnings[0].message}"
     )
+    # Neither the server secret nor the client-supplied passphrase may appear
+    # in any log record.
+    for record in caplog.records:
+        message = record.getMessage()
+        assert passphrase not in message, f"server passphrase leaked in log: {message}"
+        assert "wrong-passphrase" not in message, f"client passphrase leaked in log: {message}"
 
 
 @pytest.mark.anyio
@@ -473,6 +479,10 @@ async def test_serve_tcp_passphrase_missing_logs_warning(caplog):
     auth_warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "authentication failed" in r.message]
     assert len(auth_warnings) >= 1, f"expected auth failure warning log, got: {[r.message for r in caplog.records]}"
     assert "GetReport" in auth_warnings[0].message
+    # The server secret may not appear in any log record.
+    for record in caplog.records:
+        message = record.getMessage()
+        assert passphrase not in message, f"server passphrase leaked in log: {message}"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Mechanical merge vehicle: lands two commits addressing the 2026-07-03 review comments on #812 onto its head branch (direct push to `fix/auth-error-logging` is restricted for this session). Will be rebase-merged immediately so the commits land unchanged.

- Move `PeerAddr`/`LogContext` into the shared `internal/log` package
- Store one memoized `*auth.Auth` on `ControllerService`
- De-tautologize the token-leak tests (real metadata → bearer extraction path)
- Assert passphrase values never appear in exporter auth logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1kRipqU9ZYXH1CFJTqgTh

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1kRipqU9ZYXH1CFJTqgTh)_