### PR TITLE
fix: unblock post-shell status probe when connection is lost

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -263,6 +263,24 @@ async def _monitor_token_expiry(config, lease, cancel_scope, token_state=None) -
             return
 
 
+async def _cancel_if_connection_lost(monitor, coro):
+    """Run *coro* but cancel it as soon as monitor.connection_lost becomes True.
+
+    Returns the coroutine's result, or None if cancelled due to connection loss.
+    """
+    result = None
+    async with anyio.create_task_group() as tg:
+        async def _watcher():
+            while not monitor.connection_lost:
+                await anyio.sleep(1)
+            tg.cancel_scope.cancel()
+
+        tg.start_soon(_watcher)
+        result = await coro
+        tg.cancel_scope.cancel()
+    return result
+
+
 async def _run_shell_with_lease_async(lease, exporter_logs, config, command, cancel_scope):  # noqa: C901
     """Run shell with lease context managers and wait for afterLease hook if logs enabled.
 
@@ -352,17 +370,9 @@ async def _run_shell_with_lease_async(lease, exporter_logs, config, command, can
                                 # (5s interval in LEASE_READY) may not have detected yet.
                                 if not monitor.connection_lost:
                                     try:
-                                        probe_status = None
-                                        async with anyio.create_task_group() as probe_tg:
-
-                                            async def cancel_when_connection_lost():
-                                                while not monitor.connection_lost:
-                                                    await anyio.sleep(1)
-                                                probe_tg.cancel_scope.cancel()
-
-                                            probe_tg.start_soon(cancel_when_connection_lost)
-                                            probe_status = await client.get_status_async()
-                                            probe_tg.cancel_scope.cancel()
+                                        probe_status = await _cancel_if_connection_lost(
+                                            monitor, client.get_status_async()
+                                        )
                                         if probe_status is None:
                                             logger.debug(
                                                 "Connection probe timed out, marking connection as lost"

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -352,14 +352,29 @@ async def _run_shell_with_lease_async(lease, exporter_logs, config, command, can
                                 # (5s interval in LEASE_READY) may not have detected yet.
                                 if not monitor.connection_lost:
                                     try:
-                                        probe_status = await client.get_status_async()
-                                        if lease.lease_ended:
+                                        probe_status = None
+                                        async with anyio.create_task_group() as probe_tg:
+
+                                            async def cancel_when_connection_lost():
+                                                while not monitor.connection_lost:
+                                                    await anyio.sleep(1)
+                                                probe_tg.cancel_scope.cancel()
+
+                                            probe_tg.start_soon(cancel_when_connection_lost)
+                                            probe_status = await client.get_status_async()
+                                            probe_tg.cancel_scope.cancel()
+                                        if probe_status is None:
+                                            logger.debug(
+                                                "Connection probe timed out, marking connection as lost"
+                                            )
+                                            monitor._connection_lost = True
+                                        elif lease.lease_ended:
                                             logger.debug(
                                                 "Lease ended during probe (status=%s), skipping afterLease hook",
                                                 probe_status,
                                             )
                                             return exit_code
-                                        if probe_status is not None and probe_status not in (
+                                        elif probe_status not in (
                                             ExporterStatus.LEASE_READY,
                                             ExporterStatus.AFTER_LEASE_HOOK,
                                         ):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -2,6 +2,7 @@ import base64
 import inspect
 import json
 import logging
+import math
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
@@ -936,6 +937,54 @@ class TestRunShellWithLeaseAsync:
 
         assert exit_code == 0
         assert not monitor._connection_lost
+
+    async def test_probe_cancelled_when_connection_lost(self):
+        """Probe blocks while connection_lost is False, then unblocks
+        once the monitor marks connection as lost."""
+        monitor = _FakeStatusMonitor()
+        lease = _make_shell_lease(release=True, lease_ended=False)
+        cancel_scope = Mock(cancel_called=False)
+
+        initial_done = anyio.Event()
+
+        async def get_status_blocks_on_probe():
+            if not initial_done.is_set():
+                initial_done.set()
+                return ExporterStatus.LEASE_READY
+            await anyio.sleep(math.inf)
+
+        client = _build_fake_client(monitor, get_status_return=ExporterStatus.LEASE_READY)
+        client.get_status_async = get_status_blocks_on_probe
+
+        @asynccontextmanager
+        async def fake_client_from_path(*_a, **_kw):
+            yield client
+
+        function_returned = anyio.Event()
+
+        async def run_shell():
+            nonlocal exit_code
+            with (
+                patch("jumpstarter_cli.shell.client_from_path", side_effect=fake_client_from_path),
+                patch("jumpstarter_cli.shell._run_shell_only", return_value=0),
+            ):
+                exit_code = await _run_shell_with_lease_async(lease, False, None, (), cancel_scope)
+            function_returned.set()
+
+        async def flip_connection_lost():
+            await anyio.sleep(5)
+            assert not function_returned.is_set(), "probe returned while connection_lost was False"
+            monitor._connection_lost = True
+
+        exit_code = -1
+        with anyio.fail_after(10):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(run_shell)
+                tg.start_soon(flip_connection_lost)
+
+        assert exit_code == 0
+        assert monitor._connection_lost
+        client.end_session_async.assert_not_called()
 
 
 class TestShellWithSignalHandlingExceptionGroup:

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -15,6 +15,7 @@ from jumpstarter_cli_common.exceptions import handle_exceptions_with_reauthentic
 
 from jumpstarter_cli.shell import (
     _attempt_token_recovery,
+    _cancel_if_connection_lost,
     _monitor_token_expiry,
     _resolve_lease_from_active_async,
     _run_shell_with_lease_async,
@@ -985,6 +986,39 @@ class TestRunShellWithLeaseAsync:
         assert exit_code == 0
         assert monitor._connection_lost
         client.end_session_async.assert_not_called()
+
+
+class TestCancelIfConnectionLost:
+    """Unit tests for _cancel_if_connection_lost helper."""
+
+    async def test_returns_result_when_coro_completes(self):
+        """When the coroutine completes normally, its result is returned."""
+        monitor = _FakeStatusMonitor()
+
+        async def quick_coro():
+            return "ok"
+
+        result = await _cancel_if_connection_lost(monitor, quick_coro())
+        assert result == "ok"
+        assert not monitor.connection_lost
+
+    async def test_returns_none_when_connection_lost(self):
+        """When connection_lost flips while the coroutine is blocked, returns None."""
+        monitor = _FakeStatusMonitor()
+
+        async def blocking_coro():
+            await anyio.sleep(math.inf)
+
+        async def flip_after_delay():
+            await anyio.sleep(2)
+            monitor._connection_lost = True
+
+        with anyio.fail_after(10):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(flip_after_delay)
+                result = await _cancel_if_connection_lost(monitor, blocking_coro())
+
+        assert result is None
 
 
 class TestShellWithSignalHandlingExceptionGroup:


### PR DESCRIPTION
## Summary

After the user exits `jmp shell`, a status probe is sent to detect exporter restarts before triggering the afterLease hook. If the exporter becomes unreachable without sending a TCP RST (e.g. network partition, firewall drop, suspended process), this probe blocks indefinitely — hanging the CLI after the shell exits.

The status monitor already handles this correctly: it detects stuck connections after 20 consecutive timeouts and sets `connection_lost = True`, logging progressive warnings to the user. However, the probe runs as an independent gRPC call and never observes the monitor's flag.

## Fix

Race the probe against a lightweight watcher task that polls `monitor.connection_lost` every second. When the monitor marks the connection as lost, the watcher cancels the probe's task group scope, unblocking the CLI. The probe succeeds normally in the healthy case and cancels the watcher itself.

This preserves the existing monitor behaviour — users still see the progressive timeout warnings before the CLI exits cleanly.

## Test

Added `test_probe_cancelled_when_connection_lost` to `TestRunShellWithLeaseAsync`:
- Verifies the probe stays blocked while `connection_lost` is False (5s negative phase)
- Verifies the probe is cancelled once `connection_lost` becomes True (positive phase)
- Guarded by `fail_after(10)` to fail hard instead of hanging if the fix regresses