### PR TITLE
ci: use native Go cross-compilation instead of QEMU emulation for arm64 builds

### DIFF
--- a/controller/Containerfile
+++ b/controller/Containerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.3 AS builder
+# Use --platform=$BUILDPLATFORM to run the Go compiler natively on the build host
+# instead of under QEMU emulation. Go cross-compiles via GOOS/GOARCH (CGO_ENABLED=0).
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26.3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GIT_VERSION=unknown

--- a/controller/Containerfile.operator
+++ b/controller/Containerfile.operator
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.3 AS builder
+# Use --platform=$BUILDPLATFORM to run the Go compiler natively on the build host
+# instead of under QEMU emulation. Go cross-compiles via GOOS/GOARCH (CGO_ENABLED=0).
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26.3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GIT_VERSION=unknown

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -141,8 +141,6 @@ docker-push: ## Push docker image with the manager.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Containerfile and insert --platform=${BUILDPLATFORM} into Containerfile.cross, and preserve the original Containerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Containerfile > Containerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name jumpstarter-controller-builder
 	$(CONTAINER_TOOL) buildx use jumpstarter-controller-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) \
@@ -151,9 +149,8 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 			--build-arg BUILD_DATE=$(BUILD_DATE) \
 			--tag ${DOCKER_REPO}:${DOCKER_TAG} \
 			--tag ${DOCKER_REPO}:latest \
-			-f Containerfile.cross .
+			-f Containerfile .
 	- $(CONTAINER_TOOL) buildx rm jumpstarter-controller-builder
-	rm Containerfile.cross
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.

--- a/controller/deploy/operator/Makefile
+++ b/controller/deploy/operator/Makefile
@@ -190,17 +190,14 @@ docker-push: ## Push docker image with the manager.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Containerfile and insert --platform=${BUILDPLATFORM} into Containerfile.cross, and preserve the original Containerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' ../../Containerfile.operator > ../../Containerfile.operator.cross
 	- $(CONTAINER_TOOL) buildx create --name jumpstarter-operator-builder
 	$(CONTAINER_TOOL) buildx use jumpstarter-operator-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) \
 		--build-arg GIT_VERSION=$(GIT_VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--tag ${IMG} -f ../../Containerfile.operator.cross ../../
+		--tag ${IMG} -f ../../Containerfile.operator ../../
 	- $(CONTAINER_TOOL) buildx rm jumpstarter-operator-builder
-	rm ../../Containerfile.operator.cross
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.


### PR DESCRIPTION
## Problem

The `build-images.yaml` CI workflow builds Go container images for `linux/amd64,linux/arm64` using Docker Buildx on `ubuntu-latest` (x86_64) runners. For arm64 images, the **entire builder stage** — including Go compilation — runs under QEMU user-static emulation, which is ~10-20x slower than native execution.

The irony is that the Containerfiles were already set up for cross-compilation (`CGO_ENABLED=0`, `GOOS=${TARGETOS}`, `GOARCH=${TARGETARCH}`), but the builder stage was still being emulated because it lacked the `--platform=$BUILDPLATFORM` directive.

## Solution

Add `--platform=$BUILDPLATFORM` to the builder `FROM` line in both Go Containerfiles. This tells BuildKit to run the builder stage **natively on the host CPU** (x86_64), while Go cross-compiles for the target architecture via `GOARCH=${TARGETARCH}`.

### Files changed

| File | Change |
|------|--------|
| `controller/Containerfile` | Add `--platform=$BUILDPLATFORM` to builder FROM |
| `controller/Containerfile.operator` | Add `--platform=$BUILDPLATFORM` to builder FROM |
| `controller/Makefile` | Remove `Containerfile.cross` workaround from `docker-buildx` target |
| `controller/deploy/operator/Makefile` | Remove `Containerfile.operator.cross` workaround from `docker-buildx` target |

### Why this is safe

- `CGO_ENABLED=0` — pure Go, no C toolchain needed
- Go has first-class cross-compilation support for all target architectures
- The Makefile `docker-buildx` targets already applied this exact transformation via a `sed` workaround (generating temporary `Containerfile.cross` files) — this PR makes it permanent and removes the workaround
- Single-arch `docker-build` is unaffected (`$BUILDPLATFORM` equals the target platform)
- The runtime stage (`FROM ubi-micro`) is unaffected — it pulls the correct arch variant and only runs metadata operations (`COPY`, `USER`, `ENTRYPOINT`)

### Expected impact

- **arm64 Go compilation**: ~10-20x faster (native cross-compile vs QEMU emulation)
- **Overall arm64 image build**: ~5-10x faster (Go compilation dominates build time)
- **amd64 builds**: No change (already native)
- **No CI workflow changes needed** — QEMU setup remains for other images in the matrix