### PR TITLE
fix: detect and handle expired leases in client acquisition

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -28,6 +28,7 @@ from .common import opt_acquisition_timeout, opt_duration_partial, opt_exporter_
 from .login import relogin_client
 from jumpstarter.client import DirectLease
 from jumpstarter.client.client import client_from_path
+from jumpstarter.client.exceptions import LeaseError
 from jumpstarter.common import HOOK_WARNING_PREFIX, ExporterStatus
 from jumpstarter.common.exceptions import (
     ConnectionError,
@@ -505,6 +506,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                             except ExporterUnreachableError as exc:
                                 unreachable = exc
                             if unreachable is not None:
+                                if lease.lease_ended:
+                                    break  # lease expired naturally — exit cleanly
                                 if connect_deadline is None:
                                     connect_deadline = time.monotonic() + lease.retry_timeout
                                 if time.monotonic() >= connect_deadline:
@@ -531,6 +534,9 @@ async def _shell_with_signal_handling(  # noqa: C901
                 offline_exc = find_exception_in_group(eg, ExporterOfflineError)
                 if offline_exc:
                     raise offline_exc from None
+                lease_exc = find_exception_in_group(eg, LeaseError)
+                if lease_exc:
+                    raise lease_exc from None
                 if lease_used is not None:
                     if lease_used.lease_ended:
                         # Lease expired naturally (e.g. during beforeLease hook)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -1226,3 +1226,83 @@ class TestRetryLoopTimeout:
 
         assert exit_code == 0
         assert state["call_count"] == 3
+
+
+class TestRetryLoopLeaseExpired:
+    """Tests for lease expiry detection in the retry loop."""
+
+    async def test_exits_cleanly_when_lease_ended_during_connection(self):
+        """Retry loop should exit cleanly instead of retrying when lease has ended."""
+        lease = Mock()
+        lease.release = True
+        lease.name = "test-lease"
+        lease.exporter_name = "test-exporter"
+        lease.retry_timeout = 10.0
+        lease.lease_ended = True
+        lease.lease_transferred = False
+
+        config = _DummyConfig()
+        state = {"call_count": 0}
+
+        @asynccontextmanager
+        async def lease_async(
+            selector, exporter_name, lease_name, duration, portal,
+            acquisition_timeout, retry_timeout=None,
+        ):
+            yield lease
+
+        config.lease_async = lease_async
+
+        async def fake_run(*_):
+            state["call_count"] += 1
+            raise ExporterUnreachableError("exporter dead")
+
+        with (
+            patch("jumpstarter_cli.shell._monitor_token_expiry", new_callable=AsyncMock),
+            patch("jumpstarter_cli.shell._run_shell_with_lease_async", side_effect=fake_run),
+        ):
+            exit_code = await _shell_with_signal_handling(
+                config, None, None, None, timedelta(minutes=1), False, (), None
+            )
+
+        assert exit_code == 0
+        assert state["call_count"] == 1  # did not retry
+
+    async def test_retries_normally_when_lease_not_ended(self):
+        """Retry loop should continue retrying when lease has not ended."""
+        lease = Mock()
+        lease.release = True
+        lease.name = "test-lease"
+        lease.exporter_name = "test-exporter"
+        lease.retry_timeout = 10.0
+        lease.lease_ended = False
+        lease.lease_transferred = False
+
+        config = _DummyConfig()
+        state = {"call_count": 0}
+
+        @asynccontextmanager
+        async def lease_async(
+            selector, exporter_name, lease_name, duration, portal,
+            acquisition_timeout, retry_timeout=None,
+        ):
+            yield lease
+
+        config.lease_async = lease_async
+
+        async def fake_run(*_):
+            state["call_count"] += 1
+            if state["call_count"] < 3:
+                raise ExporterUnreachableError("exporter dead")
+            return 0
+
+        with (
+            patch("jumpstarter_cli.shell._monitor_token_expiry", new_callable=AsyncMock),
+            patch("jumpstarter_cli.shell._run_shell_with_lease_async", side_effect=fake_run),
+        ):
+            exit_code = await _shell_with_signal_handling(
+                config, None, None, None, timedelta(minutes=1), False, (), None
+            )
+
+        assert exit_code == 0
+        assert state["call_count"] == 3

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -426,10 +426,9 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
                     raise ConnectionError("Socket not ready at %s" % path) from e
 
     def _notify_lease_ending(self, remaining: timedelta) -> None:
-        """Log lease status and invoke the ending callback if set."""
+        """Set lease_ended flag and invoke the ending callback if set."""
         if remaining <= timedelta(0):
             self.lease_ended = True
-            logger.info("Lease {} ended at {}".format(self.name, datetime.now().astimezone()))
         if self.lease_ending_callback is not None:
             self.lease_ending_callback(self, remaining)
 

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -180,7 +180,8 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         if self.name:
             logger.debug("using existing lease via env or flag %s", self.name)
             existing_lease = await self.get()
-            # Verify the lease belongs to the current client
+            if existing_lease.effective_end_time:
+                raise LeaseError(f"lease {self.name} has already ended")
             if self.client_name and existing_lease.client != self.client_name:
                 raise LeaseError(
                     f"lease {self.name} belongs to client '{existing_lease.client}', "
@@ -278,9 +279,9 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
                                 f"Unsatisfiable state either"
                             )
 
-                        # lease released
-                        if condition_present_and_equal(result.conditions, "Ready", "False", "Released"):
-                            raise LeaseError(f"lease {self.name} released")
+                        if condition_false(result.conditions, "Ready"):
+                            message = condition_message(result.conditions, "Ready") or "lease is no longer active"
+                            raise LeaseError(f"lease {self.name}: {message}")
 
                         # Update spinner with appropriate status message
                         self._update_spinner_status(spinner, result)

--- a/python/packages/jumpstarter/jumpstarter/client/lease_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease_test.py
@@ -371,7 +371,7 @@ class TestRequestAsyncOwnership:
     async def test_raises_when_lease_belongs_to_different_client(self):
         """request_async should raise LeaseError when the lease belongs to another client."""
         lease = self._make_lease(client_name="my-client")
-        lease.get.return_value = Mock(client="other-client", selector=None)
+        lease.get.return_value = Mock(client="other-client", selector=None, effective_end_time=None)
 
         with pytest.raises(LeaseError, match="belongs to client 'other-client'"):
             await lease.request_async()
@@ -380,7 +380,7 @@ class TestRequestAsyncOwnership:
     async def test_skips_check_when_client_name_is_none(self):
         """request_async should skip ownership check when client_name is not set."""
         lease = self._make_lease(client_name=None)
-        lease.get.return_value = Mock(client="other-client", selector=None)
+        lease.get.return_value = Mock(client="other-client", selector=None, effective_end_time=None)
         lease._acquire = AsyncMock(return_value=lease)
 
         result = await lease.request_async()
@@ -633,3 +633,93 @@ class TestHandleAsyncUnavailableRetry:
 
         assert exc_info.value.code() == grpc.StatusCode.UNAVAILABLE
         assert dial_call_count >= 2
+
+
+class TestRequestAsyncExpiredLease:
+    """Tests for early detection of already-ended leases in request_async."""
+
+    def _make_lease(self, *, name="test-lease", client_name="my-client"):
+        lease = object.__new__(Lease)
+        lease.name = name
+        lease.client_name = client_name
+        lease.selector = None
+        lease.get = AsyncMock()
+        return lease
+
+    @pytest.mark.anyio
+    async def test_raises_when_lease_has_effective_end_time(self):
+        """request_async should raise LeaseError when the lease has already ended."""
+        lease = self._make_lease()
+        lease.get.return_value = Mock(
+            effective_end_time=datetime.now(timezone.utc),
+            client="my-client",
+            selector=None,
+        )
+
+        with pytest.raises(LeaseError, match="has already ended"):
+            await lease.request_async()
+
+    @pytest.mark.anyio
+    async def test_passes_when_lease_has_no_effective_end_time(self):
+        """request_async should proceed to _acquire when lease is still active."""
+        lease = self._make_lease()
+        lease.get.return_value = Mock(
+            effective_end_time=None,
+            client="my-client",
+            selector=None,
+        )
+        lease._acquire = AsyncMock(return_value=lease)
+
+        result = await lease.request_async()
+        assert result is lease
+        lease._acquire.assert_called_once()
+
+
+class TestAcquireExpiredLease:
+    """Tests for Ready=False detection in _acquire polling loop."""
+
+    def _make_lease(self, *, name="test-lease"):
+
+        lease = object.__new__(Lease)
+        lease.name = name
+        lease.acquisition_timeout = 5
+        lease._get_with_retry = AsyncMock()
+        return lease
+
+    @pytest.mark.anyio
+    async def test_raises_on_ready_false_expired(self):
+        """_acquire should raise LeaseError when Ready=False with reason Expired."""
+        from jumpstarter_protocol import kubernetes_pb2
+
+        lease = self._make_lease()
+        lease._get_with_retry.return_value = Mock(
+            conditions=[
+                kubernetes_pb2.Condition(
+                    type="Ready", status="False", reason="Expired",
+                    message="The lease has expired",
+                ),
+            ],
+            exporter="test-exporter",
+        )
+
+        with pytest.raises(LeaseError, match="The lease has expired"):
+            await lease._acquire()
+
+    @pytest.mark.anyio
+    async def test_raises_on_ready_false_released(self):
+        """_acquire should raise LeaseError when Ready=False with reason Released."""
+        from jumpstarter_protocol import kubernetes_pb2
+
+        lease = self._make_lease()
+        lease._get_with_retry.return_value = Mock(
+            conditions=[
+                kubernetes_pb2.Condition(
+                    type="Ready", status="False", reason="Released",
+                    message="The lease was marked for release",
+                ),
+            ],
+            exporter="test-exporter",
+        )
+
+        with pytest.raises(LeaseError, match="The lease was marked for release"):
+            await lease._acquire()


### PR DESCRIPTION
Fixes client hang when a pre-created lease expires during connection (e.g., during `beforeLease` hook execution). Before this fix, the client would freeze on "Waiting for server to provide status updates..." for up to 2 hours instead of exiting cleanly.

## Problem

PR #829 introduced a retry loop that catches `ExporterUnreachableError` and re-acquires leases. This works correctly when an exporter is suspended/restarted, but created two regressions when a lease expires during hook execution:

1. **Retry loop retries an expired lease**: The shell retry catches `ExporterUnreachableError` (from the ~20s router peer-wait timeout), releases the lease (no-op for pre-created leases with `release=False`), and tries to re-acquire the **same expired lease**.

2. **`_acquire` doesn't detect expired leases**: The polling loop checks for `Ready=True`, `Unsatisfiable`, `Invalid`, `Pending=False`, and `Ready=False` with `reason="Released"` — but not `reason="Expired"`. An expired lease has `Ready=False, reason="Expired"` with no `Pending` condition (never set when the exporter was assigned immediately), so it falls through to the spinner with a 2-hour `acquisition_timeout`.

Before PR #829, the `AioRpcError` from the router timeout propagated up and the shell exited cleanly.

## Fix 1: Detect expired leases in client acquisition (lease.py)

- **`request_async`**: Check `effective_end_time` immediately after fetching an existing lease — raise `LeaseError` if already ended, avoiding the entire `_acquire` polling loop
- **`_acquire`**: Broaden the `Ready=False` check from only matching `reason="Released"` to catching any `Ready=False` state (Expired, Released, etc.) using `condition_false()` + `condition_message()`

## Fix 2: Stop retry loop on expired leases (shell.py)

- **Retry loop**: Check `lease.lease_ended` after catching `ExporterUnreachableError` — break cleanly instead of retrying (the lease monitor already notified the client of the expiry)
- **ExceptionGroup handler**: Extract `LeaseError` from `BaseExceptionGroup` so Fix 1's error propagates cleanly through the task group

## Fix 3: Remove duplicate "Lease ended" log message (lease.py)

- **`_notify_lease_ending`**: Remove redundant log — all callers that pass `remaining <= 0` already log before calling it (with the controller's authoritative end time)

## Testing

- **Unit tests**: 6 new test cases (4 in `lease_test.py`, 2 in `shell_test.py`)
- **All existing tests pass**: 553 + 189 = 742 tests
- **Manual reproduction**: Verified with a 7-second lease that expires during `beforeLease` hook — client now exits cleanly in ~18 seconds instead of hanging for 2 hours
- **Fixes can be tested independently**: Each commit is self-contained and tests pass after each one