### PR TITLE
fix(dutlink): remove implicit power off from reset() and close()

### DIFF
--- a/python/packages/jumpstarter-driver-dutlink/jumpstarter_driver_dutlink/driver.py
+++ b/python/packages/jumpstarter-driver-dutlink/jumpstarter_driver_dutlink/driver.py
@@ -117,12 +117,6 @@ class DutlinkPower(DutlinkConfig, PowerInterface, Driver):
         self.last_action = action
         return result
 
-    def reset(self):
-        self.off()
-
-    def close(self):
-        self.off()
-
     @export
     def on(self) -> None:
         self.control("on")
@@ -188,12 +182,6 @@ class DutlinkStorageMux(DutlinkConfig, StorageMuxFlasherInterface, Driver):
             action,
             None,
         )
-
-    def reset(self):
-        self.off()
-
-    def close(self):
-        self.off()
 
     @export
     def host(self):


### PR DESCRIPTION
## Summary

Remove the `off()` calls from `reset()` and `close()` in `DutlinkPower` and `DutlinkStorageMux`.

## Problem

Depending on the hardware configuration, DUTLink power control USB transfers can block for **15-20+ seconds**. Since `reset()` is called at lease start and `close()` at lease end, this means up to ~40 seconds of exporter blocking per lease cycle just for implicit power-off operations — even when the device is already off or the user is about to power it on.

## Solution

Remove the implicit `off()` from both lifecycle methods. Power and storage mux state management becomes the responsibility of:

- **The user** — via explicit `power.off()` / `storage.off()` calls during their session
- **The admin** — via pre/post lease hooks (e.g. `j power off` in an `afterLease` hook)

This is consistent with how other hardware drivers already behave — they don't implicitly power off on lease boundaries.

## Changes

- `DutlinkPower`: removed `reset()` and `close()` overrides (both just called `self.off()`)
- `DutlinkStorageMux`: removed `reset()` and `close()` overrides (both just called `self.off()`)

The base `Driver.reset()` / `Driver.close()` methods still run (recursing into children), but since these sub-drivers have no children of their own, it's effectively a no-op.