### PR TITLE
fix: catch shell command exceptions

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/common/utils.py
+++ b/python/packages/jumpstarter/jumpstarter/common/utils.py
@@ -86,7 +86,17 @@ def _run_process(
     lease=None,
 ) -> int:
     """Helper to run a process with an option to set a lease ending callback."""
-    process = Popen(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, env=env)
+    try:
+        process = Popen(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, env=env)
+    except FileNotFoundError:
+        print(f"Error: command not found: {cmd[0]}", file=sys.stderr)
+        return 127
+    except PermissionError:
+        print(f"Error: permission denied: {cmd[0]}", file=sys.stderr)
+        return 126
+    except OSError as exc:
+        print(f"Error: cannot execute {cmd[0]}: {exc}", file=sys.stderr)
+        return 126
     if lease is not None:
         lease.lease_ending_callback = partial(lease_ending_handler, process)
     return process.wait()

--- a/python/packages/jumpstarter/jumpstarter/common/utils_test.py
+++ b/python/packages/jumpstarter/jumpstarter/common/utils_test.py
@@ -29,6 +29,50 @@ def test_launch_shell(tmp_path, monkeypatch):
     assert exit_code == 1
 
 
+def test_launch_shell_command_not_found(tmp_path, capfd):
+    exit_code = launch_shell(
+        host=str(tmp_path / "test.sock"),
+        context="remote",
+        allow=["*"],
+        unsafe=False,
+        use_profiles=False,
+        command=("nonexistent_binary_xyz",),
+    )
+    assert exit_code == 127
+    assert "command not found: nonexistent_binary_xyz" in capfd.readouterr().err
+
+
+def test_launch_shell_permission_denied(tmp_path, capfd):
+    script = tmp_path / "not_executable.sh"
+    script.write_text("#!/bin/sh\necho hi\n")
+    script.chmod(0o644)
+    exit_code = launch_shell(
+        host=str(tmp_path / "test.sock"),
+        context="remote",
+        allow=["*"],
+        unsafe=False,
+        use_profiles=False,
+        command=(str(script),),
+    )
+    assert exit_code == 126
+    assert "permission denied" in capfd.readouterr().err
+
+
+def test_launch_shell_oserror(tmp_path, capfd):
+    from unittest.mock import patch
+    with patch("jumpstarter.common.utils.Popen", side_effect=OSError(22, "Invalid argument")):
+        exit_code = launch_shell(
+            host=str(tmp_path / "test.sock"),
+            context="remote",
+            allow=["*"],
+            unsafe=False,
+            use_profiles=False,
+            command=("some_cmd",),
+        )
+    assert exit_code == 126
+    assert "cannot execute" in capfd.readouterr().err
+
+
 def test_launch_shell_sets_lease_env(tmp_path, monkeypatch):
     env_output = tmp_path / "env_output.txt"
     script = tmp_path / "capture_env.sh"


### PR DESCRIPTION
Otherwise we get unrelated errors like:

```shell
jmp shell --selector dut=demo --client demo-starve -- shell hello
[07/11/26 16:33:13] INFO     [jumpstarter.client.lease] Acquiring lease 019f5161-d4ae-7ebd-bfca-55e170a24392 for selector dut=demo for duration 0:30:00
[07/11/26 16:33:14] INFO     Waiting for ready connection at /var/folders/4m/llxcfbf1431fz8bjyr5cxtgr0000gn/T/jumpstarter-52z1j_9f/socket
[07/11/26 16:33:15] INFO     [jumpstarter_cli.shell] Waiting for beforeLease hook to complete...
                    INFO     [jumpstarter.client.status_monitor] Status changed: None -> LEASE_READY (version=2)
                    INFO     [jumpstarter.client.lease] Releasing Lease 019f5161-d4ae-7ebd-bfca-55e170a24392
Error: Connection to exporter lost
```

with fix:
```shell
[07/11/26 16:34:13] INFO     [jumpstarter.client.lease] Acquiring lease 019f5162-bc17-7a76-b827-f5d5ebbf83e7 for selector dut=demo for duration 0:30:00
                    INFO     Waiting for ready connection at /var/folders/4m/llxcfbf1431fz8bjyr5cxtgr0000gn/T/jumpstarter-e663mgog/socket
[07/11/26 16:34:14] INFO     [jumpstarter_cli.shell] Waiting for beforeLease hook to complete...
                    INFO     [jumpstarter.client.status_monitor] Status changed: None -> LEASE_READY (version=2)
Error: command not found: shell
                    INFO     [jumpstarter_cli.shell] Running afterLease hook (Ctrl+C to skip)...
                    INFO     [jumpstarter.client.status_monitor] Status changed: LEASE_READY -> AVAILABLE (version=3)
                    INFO     [jumpstarter_cli.shell] afterLease hook completed
[07/11/26 16:34:15] INFO     [jumpstarter.client.lease] Releasing Lease 019f5162-bc17-7a76-b827-f5d5ebbf83e7
```