### PR TITLE
fix: skip processing for already-ended leases

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -634,7 +634,10 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                     )
                 else:
                     if lease_scope.skip_after_lease_hook:
-                        logger.info("Skipping afterLease hook: beforeLease hook failed")
+                        if lease_scope.lease_ended.is_set():
+                            logger.info("Skipping afterLease hook: lease ended before beforeLease hook ran")
+                        else:
+                            logger.info("Skipping afterLease hook: beforeLease hook failed")
                     if not self._stop_requested:
                         logger.debug(
                             "No afterLease hook or no client on session close,"
@@ -649,6 +652,22 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 logger.debug("Waiting for afterLease hook to complete before closing session")
                 await lease_scope.after_lease_hook_done.wait()
                 logger.debug("afterLease hook completed, closing session")
+
+    async def _skip_stale_lease(self, lease_name: str, lease_scope: LeaseContext, context: str) -> bool:
+        """Handle early bail for a stale lease whose lease_ended is already set.
+
+        Sets the events that serve() is waiting on and reports AVAILABLE.
+        Returns True if the lease was stale and the caller should return.
+        """
+        if not lease_scope.lease_ended.is_set():
+            return False
+        logger.info("Lease %s already ended (%s), skipping", lease_name, context)
+        lease_scope.skip_after_lease_hook = True
+        lease_scope.before_lease_hook.set()
+        if not self._stop_requested:
+            await self._report_status(ExporterStatus.AVAILABLE, "Available for new lease")
+        lease_scope.after_lease_hook_done.set()
+        return True
 
     async def handle_lease(self, lease_name: str, tg: TaskGroup, lease_scope: LeaseContext) -> None:
         """Handle all incoming client connections for a lease.
@@ -674,6 +693,18 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             the serve() method when a lease is assigned. It terminates when the lease
             ends or the exporter stops.
         """
+        # Yield to let serve() process any immediately-following leased=False
+        # status that's already in the buffer. Without this, handle_lease runs
+        # before serve() gets a chance to set lease_ended (anyio's receive()
+        # always checkpoints, even when data is buffered).
+        await anyio.sleep(0)
+
+        # Fast path: if the lease is already ended (stale lease from backlog
+        # when the exporter couldn't keep up with lease churn), skip session
+        # creation and all connection handling entirely.
+        if await self._skip_stale_lease(lease_name, lease_scope, "before session creation"):
+            return
+
         logger.info("Listening for incoming connection requests on lease %s", lease_name)
 
         # Buffer Listen responses to avoid blocking when responses arrive before
@@ -694,6 +725,14 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             # before session was created, e.g., BEFORE_LEASE_HOOK when hooks are configured)
             session.update_status(lease_scope.current_status, lease_scope.status_message)
             logger.debug("Session sockets: main=%s, hook=%s", main_path, hook_path)
+
+            # Check if lease ended during session creation — serve() often
+            # processes the buffered leased=False while session_for_lease is
+            # setting up sockets and gRPC servers.  Bailing here avoids the
+            # Listen stream, conn_tg, and _cleanup_after_lease overhead.
+            # The session context manager handles teardown on return.
+            if await self._skip_stale_lease(lease_name, lease_scope, "during session setup"):
+                return
 
             # Accept connections immediately - driver calls will be gated internally
             # until the beforeLease hook completes. This allows LogStream to work
@@ -764,7 +803,11 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 # blocks forever.  When conn_tg is cancelled before the no-hook
                 # path reaches lease_scope.before_lease_hook.set(), this flag
                 # remains unset and _cleanup_after_lease (shielded) deadlocks.
-                if not lease_scope.before_lease_hook.is_set():
+                # Only apply this fallback when NO hooks are configured — when
+                # hooks ARE configured, run_before_lease_hook's finally block
+                # sets the event after updating skip_after_lease_hook. Setting
+                # it here prematurely would race with that flag update.
+                if not self.hook_executor and not lease_scope.before_lease_hook.is_set():
                     lease_scope.before_lease_hook.set()
                 # Close the listen stream to signal termination to listen_rx
                 await listen_tx.aclose()
@@ -849,10 +892,14 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                         logger.info("afterLease hook completed")
 
                     # Clear lease scope for next lease
+                    session_was_created = (
+                        self._lease_context is not None and self._lease_context.session is not None
+                    )
                     self._lease_context = None
-                    # Brief delay to ensure session is fully closed before next lease
-                    # This prevents SSL corruption from overlapping connections
-                    await sleep(0.2)
+                    if session_was_created:
+                        # Brief delay to ensure session is fully closed before next lease
+                        # This prevents SSL corruption from overlapping connections
+                        await sleep(0.2)
                     logger.debug("Ready for next lease")
 
                     if self._stop_requested:

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -551,3 +551,82 @@ class TestReportStatusGrpcErrorHandling:
         assert not any("ReportStatus not supported" in r.message for r in warning_msgs), (
             "UNAVAILABLE error should not produce 'not supported' warning"
         )
+
+
+class TestHandleLeaseStaleSkip:
+    async def test_handle_lease_skips_session_for_stale_lease(self):
+        """When lease_ended is already set, handle_lease skips session
+        creation entirely and just sets the events needed by serve()."""
+        lease_ctx = LeaseContext(
+            lease_name="stale-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        lease_ctx.lease_ended.set()
+
+        exporter = make_exporter(lease_ctx)
+        session_for_lease_mock = AsyncMock()
+        exporter.session_for_lease = session_for_lease_mock
+
+        async with create_task_group() as tg:
+            await exporter.handle_lease("stale-lease", tg, lease_ctx)
+
+        session_for_lease_mock.assert_not_called()
+        assert lease_ctx.skip_after_lease_hook is True
+        assert lease_ctx.before_lease_hook.is_set()
+        assert lease_ctx.after_lease_hook_done.is_set()
+        assert lease_ctx.session is None
+        exporter._report_status.assert_awaited_once_with(
+            ExporterStatus.AVAILABLE, "Available for new lease",
+        )
+
+    async def test_handle_lease_stale_skip_suppresses_available_on_shutdown(self):
+        """When stop_requested is True, the stale lease fast path should
+        not report AVAILABLE status."""
+        lease_ctx = LeaseContext(
+            lease_name="stale-lease",
+            before_lease_hook=Event(),
+        )
+        lease_ctx.lease_ended.set()
+
+        exporter = make_exporter(lease_ctx)
+        exporter._stop_requested = True
+
+        async with create_task_group() as tg:
+            await exporter.handle_lease("stale-lease", tg, lease_ctx)
+
+        assert lease_ctx.after_lease_hook_done.is_set()
+        exporter._report_status.assert_not_awaited()
+
+    async def test_handle_lease_skips_conn_handling_when_lease_ends_during_session(self):
+        """When lease_ended is set during session creation (serve() processes
+        the buffered leased=False while session_for_lease sets up sockets),
+        handle_lease bails after session setup, skipping Listen/conn_tg."""
+        from contextlib import asynccontextmanager
+
+        lease_ctx = LeaseContext(
+            lease_name="stale-during-setup",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+
+        mock_session = MagicMock()
+        mock_session.context_log_source.return_value = nullcontext()
+
+        @asynccontextmanager
+        async def fake_session_for_lease():
+            lease_ctx.lease_ended.set()
+            yield (mock_session, "/tmp/main.sock", "/tmp/hook.sock")
+
+        exporter = make_exporter(lease_ctx)
+        exporter.session_for_lease = fake_session_for_lease
+
+        async with create_task_group() as tg:
+            await exporter.handle_lease("stale-during-setup", tg, lease_ctx)
+
+        assert lease_ctx.skip_after_lease_hook is True
+        assert lease_ctx.before_lease_hook.is_set()
+        assert lease_ctx.after_lease_hook_done.is_set()
+        exporter._report_status.assert_awaited_once_with(
+            ExporterStatus.AVAILABLE, "Available for new lease",
+        )

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -608,6 +608,37 @@ class HookExecutor:
             except Exception as e:
                 logger.error("Failed to request lease release: %s", e, exc_info=True)
 
+    async def _wait_for_lease_ready(
+        self,
+        lease_scope: "LeaseContext",
+        report_status: Callable[["ExporterStatus", str], Awaitable[None]],
+    ) -> bool:
+        """Wait for lease scope to be fully populated by handle_lease.
+
+        Returns True if ready, False if the caller should bail out
+        (lease already ended or timeout waiting for session).
+        """
+        timeout = 30  # seconds
+        interval = 0.1  # seconds
+        elapsed = 0.0
+        while not lease_scope.is_ready():
+            if lease_scope.lease_ended.is_set():
+                logger.info(
+                    "Lease %s ended while waiting for session, skipping beforeLease hook",
+                    lease_scope.lease_name,
+                )
+                lease_scope.skip_after_lease_hook = True
+                return False
+            if elapsed >= timeout:
+                error_msg = "Timeout waiting for lease scope to be ready"
+                logger.error(error_msg)
+                await report_status(ExporterStatus.BEFORE_LEASE_HOOK_FAILED, error_msg)
+                lease_scope.before_lease_hook.set()
+                return False
+            await anyio.sleep(interval)
+            elapsed += interval
+        return True
+
     async def run_before_lease_hook(
         self,
         lease_scope: "LeaseContext",
@@ -632,25 +663,23 @@ class HookExecutor:
         """
         should_release = False
         try:
-            # Wait for lease scope to be fully populated by handle_lease
-            # This is necessary because handle_lease and run_before_lease_hook run concurrently
-            timeout = 30  # seconds
-            interval = 0.1  # seconds
-            elapsed = 0.0
-            while not lease_scope.is_ready():
-                if elapsed >= timeout:
-                    error_msg = "Timeout waiting for lease scope to be ready"
-                    logger.error(error_msg)
-                    await report_status(ExporterStatus.BEFORE_LEASE_HOOK_FAILED, error_msg)
-                    lease_scope.before_lease_hook.set()
-                    return
-                await anyio.sleep(interval)
-                elapsed += interval
+            if not await self._wait_for_lease_ready(lease_scope, report_status):
+                return
 
             # Check if hook is configured
             if not self.config.before_lease:
                 logger.debug("No before-lease hook configured")
                 await report_status(ExporterStatus.LEASE_READY, "Ready for commands")
+                return
+
+            # Skip hook if lease already ended (e.g. stale lease from backlog
+            # when the exporter couldn't keep up with lease churn)
+            if lease_scope.lease_ended.is_set():
+                logger.info(
+                    "Lease %s already ended, skipping beforeLease hook",
+                    lease_scope.lease_name,
+                )
+                lease_scope.skip_after_lease_hook = True
                 return
 
             await report_status(ExporterStatus.BEFORE_LEASE_HOOK, "Running beforeLease hook")

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -1541,9 +1541,9 @@ class TestBeforeLeaseHookLeaseEndedGuard:
     NOT set status to LEASE_READY, preventing the exporter from being
     stuck in LEASE_READY permanently."""
 
-    async def test_run_before_lease_hook_skips_lease_ready_when_lease_ended(self, lease_scope) -> None:
-        """When the lease has already ended by the time the beforeLease hook
-        completes, status must NOT be set to LEASE_READY."""
+    async def test_run_before_lease_hook_skips_entirely_when_lease_ended(self, lease_scope) -> None:
+        """When the lease has already ended before the hook runs, the hook
+        subprocess must NOT be executed and skip_after_lease_hook must be set."""
         hook_config = HookConfigV1Alpha1(
             before_lease=HookInstanceConfigV1Alpha1(script="echo setup", timeout=10),
         )
@@ -1564,14 +1564,11 @@ class TestBeforeLeaseHookLeaseEndedGuard:
             mock_shutdown,
         )
 
-        lease_ready_calls = [s for s, _ in status_calls if s == ExporterStatus.LEASE_READY]
-        assert len(lease_ready_calls) == 0, (
-            f"LEASE_READY must NOT be set when lease has already ended, got: {status_calls}"
+        assert len(status_calls) == 0, (
+            f"No status should be reported when hook is skipped due to lease ended, got: {status_calls}"
         )
-
-        hook_started_calls = [s for s, _ in status_calls if s == ExporterStatus.BEFORE_LEASE_HOOK]
-        assert len(hook_started_calls) == 1, (
-            f"BEFORE_LEASE_HOOK must be reported (hook must run) even when lease has ended, got: {status_calls}"
+        assert lease_scope.skip_after_lease_hook is True, (
+            "skip_after_lease_hook must be set when beforeLease hook is skipped"
         )
 
     async def test_run_before_lease_hook_sets_event_even_when_lease_ended(self, lease_scope) -> None:
@@ -1597,9 +1594,9 @@ class TestBeforeLeaseHookLeaseEndedGuard:
             "before_lease_hook event must be set even when lease has ended"
         )
 
-    async def test_run_before_lease_hook_warn_skips_lease_ready_when_lease_ended(self, lease_scope) -> None:
-        """When hook fails with on_failure=warn and the lease has already ended,
-        LEASE_READY must still be skipped."""
+    async def test_run_before_lease_hook_warn_skips_entirely_when_lease_ended(self, lease_scope) -> None:
+        """When lease has already ended, hook is skipped entirely regardless
+        of on_failure setting — the hook subprocess never runs."""
         hook_config = HookConfigV1Alpha1(
             before_lease=HookInstanceConfigV1Alpha1(script="exit 1", timeout=10, on_failure="warn"),
         )
@@ -1620,12 +1617,93 @@ class TestBeforeLeaseHookLeaseEndedGuard:
             mock_shutdown,
         )
 
-        lease_ready_calls = [s for s, _ in status_calls if s == ExporterStatus.LEASE_READY]
-        assert len(lease_ready_calls) == 0, (
-            f"LEASE_READY must NOT be set when lease has ended (even with warn), got: {status_calls}"
+        assert len(status_calls) == 0, (
+            f"No status should be reported when hook is skipped due to lease ended, got: {status_calls}"
+        )
+        assert lease_scope.skip_after_lease_hook is True, (
+            "skip_after_lease_hook must be set when beforeLease hook is skipped (warn)"
         )
 
-        hook_started_calls = [s for s, _ in status_calls if s == ExporterStatus.BEFORE_LEASE_HOOK]
-        assert len(hook_started_calls) == 1, (
-            f"BEFORE_LEASE_HOOK must be reported (hook must run) even when lease has ended, got: {status_calls}"
+    async def test_wait_for_lease_ready_times_out_when_session_never_populated(self) -> None:
+        """When is_ready() never becomes True and lease_ended is never set,
+        _wait_for_lease_ready must time out, report BEFORE_LEASE_HOOK_FAILED,
+        and set before_lease_hook to unblock downstream."""
+        import anyio
+
+        from jumpstarter.exporter.lease_context import LeaseContext
+
+        lease_scope = LeaseContext(
+            lease_name="test-lease-timeout",
+            before_lease_hook=anyio.Event(),
+            client_name="test-client",
+        )
+
+        executor = HookExecutor(
+            config=HookConfigV1Alpha1(
+                before_lease=HookInstanceConfigV1Alpha1(script="echo setup", timeout=10),
+            )
+        )
+
+        status_calls = []
+
+        async def mock_report_status(status, msg):
+            status_calls.append((status, msg))
+
+        # Make sleep instant so the 30s timeout fires immediately
+        # without blocking the test for 30 real seconds.
+        async def instant_sleep(_delay):
+            pass
+
+        with patch("jumpstarter.exporter.hooks.anyio.sleep", side_effect=instant_sleep):
+            result = await executor._wait_for_lease_ready(lease_scope, mock_report_status)
+
+        assert result is False
+        assert any(
+            s == ExporterStatus.BEFORE_LEASE_HOOK_FAILED
+            for s, _ in status_calls
+        ), f"Expected BEFORE_LEASE_HOOK_FAILED, got: {status_calls}"
+        assert lease_scope.before_lease_hook.is_set()
+
+    async def test_run_before_lease_hook_skips_when_lease_ended_during_is_ready_wait(self) -> None:
+        """When lease_ended is set before the session is created (is_ready()
+        returns False), the hook must bail out immediately without waiting
+        for the full is_ready timeout."""
+        from anyio import Event
+
+        from jumpstarter.exporter.lease_context import LeaseContext
+
+        lease_scope = LeaseContext(
+            lease_name="test-lease-stale",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        # Leave session=None and socket_path="" so is_ready() returns False
+        lease_scope.lease_ended.set()
+
+        hook_config = HookConfigV1Alpha1(
+            before_lease=HookInstanceConfigV1Alpha1(script="echo setup", timeout=10),
+        )
+        executor = HookExecutor(config=hook_config)
+
+        status_calls = []
+
+        async def mock_report_status(status, msg):
+            status_calls.append((status, msg))
+
+        mock_shutdown = MagicMock()
+
+        await executor.run_before_lease_hook(
+            lease_scope,
+            mock_report_status,
+            mock_shutdown,
+        )
+
+        assert len(status_calls) == 0, (
+            f"No status should be reported when bailing out during is_ready wait, got: {status_calls}"
+        )
+        assert lease_scope.skip_after_lease_hook is True, (
+            "skip_after_lease_hook must be set when skipping during is_ready wait"
+        )
+        assert lease_scope.before_lease_hook.is_set(), (
+            "before_lease_hook event must be set to unblock downstream waiters"
         )


### PR DESCRIPTION
## Summary

When the exporter falls behind processing leases (e.g. temporary unavailability, resource starvation, or slow hooks), the client retry loop creates new leases faster than the exporter can process them. Each stale lease triggered full session creation, hook execution, and teardown — a cascading backlog that prevented recovery.

Three layers of stale lease detection:

1. **hooks.py**: check `lease_ended` before executing hook subprocess, and during the `is_ready` wait loop. Extracted `_wait_for_lease_ready` helper to keep complexity under C901 limit. Both hooks (before and after lease) are skipped for stale leases.

2. **exporter.py `handle_lease`**: yield (`sleep(0)`) then check `lease_ended` before session creation; check again after session creation but before Listen stream and connection handling. Extracted `_skip_stale_lease` helper for both check sites.

3. **exporter.py `serve`**: skip 0.2s inter-lease sleep when no session was created (no connections to overlap).

Also fixes a race condition in `handle_lease`'s finally block where `before_lease_hook.set()` was called unconditionally, racing with `run_before_lease_hook`'s `skip_after_lease_hook` flag update. Now conditioned on `not self.hook_executor`.

## Test plan

- [x] 545 unit tests pass (`make pkg-test-jumpstarter`)
- [x] Lint clean (`make lint-fix`)
- [x] Type check clean (`make pkg-ty-jumpstarter`)
- [x] Manual test: SIGSTOP/SIGCONT with on-demand lease — stale leases drained in ~3s (16 leases), session skipped for all but the first
- [x] Manual test: SIGSTOP/SIGCONT with on-demand lease, client connects after resume — stale backlog drained, live lease processed normally with both hooks
- [x] Manual test: named lease (`--lease`) — no stale backlog, normal lifecycle unaffected