### PR TITLE
fix: replace deprecated asyncio event loop patterns

### DIFF
--- a/python/packages/jumpstarter-driver-mitmproxy/examples/addons/data_stream_websocket.py
+++ b/python/packages/jumpstarter-driver-mitmproxy/examples/addons/data_stream_websocket.py
@@ -131,7 +131,7 @@ class Handler:
                     "normal", DEFAULT_SCENARIOS["normal"],
                 ))
 
-                task = asyncio.ensure_future(
+                task = asyncio.create_task(
                     self._push_telemetry(
                         flow, scenario, interval_ms / 1000.0,
                     )
@@ -169,7 +169,7 @@ class Handler:
                 new_scenario, DEFAULT_SCENARIOS["normal"],
             ))
             interval_ms = config.get("push_interval_ms", 100)
-            task = asyncio.ensure_future(
+            task = asyncio.create_task(
                 self._push_telemetry(
                     flow, scenario, interval_ms / 1000.0,
                 )

--- a/python/packages/jumpstarter-driver-shell/jumpstarter_driver_shell/driver.py
+++ b/python/packages/jumpstarter-driver-shell/jumpstarter_driver_shell/driver.py
@@ -198,14 +198,14 @@ class Shell(Driver):
         )
 
         # Create a task to monitor the process timeout
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
 
         if timeout is None:
             timeout = self.timeout
 
         # Read output in real-time
         while process.returncode is None:
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            if asyncio.get_running_loop().time() - start_time > timeout:
                 # Send SIGTERM to entire process group for graceful termination
                 try:
                     os.killpg(process.pid, signal.SIGTERM)

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver.py
@@ -67,27 +67,31 @@ class Tftp(Driver):
         return "jumpstarter_driver_tftp.client.TftpServerClient"
 
     def _start_server(self):
-        self._loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._loop)
+        try:
+            asyncio.run(self._run_server_lifecycle())
+        except Exception as e:
+            self.logger.error(f"Error running TFTP server: {e}")
+        finally:
+            self.logger.info("TFTP server thread completed")
+
+    async def _run_server_lifecycle(self):
+        """Set up and run the TFTP server within a proper async context.
+
+        This ensures asyncio.Event() objects inside TftpServer are created
+        with a running event loop, as required by Python 3.14+.
+        """
+        self._loop = asyncio.get_running_loop()
         self.server = TftpServer(
             host=self.host,
             port=self.port,
             operator=self.children["storage"]._operator,
             logger=self.logger,
         )
+        self._loop_ready.set()
         try:
-            self._loop_ready.set()
-            self._loop.run_until_complete(self._run_server())
-        except Exception as e:
-            self.logger.error(f"Error running TFTP server: {e}")
+            await self._run_server()
         finally:
-            try:
-                self._loop.run_until_complete(self._loop.shutdown_asyncgens())
-                self._loop.close()
-            except Exception as e:
-                self.logger.error(f"Error during event loop cleanup: {e}")
             self._loop = None
-            self.logger.info("TFTP server thread completed")
 
     async def _run_server(self):
         try:

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver.py
@@ -45,6 +45,7 @@ class Tftp(Driver):
     _shutdown_event: threading.Event = field(init=False, default_factory=threading.Event)
     _loop_ready: threading.Event = field(init=False, default_factory=threading.Event)
     _loop: Optional[asyncio.AbstractEventLoop] = field(init=False, default=None)
+    _startup_error: Optional[BaseException] = field(init=False, default=None)
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -77,17 +78,26 @@ class Tftp(Driver):
     async def _run_server_lifecycle(self):
         """Set up and run the TFTP server within a proper async context.
 
-        This ensures asyncio.Event() objects inside TftpServer are created
-        with a running event loop, as required by Python 3.14+.
+        Uses asyncio.run() instead of the deprecated new_event_loop() +
+        set_event_loop() + run_until_complete() pattern, which emits
+        DeprecationWarning on Python 3.12/3.13 and breaks on 3.14
+        (get_event_loop() raises RuntimeError when no loop is running).
         """
-        self._loop = asyncio.get_running_loop()
-        self.server = TftpServer(
-            host=self.host,
-            port=self.port,
-            operator=self.children["storage"]._operator,
-            logger=self.logger,
-        )
-        self._loop_ready.set()
+        try:
+            self._loop = asyncio.get_running_loop()
+            self.server = TftpServer(
+                host=self.host,
+                port=self.port,
+                operator=self.children["storage"]._operator,
+                logger=self.logger,
+            )
+        except Exception as e:
+            self._startup_error = e
+            raise
+        finally:
+            # Always unblock start() so it can check _startup_error
+            # instead of waiting for the full timeout.
+            self._loop_ready.set()
         try:
             await self._run_server()
         finally:
@@ -124,6 +134,7 @@ class Tftp(Driver):
 
         self._shutdown_event.clear()
         self._loop_ready.clear()
+        self._startup_error = None
 
         self.server_thread = threading.Thread(target=self._start_server, daemon=True)
         self.server_thread.start()
@@ -132,6 +143,10 @@ class Tftp(Driver):
             self.logger.error("Timeout waiting for event loop to be ready")
             self.server_thread = None
             raise TftpError("Failed to start TFTP server - event loop initialization timeout")
+
+        if self._startup_error is not None:
+            self.server_thread = None
+            raise TftpError(f"Failed to start TFTP server: {self._startup_error}") from self._startup_error
 
         self.logger.info(f"TFTP server started on {self.host}:{self.port}")
 

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver_test.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver_test.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver_test.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver_test.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from jumpstarter_driver_tftp.driver import Tftp
+from jumpstarter_driver_tftp.driver import Tftp, TftpError
 
 from jumpstarter.common.utils import serve
 
@@ -85,10 +85,10 @@ def test_tftp_start_server_logs_error_on_failure(tmp_path):
 
 @pytest.mark.anyio
 async def test_tftp_run_server_lifecycle_creates_server_in_async_context(tmp_path):
-    """Test that _run_server_lifecycle creates TftpServer with a running event loop.
+    """Test that _run_server_lifecycle creates TftpServer within asyncio.run().
 
-    This is the key fix: asyncio.Event() objects inside TftpServer are now
-    created with a running loop, which is required by Python 3.14+.
+    This validates the replacement of the deprecated new_event_loop() +
+    set_event_loop() + run_until_complete() pattern with asyncio.run().
     """
     server = Tftp(root_dir=str(tmp_path), host="127.0.0.1", port=0)
 
@@ -96,10 +96,29 @@ async def test_tftp_run_server_lifecycle_creates_server_in_async_context(tmp_pat
     with patch.object(server, "_run_server", new_callable=AsyncMock):
         await server._run_server_lifecycle()
 
-    # Server was created in async context, Event() objects are bound to a loop
+    # Server was created in async context
     assert server.server is not None
     assert server.server.shutdown_event is not None
     assert server.server.ready_event is not None
     # Loop ref is cleaned up in the finally block
     assert server._loop is None
+    server.close()
+
+
+def test_tftp_start_surfaces_startup_error(tmp_path):
+    """Test that start() surfaces the real error instead of a generic timeout.
+
+    If TftpServer construction fails inside _run_server_lifecycle, the
+    _startup_error field is set and _loop_ready is signalled via finally,
+    so start() returns promptly and raises the actual cause.
+    """
+    server = Tftp(root_dir=str(tmp_path), host="127.0.0.1", port=0)
+
+    with patch(
+        "jumpstarter_driver_tftp.driver.TftpServer",
+        side_effect=RuntimeError("port already in use"),
+    ):
+        with pytest.raises(TftpError, match="port already in use"):
+            server.start()
+
     server.close()

--- a/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver_test.py
+++ b/python/packages/jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver_test.py
@@ -1,3 +1,6 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from jumpstarter_driver_tftp.driver import Tftp
@@ -43,4 +46,61 @@ def test_tftp_root_directory_creation(tmp_path):
     new_dir = tmp_path / "new_tftp_root"
     server = Tftp(root_dir=str(new_dir))
     assert new_dir.exists()
+    server.close()
+
+
+def test_tftp_start_stop(tmp_path):
+    """Test that start/stop lifecycle works via asyncio.run() in the server thread."""
+    server = Tftp(root_dir=str(tmp_path), host="127.0.0.1", port=0)
+    server.start()
+    try:
+        # _run_server_lifecycle ran: loop was captured and server was created
+        assert server.server is not None
+        assert server._loop is not None
+    finally:
+        server.stop()
+    server.close()
+
+
+def test_tftp_start_stop_cleans_up_loop(tmp_path):
+    """Test that _loop is set to None after shutdown."""
+    server = Tftp(root_dir=str(tmp_path), host="127.0.0.1", port=0)
+    server.start()
+    server.stop()
+    # After stop, the thread has exited and _loop should be cleaned up
+    assert server._loop is None
+    server.close()
+
+
+def test_tftp_start_server_logs_error_on_failure(tmp_path):
+    """Test the error handling path in _start_server."""
+    server = Tftp(root_dir=str(tmp_path), host="127.0.0.1", port=0)
+
+    with patch.object(server, "_run_server_lifecycle", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+        # _start_server runs in the calling thread here (not via start())
+        server._start_server()
+
+    # Should not raise, error is logged
+    server.close()
+
+
+@pytest.mark.anyio
+async def test_tftp_run_server_lifecycle_creates_server_in_async_context(tmp_path):
+    """Test that _run_server_lifecycle creates TftpServer with a running event loop.
+
+    This is the key fix: asyncio.Event() objects inside TftpServer are now
+    created with a running loop, which is required by Python 3.14+.
+    """
+    server = Tftp(root_dir=str(tmp_path), host="127.0.0.1", port=0)
+
+    # Patch _run_server so we don't actually start listening
+    with patch.object(server, "_run_server", new_callable=AsyncMock):
+        await server._run_server_lifecycle()
+
+    # Server was created in async context, Event() objects are bound to a loop
+    assert server.server is not None
+    assert server.server.shutdown_event is not None
+    assert server.server.ready_event is not None
+    # Loop ref is cleaned up in the finally block
+    assert server._loop is None
     server.close()

--- a/python/packages/jumpstarter-driver-tftp/pyproject.toml
+++ b/python/packages/jumpstarter-driver-tftp/pyproject.toml
@@ -38,6 +38,10 @@ log_cli = true
 log_cli_level = "INFO"
 testpaths = ["jumpstarter_driver_tftp"]
 asyncio_mode = "auto"
+addopts = "--cov --cov-report=html --cov-report=xml"
+
+[tool.coverage.run]
+source = ["."]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]


### PR DESCRIPTION
## Summary

Audited the entire codebase for deprecated asyncio event loop patterns that emit `DeprecationWarning` on Python 3.12/3.13 and will break on Python 3.14. Found and fixed three locations (the SNMP driver had the same issue and was already fixed in #775).

## Compatibility matrix

| Deprecated pattern | 3.12 | 3.13 | 3.14 | Replacement (since 3.7) |
|---|---|---|---|---|
| `get_event_loop()` (no running loop) | DeprecationWarning | DeprecationWarning | **RuntimeError** | `get_running_loop()` |
| `set_event_loop()` | DeprecationWarning | DeprecationWarning | **No-op** | `asyncio.run()` |
| `asyncio.Event()` (no running loop) | DeprecationWarning | DeprecationWarning | **RuntimeError** | Create inside `async def` |
| `ensure_future()` | DeprecationWarning | DeprecationWarning | DeprecationWarning | `create_task()` |

## Changes

### 1. TFTP driver (HIGH — will crash on 3.14)

`jumpstarter-driver-tftp/jumpstarter_driver_tftp/driver.py`

`_start_server()` ran in a thread using `new_event_loop()` + `set_event_loop()` + `run_until_complete()`, and constructed `TftpServer` (which creates `asyncio.Event()` objects) before the loop was running.

Replaced with `asyncio.run()` and moved `TftpServer` construction into an async method so `asyncio.Event()` objects are created with a running loop.

### 2. Shell driver (MEDIUM — deprecation warnings on 3.12/3.13)

`jumpstarter-driver-shell/jumpstarter_driver_shell/driver.py`

Replaced `asyncio.get_event_loop().time()` with `asyncio.get_running_loop().time()` (called from async context, so trivial swap).

### 3. mitmproxy example (LOW — deprecated but functional)

`jumpstarter-driver-mitmproxy/examples/addons/data_stream_websocket.py`

Replaced `asyncio.ensure_future()` with `asyncio.create_task()`.

## Audit scope

Searched all Python packages for `get_event_loop`, `new_event_loop`, `set_event_loop`, `run_until_complete`, `ensure_future`, and `asyncio.Event()`/`Queue()`/`Lock()` created outside async contexts. The rest of the codebase already uses the correct modern APIs.