### PR TITLE
feat: add --insecure-tls flags to config creation CLI

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_client.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_client.py
@@ -7,6 +7,9 @@ from jumpstarter_cli_common.opt import (
     OutputMode,
     OutputType,
     PathOutputType,
+    confirm_insecure_tls,
+    opt_insecure_tls,
+    opt_nointeractive,
     opt_output_all,
     opt_output_path_only,
 )
@@ -14,6 +17,7 @@ from jumpstarter_cli_common.print import model_print
 
 from jumpstarter.config.client import ClientConfigV1Alpha1, ClientConfigV1Alpha1Drivers
 from jumpstarter.config.common import ObjectMeta
+from jumpstarter.config.tls import TLSConfigV1Alpha1
 from jumpstarter.config.user import UserConfigV1Alpha1
 
 
@@ -67,6 +71,8 @@ def config_client():
     default="",
 )
 @click.option("--unsafe", is_flag=True, help="Should all driver client packages be allowed to load (UNSAFE!).")
+@opt_insecure_tls
+@opt_nointeractive
 @opt_output_path_only
 @handle_exceptions
 def create_client_config(
@@ -77,6 +83,8 @@ def create_client_config(
     token: str,
     allow: str,
     unsafe: bool,
+    insecure_tls: bool,
+    nointeractive: bool,
     out: Optional[PathLike],
     output: PathOutputType,
 ):
@@ -84,12 +92,15 @@ def create_client_config(
     if out is None and ClientConfigV1Alpha1.exists(alias):
         raise click.ClickException(f"A client with the name '{alias}' already exists.")
 
+    confirm_insecure_tls(insecure_tls, nointeractive)
+
     config = ClientConfigV1Alpha1(
         alias=alias,
         metadata=ObjectMeta(namespace=namespace, name=name),
         endpoint=endpoint,
         token=token,
         drivers=ClientConfigV1Alpha1Drivers(allow=allow.split(","), unsafe=unsafe),
+        tls=TLSConfigV1Alpha1(insecure=insecure_tls),
     )
     path = ClientConfigV1Alpha1.save(config, out)
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_client_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_client_test.py
@@ -1,0 +1,90 @@
+from click.testing import CliRunner
+
+from .config_client import config_client
+from jumpstarter.config.client import ClientConfigV1Alpha1
+
+CLIENT_ALIAS = "test-client"
+CLIENT_NAMESPACE = "default"
+CLIENT_NAME = "my-client"
+CLIENT_ENDPOINT = "grpc.example.com:443"
+CLIENT_TOKEN = "test-token"
+CLIENT_ALLOW = "pkg1,pkg2"
+
+COMMON_ARGS = [
+    "--namespace",
+    CLIENT_NAMESPACE,
+    "--name",
+    CLIENT_NAME,
+    "--endpoint",
+    CLIENT_ENDPOINT,
+    "--token",
+    CLIENT_TOKEN,
+    "--allow",
+    CLIENT_ALLOW,
+]
+
+
+def test_create_client_config_default(tmp_path):
+    out = tmp_path / "client.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        config_client,
+        ["create", CLIENT_ALIAS, "--out", str(out)] + COMMON_ARGS,
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ClientConfigV1Alpha1.from_file(out)
+    assert config.endpoint == CLIENT_ENDPOINT
+    assert config.tls.insecure is False
+
+
+def test_create_client_config_insecure_tls(tmp_path):
+    out = tmp_path / "client.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        config_client,
+        ["create", CLIENT_ALIAS, "--out", str(out), "--insecure-tls", "--nointeractive"] + COMMON_ARGS,
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ClientConfigV1Alpha1.from_file(out)
+    assert config.tls.insecure is True
+
+
+def test_create_client_config_insecure_tls_short_flag(tmp_path):
+    out = tmp_path / "client.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        config_client,
+        ["create", CLIENT_ALIAS, "--out", str(out), "-k", "--nointeractive"] + COMMON_ARGS,
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ClientConfigV1Alpha1.from_file(out)
+    assert config.tls.insecure is True
+
+
+def test_create_client_config_insecure_tls_confirm(tmp_path):
+    out = tmp_path / "client.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        config_client,
+        ["create", CLIENT_ALIAS, "--out", str(out), "--insecure-tls"] + COMMON_ARGS,
+        input="y\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ClientConfigV1Alpha1.from_file(out)
+    assert config.tls.insecure is True
+
+
+def test_create_client_config_insecure_tls_abort(tmp_path):
+    out = tmp_path / "client.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        config_client,
+        ["create", CLIENT_ALIAS, "--out", str(out), "--insecure-tls"] + COMMON_ARGS,
+        input="n\n",
+    )
+    assert result.exit_code != 0
+    assert not out.exists()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter.py
@@ -3,6 +3,9 @@ from jumpstarter_cli_common.opt import (
     OutputMode,
     OutputType,
     PathOutputType,
+    confirm_insecure_tls,
+    opt_insecure_tls,
+    opt_nointeractive,
     opt_output_all,
     opt_output_path_only,
 )
@@ -10,6 +13,7 @@ from jumpstarter_cli_common.print import model_print
 
 from jumpstarter.common.exceptions import ConfigurationError
 from jumpstarter.config.exporter import ExporterConfigV1Alpha1, ObjectMeta
+from jumpstarter.config.tls import TLSConfigV1Alpha1
 
 
 def _validate_alias_param(ctx, param, value):
@@ -35,20 +39,27 @@ def config_exporter():
 @click.option("--name", prompt=True)
 @click.option("--endpoint", prompt=True)
 @click.option("--token", prompt=True)
+@opt_insecure_tls
+@opt_nointeractive
 @opt_output_path_only
 @arg_alias
-def create_exporter_config(alias, namespace, name, endpoint, token, output: PathOutputType):
+def create_exporter_config(
+    alias, namespace, name, endpoint, token, insecure_tls, nointeractive, output: PathOutputType
+):
     """Create an exporter config."""
     # Guard against overwriting an existing user-level config (the write target).
     # A same-named config in the system location (/etc) is allowed to be shadowed.
     if ExporterConfigV1Alpha1.user_config_exists(alias):
         raise click.ClickException(f'exporter "{alias}" exists')
 
+    confirm_insecure_tls(insecure_tls, nointeractive)
+
     config = ExporterConfigV1Alpha1(
         alias=alias,
         metadata=ObjectMeta(namespace=namespace, name=name),
         endpoint=endpoint,
         token=token,
+        tls=TLSConfigV1Alpha1(insecure=insecure_tls),
     )
     path = ExporterConfigV1Alpha1.save(config)
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_exporter_test.py
@@ -84,11 +84,10 @@ def test_edit_passes_string_filename_to_click_edit():
     mock_config = MagicMock()
     mock_config.path = Path("/etc/jumpstarter/exporters/default.yaml")
 
-    with patch(
-        "jumpstarter_cli.config_exporter.ExporterConfigV1Alpha1"
-    ) as mock_exporter_cls, patch(
-        "jumpstarter_cli.config_exporter.click.edit"
-    ) as mock_edit:
+    with (
+        patch("jumpstarter_cli.config_exporter.ExporterConfigV1Alpha1") as mock_exporter_cls,
+        patch("jumpstarter_cli.config_exporter.click.edit") as mock_edit,
+    ):
         mock_exporter_cls.load.return_value = mock_config
 
         runner = CliRunner()
@@ -97,15 +96,11 @@ def test_edit_passes_string_filename_to_click_edit():
         assert result.exit_code == 0
         mock_edit.assert_called_once()
         filename_arg = mock_edit.call_args[1]["filename"]
-        assert isinstance(filename_arg, str), (
-            f"Expected str but got {type(filename_arg).__name__}"
-        )
+        assert isinstance(filename_arg, str), f"Expected str but got {type(filename_arg).__name__}"
 
 
 def test_edit_nonexistent_exporter_shows_error():
-    with patch(
-        "jumpstarter_cli.config_exporter.ExporterConfigV1Alpha1"
-    ) as mock_exporter_cls:
+    with patch("jumpstarter_cli.config_exporter.ExporterConfigV1Alpha1") as mock_exporter_cls:
         mock_exporter_cls.load.side_effect = FileNotFoundError
 
         runner = CliRunner()
@@ -113,3 +108,51 @@ def test_edit_nonexistent_exporter_shows_error():
 
         assert result.exit_code != 0
         assert "does not exist" in result.output
+
+
+def test_create_exporter_default_tls(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", tmp_path / "user")
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", tmp_path / "system")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        config_exporter,
+        ["create", "myexporter"],
+        input="default\nmyexporter\njumpstarter.my-lab.com:1443\ntest-token\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ExporterConfigV1Alpha1.load("myexporter")
+    assert config.tls.insecure is False
+
+
+def test_create_exporter_insecure_tls(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", tmp_path / "user")
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", tmp_path / "system")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        config_exporter,
+        ["create", "--insecure-tls", "--nointeractive", "myexporter"],
+        input="default\nmyexporter\njumpstarter.my-lab.com:1443\ntest-token\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ExporterConfigV1Alpha1.load("myexporter")
+    assert config.tls.insecure is True
+
+
+def test_create_exporter_insecure_tls_short_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", tmp_path / "user")
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "SYSTEM_CONFIG_PATH", tmp_path / "system")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        config_exporter,
+        ["create", "-k", "--nointeractive", "myexporter"],
+        input="default\nmyexporter\njumpstarter.my-lab.com:1443\ntest-token\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    config = ExporterConfigV1Alpha1.load("myexporter")
+    assert config.tls.insecure is True


### PR DESCRIPTION
Currently --insecure-fls is missing from CLI commands such as:
```
  jmp config client create
```

Requiring manual editing of the client or usage of JMP_GRPC_INSECURE=1