### PR TITLE
fix: raise MissingDriverError for driver allow-list mismatches

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/common/importlib.py
+++ b/python/packages/jumpstarter/jumpstarter/common/importlib.py
@@ -52,11 +52,14 @@ def import_class(class_path: str, allow: list[str], unsafe: bool):
     is equivalent to `from example_package.some_module import FooClass; return FooClass`
 
     while `import_class("example_package.some_module.fooclass", allow=["notexample_package.*"], unsafe=false)`
-    throws ImportError due to not matching the allow list
+    throws MissingDriverError due to not matching the allow list
     """
     if not unsafe:
         if not any(fnmatchcase(class_path, pattern) for pattern in allow):
-            raise ImportError(f"{class_path} doesn't match any of the allowed patterns")
+            raise MissingDriverError(
+                message=f"{class_path} doesn't match any of the allowed patterns",
+                class_path=class_path,
+            )
     try:
         module_path, class_name = class_path.rsplit(".", 1)
     except ValueError as e:

--- a/python/packages/jumpstarter/jumpstarter/common/importlib_test.py
+++ b/python/packages/jumpstarter/jumpstarter/common/importlib_test.py
@@ -10,12 +10,12 @@ def test_import_class():
     with pytest.raises(MissingDriverError):
         import_class("os.invalid", [], True)
 
-    with pytest.raises(ImportError):
+    with pytest.raises(MissingDriverError):
         import_class("os.open", [], False)
 
     import_class("os.open", ["os.*"], False)
 
-    with pytest.raises(ImportError):
+    with pytest.raises(MissingDriverError):
         import_class("os.open", ["sys.*"], False)
 
     with pytest.raises(ImportError):


### PR DESCRIPTION
Otherwise, when using a env var client config, we will get an unrelated error like, when the user does not set `JMP_DRIVERS_UNSAFE=true` or `JMP_DRIVERS_ALLOW="UNSAFE"`


```shell
$ jmp shell -l video=true,enabled=true,firmware=es21 --duration 1h
[07/10/26 10:17:01] INFO     [jumpstarter.client.lease] Acquiring lease 019f4ae3-0d14-7b6e-8de2-68dad96972a3 for selector video=true,enabled=true,firmware=es21 for duration 1:00:00
[07/10/26 10:17:02] INFO     Waiting for ready connection at /var/folders/4m/llxcfbf1431fz8bjyr5cxtgr0000gn/T/jumpstarter-dfsi03r_/socket
[07/10/26 10:17:03] INFO     Releasing Lease 019f4ae3-0d14-7b6e-8de2-68dad96972a3
Error: Connection to exporter lost
```

with this change:
```shell
$ jmp shell -l video=true,enabled=true,firmware=es21 --duration 1h
[07/10/26 10:16:48] INFO     [jumpstarter.client.lease] Acquiring lease 019f4ae2-d828-76e4-865e-1017ef2dc5d8 for selector video=true,enabled=true,firmware=es21 for duration 1:00:00
                    INFO     Waiting for ready connection at /var/folders/4m/llxcfbf1431fz8bjyr5cxtgr0000gn/T/jumpstarter-4plbwien/socket
[07/10/26 10:16:50] WARNING  [jumpstarter.client.client] Driver client 'jumpstarter_driver_snmp.client.SNMPServerClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_network.client.NetworkClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_ustreamer.client.UStreamerClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_opendal.client.OpendalClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_pyserial.client.PySerialClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_shell.client.ShellClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_network.client.NetworkClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_network.client.NetworkClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_network.client.NetworkClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_network.client.NetworkClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_ridesx.client.RideSXPowerClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_ridesx.client.RideSXPowerClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_ssh.client.SSHWrapperClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_ssh.client.SSHWrapperClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_tmt.client.TMTClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_vnc.client.VNClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_ridesx.client.RideSXClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_composite.client.CompositeClient' is not available.
                    WARNING  Driver client 'jumpstarter_driver_composite.client.CompositeClient' is not available.
                    INFO     [jumpstarter_cli.shell] Waiting for beforeLease hook to complete...
                    INFO     [jumpstarter.client.status_monitor] Status changed: None -> LEASE_READY (version=2)
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
jumpstarter⚡qti-snapdragon-ride4-sa8775p-22➤
```

and when the user tries to use `j`:
```
│ │ ╰──────────────────────────────────────────────────────────────────────────────────────────╯ │ │
│ │ ImportError: Driver 'jumpstarter_driver_composite.client.CompositeClient' is not installed.  │ │
│ │                                                                                              │ │
│ │ This usually indicates a version mismatch between your client and the exporter.              │ │
│ │ Please try to update your client to the latest version and ensure the exporter has the       │ │
│ │ correct version installed.                                                                   │ │
```