### PR TITLE
fix: force close the socket when cleaning up http thread (#889)

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -69,7 +69,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build the documentation
-        run: make docs-all
+        run: make docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/python/packages/jumpstarter-driver-http/jumpstarter_driver_http/driver.py
+++ b/python/packages/jumpstarter-driver-http/jumpstarter_driver_http/driver.py
@@ -137,12 +137,29 @@ class HttpServer(Driver):
         if self.runner:
             try:
                 anyio.from_thread.run(self._async_cleanup)
-            except Exception as e:
-                self.logger.warning(f"HTTP server cleanup failed: {e}")
+            except Exception:
+                self._force_close_sockets()
             finally:
                 self.runner = None
                 self._bound_port = 0
         super().close()
+
+    def _force_close_sockets(self):
+        """Force-close server sockets when async cleanup is unavailable.
+
+        When close() is called from the event loop thread (e.g. during
+        Session teardown), anyio.from_thread.run() cannot dispatch the
+        async cleanup. Closing the underlying transport sockets directly
+        ensures the port is released.
+        """
+        try:
+            if self.runner:
+                for site in self.runner.sites:
+                    if hasattr(site, "_server") and site._server:
+                        site._server.close()
+            self.logger.info("HTTP server sockets force-closed.")
+        except Exception as e:
+            self.logger.warning(f"HTTP server force-close failed: {e}")
 
     async def _async_cleanup(self):
         try:

--- a/python/packages/jumpstarter-driver-http/jumpstarter_driver_http/driver_test.py
+++ b/python/packages/jumpstarter-driver-http/jumpstarter_driver_http/driver_test.py
@@ -222,18 +222,22 @@ async def test_driver_port_zero_assigns_real_port(tmp_path):
 
 @pytest.mark.anyio
 async def test_driver_close_with_running_loop(tmp_path, unused_tcp_port):
-    """close() while an event loop is running should clean up via anyio."""
-    server = HttpServer(root_dir=str(tmp_path), port=unused_tcp_port)
+    """close() from the event loop thread must release the port."""
+    server = HttpServer(root_dir=str(tmp_path), host="127.0.0.1", port=unused_tcp_port)
     await server.start()
     assert server.runner is not None
 
-    # close() is synchronous; when called from an async context,
-    # anyio.from_thread.run() may not work (we're on the event loop thread),
-    # but the finally block still sets runner=None and _bound_port=0.
     server.close()
 
     assert server.runner is None
     assert server._bound_port == 0
+
+    import socket
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind((server.host, unused_tcp_port))
+    finally:
+        s.close()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
fixes #888

reproducer:
1. Start flashing with the flasher driver, kill/ctrl+c mid flash
2. delete the lease
3. create a shell with a new lease and try to flash again, which will fail on address already in use


(cherry picked from commit a54aa4aa6e454e7802a19e1057d6e286b8b464c1)