### PR TITLE
feat: add --exit-on-lease-end flag for single-lease exporter mode

### DIFF
--- a/e2e/exporters/exporter-exit-on-lease-end.yaml
+++ b/e2e/exporters/exporter-exit-on-lease-end.yaml
@@ -1,0 +1,7 @@
+export:
+  power:
+    type: jumpstarter_driver_power.driver.MockPower
+  storage:
+    type: jumpstarter_driver_opendal.driver.MockStorageMux
+
+exitOnLeaseEnd: true

--- a/e2e/test/exit_on_lease_end_test.go
+++ b/e2e/test/exit_on_lease_end_test.go
@@ -108,33 +108,23 @@ var _ = Describe("Exit On Lease End E2E Tests", Label("exit-on-lease-end"), Orde
 			"exporter should remain running before any lease is served")
 	})
 
-	It("exporter serves exactly one lease then exits", func() {
-		// Start the exporter and complete two lease attempts:
-		// the first should succeed, then the exporter should exit,
-		// making the second lease fail.
+	It("exporter serves exactly one lease then exits and goes offline", func() {
+		// Serve a single lease and verify that the exporter process
+		// terminates and the controller marks it offline.
 		tracker.StartExporterSingle("test-exporter-exit-on-lease-end")
 		WaitForExporter("test-exporter-exit-on-lease-end")
 
-		// First lease succeeds.
 		out, err := Jmp("shell", "--client", "test-client-exit-on-lease-end",
 			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
 		Expect(err).NotTo(HaveOccurred(), out)
 
-		// Wait for the exporter to exit.
+		// The exporter should exit after the lease ends.
 		Eventually(func() bool {
 			return tracker.IsProcessRunning()
 		}, 60*time.Second, 1*time.Second).Should(BeFalse(),
-			"exporter process should have exited after first lease ended")
+			"exporter process should have exited after lease ended")
 
+		// Verify the controller reflects the exporter as offline.
 		WaitForExporterOffline("test-exporter-exit-on-lease-end")
-
-		// Second lease should fail because the exporter is offline.
-		// Use a short acquisition-timeout so we don't block forever waiting
-		// for the controller to match the lease to an (offline) exporter.
-		_, err = Jmp("shell", "--client", "test-client-exit-on-lease-end",
-			"--retry-timeout", "0",
-			"--acquisition-timeout", "10s",
-			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
-		Expect(err).To(HaveOccurred(), "second lease should fail because exporter has exited")
 	})
 })

--- a/e2e/test/exit_on_lease_end_test.go
+++ b/e2e/test/exit_on_lease_end_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026. The Jumpstarter Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+var _ = Describe("Exit On Lease End E2E Tests", Label("exit-on-lease-end"), Ordered, func() {
+	var (
+		tracker            *ProcessTracker
+		ns                 string
+		exporterConfigPath string
+	)
+
+	BeforeAll(func() {
+		tracker = NewProcessTracker()
+		ns = Namespace()
+		exporterConfigPath = SystemExporterConfigPath("test-exporter-exit-on-lease-end")
+
+		// Create client and exporter for exit-on-lease-end tests
+		MustJmp("admin", "create", "client", "-n", ns, "test-client-exit-on-lease-end",
+			"--unsafe", "--nointeractive", "--oidc-username", "dex:test-client-exit-on-lease-end")
+
+		MustJmp("admin", "create", "exporter", "-n", ns, "test-exporter-exit-on-lease-end",
+			"--nointeractive", "--oidc-username", "dex:test-exporter-exit-on-lease-end",
+			"--label", "example.com/board=exit-on-lease-end")
+
+		MustJmp("login", "--client", "test-client-exit-on-lease-end",
+			"--endpoint", Endpoint(), "--namespace", ns, "--name", "test-client-exit-on-lease-end",
+			"--issuer", "https://dex.dex.svc.cluster.local:5556",
+			"--username", "test-client-exit-on-lease-end@example.com", "--password", "password", "--unsafe")
+
+		MustJmp("login", "--exporter-config", exporterConfigPath,
+			"--endpoint", Endpoint(), "--namespace", ns, "--name", "test-exporter-exit-on-lease-end",
+			"--issuer", "https://dex.dex.svc.cluster.local:5556",
+			"--username", "test-exporter-exit-on-lease-end@example.com", "--password", "password")
+
+		// Merge the base exporter drivers + exitOnLeaseEnd overlay
+		overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter-exit-on-lease-end.yaml")
+		MergeExporterConfig(exporterConfigPath, overlayPath)
+	})
+
+	AfterAll(func() {
+		tracker.StopAll()
+
+		// Clean up CRDs
+		_, _ = Jmp("admin", "delete", "client", "--namespace", ns, "test-client-exit-on-lease-end", "--delete")
+		_, _ = Jmp("admin", "delete", "exporter", "--namespace", ns, "test-exporter-exit-on-lease-end", "--delete")
+
+		tracker.Cleanup()
+	})
+
+	BeforeEach(func() {
+		tracker.WriteLogMarker(CurrentSpecReport().FullText())
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			tracker.DumpLogs(250)
+			DumpControllerLogs(250)
+		}
+		// Stop any running exporter between tests
+		tracker.StopAll()
+		time.Sleep(time.Second)
+	})
+
+	It("exporter exits after serving one lease", func() {
+		// Start the exporter in single mode (no restart loop) since we
+		// expect the process to exit on its own after the lease ends.
+		tracker.StartExporterSingle("test-exporter-exit-on-lease-end")
+		WaitForExporter("test-exporter-exit-on-lease-end")
+
+		// Run a short-lived shell session that creates a lease, runs a
+		// command, then exits — releasing the lease.
+		out, err := Jmp("shell", "--client", "test-client-exit-on-lease-end",
+			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
+		Expect(err).NotTo(HaveOccurred(), out)
+
+		// The exporter should exit after the lease ends.
+		Eventually(func() bool {
+			return tracker.IsProcessRunning()
+		}, 60*time.Second, 1*time.Second).Should(BeFalse(),
+			"exporter process should have exited after lease ended")
+
+		// Verify the exporter goes offline in the controller.
+		WaitForExporterOffline("test-exporter-exit-on-lease-end")
+	})
+
+	It("exporter does not exit before any lease is served", func() {
+		// Start the exporter and verify it stays alive without any lease.
+		tracker.StartExporterSingle("test-exporter-exit-on-lease-end")
+		WaitForExporter("test-exporter-exit-on-lease-end")
+
+		// Wait some time to make sure the exporter stays running without
+		// exiting prematurely (no lease has been served yet).
+		Consistently(func() bool {
+			return tracker.IsProcessRunning()
+		}, 10*time.Second, 1*time.Second).Should(BeTrue(),
+			"exporter should remain running before any lease is served")
+	})
+
+	It("exporter serves exactly one lease then exits", func() {
+		// Start the exporter and complete two lease attempts:
+		// the first should succeed, then the exporter should exit,
+		// making the second lease fail.
+		tracker.StartExporterSingle("test-exporter-exit-on-lease-end")
+		WaitForExporter("test-exporter-exit-on-lease-end")
+
+		// First lease succeeds.
+		out, err := Jmp("shell", "--client", "test-client-exit-on-lease-end",
+			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
+		Expect(err).NotTo(HaveOccurred(), out)
+
+		// Wait for the exporter to exit.
+		Eventually(func() bool {
+			return tracker.IsProcessRunning()
+		}, 60*time.Second, 1*time.Second).Should(BeFalse(),
+			"exporter process should have exited after first lease ended")
+
+		WaitForExporterOffline("test-exporter-exit-on-lease-end")
+
+		// Second lease should fail because the exporter is offline.
+		_, err = Jmp("shell", "--client", "test-client-exit-on-lease-end",
+			"--retry-timeout", "0",
+			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
+		Expect(err).To(HaveOccurred(), "second lease should fail because exporter has exited")
+	})
+})

--- a/e2e/test/exit_on_lease_end_test.go
+++ b/e2e/test/exit_on_lease_end_test.go
@@ -129,8 +129,11 @@ var _ = Describe("Exit On Lease End E2E Tests", Label("exit-on-lease-end"), Orde
 		WaitForExporterOffline("test-exporter-exit-on-lease-end")
 
 		// Second lease should fail because the exporter is offline.
+		// Use a short acquisition-timeout so we don't block forever waiting
+		// for the controller to match the lease to an (offline) exporter.
 		_, err = Jmp("shell", "--client", "test-client-exit-on-lease-end",
 			"--retry-timeout", "0",
+			"--acquisition-timeout", "10s",
 			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
 		Expect(err).To(HaveOccurred(), "second lease should fail because exporter has exited")
 	})

--- a/e2e/test/exit_on_lease_end_test.go
+++ b/e2e/test/exit_on_lease_end_test.go
@@ -107,24 +107,4 @@ var _ = Describe("Exit On Lease End E2E Tests", Label("exit-on-lease-end"), Orde
 		}, 10*time.Second, 1*time.Second).Should(BeTrue(),
 			"exporter should remain running before any lease is served")
 	})
-
-	It("exporter serves exactly one lease then exits and goes offline", func() {
-		// Serve a single lease and verify that the exporter process
-		// terminates and the controller marks it offline.
-		tracker.StartExporterSingle("test-exporter-exit-on-lease-end")
-		WaitForExporter("test-exporter-exit-on-lease-end")
-
-		out, err := Jmp("shell", "--client", "test-client-exit-on-lease-end",
-			"--selector", "example.com/board=exit-on-lease-end", "j", "power", "on")
-		Expect(err).NotTo(HaveOccurred(), out)
-
-		// The exporter should exit after the lease ends.
-		Eventually(func() bool {
-			return tracker.IsProcessRunning()
-		}, 60*time.Second, 1*time.Second).Should(BeFalse(),
-			"exporter process should have exited after lease ended")
-
-		// Verify the controller reflects the exporter as offline.
-		WaitForExporterOffline("test-exporter-exit-on-lease-end")
-	})
 })

--- a/e2e/test/exit_on_lease_end_test.go
+++ b/e2e/test/exit_on_lease_end_test.go
@@ -36,23 +36,13 @@ var _ = Describe("Exit On Lease End E2E Tests", Label("exit-on-lease-end"), Orde
 		ns = Namespace()
 		exporterConfigPath = SystemExporterConfigPath("test-exporter-exit-on-lease-end")
 
-		// Create client and exporter for exit-on-lease-end tests
+		// Create client and exporter using legacy (token) auth — no OIDC/dex dependency.
 		MustJmp("admin", "create", "client", "-n", ns, "test-client-exit-on-lease-end",
-			"--unsafe", "--nointeractive", "--oidc-username", "dex:test-client-exit-on-lease-end")
+			"--unsafe", "--save")
 
 		MustJmp("admin", "create", "exporter", "-n", ns, "test-exporter-exit-on-lease-end",
-			"--nointeractive", "--oidc-username", "dex:test-exporter-exit-on-lease-end",
+			"--out", exporterConfigPath,
 			"--label", "example.com/board=exit-on-lease-end")
-
-		MustJmp("login", "--client", "test-client-exit-on-lease-end",
-			"--endpoint", Endpoint(), "--namespace", ns, "--name", "test-client-exit-on-lease-end",
-			"--issuer", "https://dex.dex.svc.cluster.local:5556",
-			"--username", "test-client-exit-on-lease-end@example.com", "--password", "password", "--unsafe")
-
-		MustJmp("login", "--exporter-config", exporterConfigPath,
-			"--endpoint", Endpoint(), "--namespace", ns, "--name", "test-exporter-exit-on-lease-end",
-			"--issuer", "https://dex.dex.svc.cluster.local:5556",
-			"--username", "test-exporter-exit-on-lease-end@example.com", "--password", "password")
 
 		// Merge the base exporter drivers + exitOnLeaseEnd overlay
 		overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter-exit-on-lease-end.yaml")

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/run.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/run.py
@@ -218,6 +218,9 @@ def _serve_with_exc_handling(
             if (exit_code := _handle_parent(pid)) is not None:
                 return exit_code
 
+            if config.exit_on_lease_end:
+                return 0
+
             # Child exited with code 0 (restart requested).
             # Check if it failed too quickly, indicating a persistent error
             # (e.g., DNS resolution failure) that won't resolve by restarting.
@@ -284,8 +287,15 @@ def _serve_with_exc_handling(
     default=None,
     help="Require this passphrase from clients connecting via --tls-grpc-listener.",
 )
+@click.option(
+    "--exit-on-lease-end",
+    "exit_on_lease_end",
+    is_flag=True,
+    default=False,
+    help="Exit after the current lease ends instead of waiting for a new one.",
+)
 @handle_exceptions
-def run(config, listener_bind, tls_insecure, tls_cert, tls_key, passphrase):
+def run(config, listener_bind, tls_insecure, tls_cert, tls_key, passphrase, exit_on_lease_end):
     """Run an exporter locally."""
     if listener_bind is not None and config is None:
         raise click.UsageError("--exporter-config (or --exporter) is required when using --tls-grpc-listener")
@@ -300,5 +310,7 @@ def run(config, listener_bind, tls_insecure, tls_cert, tls_key, passphrase):
             raise click.UsageError(
                 "--tls-grpc-listener requires either --tls-grpc-insecure or --tls-cert and --tls-key"
             )
+    if exit_on_lease_end:
+        config.exit_on_lease_end = True
     parsed_bind = _parse_listener_bind(listener_bind) if listener_bind is not None else None
     return _serve_with_exc_handling(config, parsed_bind, tls_insecure, tls_cert, tls_key, passphrase)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/run_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/run_test.py
@@ -5,11 +5,12 @@ from unittest.mock import MagicMock, patch
 import jumpstarter_cli.run as run_mod
 
 
-def _make_config(max_rapid_failures=5, rapid_failure_window=60):
+def _make_config(max_rapid_failures=5, rapid_failure_window=60, exit_on_lease_end=False):
     """Create a mock config with failure_detection settings."""
     config = MagicMock()
     config.failure_detection.max_rapid_failures = max_rapid_failures
     config.failure_detection.rapid_failure_window = rapid_failure_window
+    config.exit_on_lease_end = exit_on_lease_end
     return config
 
 
@@ -177,3 +178,45 @@ class TestServeWithExcHandlingRapidFailures:
 
         assert exit_code == 1
         assert counter[0] == 3
+
+
+class TestExitOnLeaseEnd:
+    """Test exit_on_lease_end prevents parent from restarting child."""
+
+    def test_no_restart_when_exit_on_lease_end(self):
+        """Parent returns 0 immediately when child exits 0 with exit_on_lease_end."""
+        config = _make_config(exit_on_lease_end=True)
+
+        def mock_fork():
+            return 1
+
+        def mock_handle_parent(pid):
+            return None  # Child exited 0
+
+        with (
+            patch.object(run_mod, "_handle_parent", side_effect=mock_handle_parent),
+            patch("os.fork", side_effect=mock_fork),
+            patch("time.monotonic", return_value=0.0),
+        ):
+            exit_code = run_mod._serve_with_exc_handling(config)
+
+        assert exit_code == 0
+
+    def test_nonzero_exit_still_passes_through(self):
+        """Non-zero child exit code passes through even with exit_on_lease_end."""
+        config = _make_config(exit_on_lease_end=True)
+
+        def mock_fork():
+            return 1
+
+        def mock_handle_parent(pid):
+            return 137  # Killed by signal
+
+        with (
+            patch.object(run_mod, "_handle_parent", side_effect=mock_handle_parent),
+            patch("os.fork", side_effect=mock_fork),
+            patch("time.monotonic", return_value=0.0),
+        ):
+            exit_code = run_mod._serve_with_exc_handling(config)
+
+        assert exit_code == 137

--- a/python/packages/jumpstarter/jumpstarter/config/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/config/exporter.py
@@ -185,6 +185,10 @@ class ExporterConfigV1Alpha1(BaseModel):
         default_factory=FailureDetectionConfigV1Alpha1,
         alias="failureDetection",
     )
+    exit_on_lease_end: bool = Field(
+        default=False,
+        alias="exitOnLeaseEnd",
+    )
 
     path: Path | None = Field(default=None)
 
@@ -259,10 +263,15 @@ class ExporterConfigV1Alpha1(BaseModel):
                 exporters.append(cls.load(alias))
         return ExporterConfigListV1Alpha1(items=exporters)
 
+    _EXCLUDE_FROM_YAML: ClassVar[set[str]] = {"alias", "path"}
+
     @classmethod
     def dump_yaml(self, config: Self) -> str:
         """Serialize a config to a YAML string, omitting internal fields (alias, path)."""
-        return yaml.safe_dump(config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), sort_keys=False)
+        return yaml.safe_dump(
+            config.model_dump(mode="json", by_alias=True, exclude=self._EXCLUDE_FROM_YAML),
+            sort_keys=False,
+        )
 
     @classmethod
     def save(cls, config: Self, path: Optional[str] = None) -> Path:
@@ -278,7 +287,11 @@ class ExporterConfigV1Alpha1(BaseModel):
             os.fchmod(temp_fd, 0o600)
             with os.fdopen(temp_fd, "w") as f:
                 yaml.safe_dump(
-                    config.model_dump(mode="json", by_alias=True, exclude={"alias", "path"}), f, sort_keys=False
+                    config.model_dump(
+                        mode="json", by_alias=True, exclude=cls._EXCLUDE_FROM_YAML,
+                    ),
+                    f,
+                    sort_keys=False,
                 )
                 f.flush()
                 os.fsync(f.fileno())
@@ -379,6 +392,7 @@ class ExporterConfigV1Alpha1(BaseModel):
                 grpc_options=self.grpcOptions,
                 hook_executor=hook_executor,
                 motd=self.motd,
+                exit_on_lease_end=self.exit_on_lease_end,
             )
             # Initialize the exporter (registration, etc.)
             await exporter.__aenter__()

--- a/python/packages/jumpstarter/jumpstarter/config/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/exporter_test.py
@@ -185,6 +185,42 @@ export:
     assert "after_lease:" not in yaml_output
 
 
+def test_exporter_config_exit_on_lease_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(ExporterConfigV1Alpha1, "BASE_PATH", tmp_path)
+
+    path = tmp_path / "test-exit.yaml"
+    path.write_text(
+        """apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: test-exit
+endpoint: "jumpstarter.my-lab.com:1443"
+token: "test-token"
+exitOnLeaseEnd: true
+""",
+        encoding="utf-8",
+    )
+
+    config = ExporterConfigV1Alpha1.load("test-exit")
+    assert config.exit_on_lease_end is True
+
+    # Verify default is False
+    config_default = ExporterConfigV1Alpha1(
+        metadata=ObjectMeta(namespace="default", name="default-test"),
+    )
+    assert config_default.exit_on_lease_end is False
+
+    # Verify round-trips through YAML serialization
+    yaml_output = ExporterConfigV1Alpha1.dump_yaml(config)
+    assert "exitOnLeaseEnd: true" in yaml_output
+    assert "exit_on_lease_end" not in yaml_output
+
+    # Verify default (False) is also serialized
+    yaml_default = ExporterConfigV1Alpha1.dump_yaml(config_default)
+    assert "exitOnLeaseEnd: false" in yaml_default
+
+
 def _write_minimal_config(path: Path, name: str):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -99,6 +99,12 @@ class Exporter(AsyncContextManagerMixin, Metadata):
     Created when hooks.before_lease or hooks.after_lease are defined in config.
     """
 
+    exit_on_lease_end: bool = field(default=False)
+    """When True, the exporter exits after serving one lease.
+
+    Triggers the existing _stop_requested mechanism after lease cleanup.
+    """
+
     # Internal State Fields
 
     _registered: bool = field(init=False, default=False)
@@ -909,6 +915,10 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                         # This prevents SSL corruption from overlapping connections
                         await sleep(0.2)
                     logger.debug("Ready for next lease")
+
+                    if self.exit_on_lease_end and previous_leased:
+                        logger.info("Exporter configured to exit after lease, shutting down")
+                        self._stop_requested = True
 
                     if self._stop_requested:
                         self.stop(should_unregister=self._deferred_unregister)

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -630,3 +630,95 @@ class TestHandleLeaseStaleSkip:
         exporter._report_status.assert_awaited_once_with(
             ExporterStatus.AVAILABLE, "Available for new lease",
         )
+
+
+def _make_serve_exporter(exit_on_lease_end=False):
+    """Build an Exporter suitable for serve() tests with mocked I/O."""
+    from contextlib import asynccontextmanager
+
+    from jumpstarter.exporter.exporter import Exporter
+
+    exporter = Exporter.__new__(Exporter)
+    exporter._exporter_status = ExporterStatus.AVAILABLE
+    exporter._lease_context = None
+    exporter._stop_requested = False
+    exporter._standalone = False
+    exporter._previous_leased = False
+    exporter._tg = None
+    exporter._started = False
+    exporter._registered = True
+    exporter._unregister = False
+    exporter._deferred_unregister = True
+    exporter._exit_code = None
+    exporter.hook_executor = None
+    exporter.exit_on_lease_end = exit_on_lease_end
+    exporter._report_status = AsyncMock()
+    exporter._request_lease_release = AsyncMock()
+
+    @asynccontextmanager
+    async def fake_session():
+        yield
+
+    exporter.session = fake_session
+    return exporter
+
+
+def _wire_status_stream(exporter, statuses):
+    """Replace _retry_stream with a function that feeds statuses into tx."""
+    async def fake_retry_stream(name, factory, tx, **kwargs):
+        for s in statuses:
+            await tx.send(s)
+        await tx.aclose()
+
+    exporter._retry_stream = fake_retry_stream
+
+
+def _wire_handle_lease(exporter):
+    """Replace handle_lease with a minimal mock that satisfies lifecycle events."""
+    async def fake_handle_lease(lease_name, tg, lease_ctx):
+        await lease_ctx.lease_ended.wait()
+        lease_ctx.after_lease_hook_done.set()
+
+    exporter.handle_lease = fake_handle_lease
+
+
+class TestExitOnLeaseEnd:
+    async def test_serve_stops_after_lease_ends(self):
+        """serve() sets _stop_requested after a lease→unleased transition
+        when exit_on_lease_end is True."""
+        exporter = _make_serve_exporter(exit_on_lease_end=True)
+        _wire_status_stream(exporter, [
+            MagicMock(leased=True, lease_name="test-lease", client_name="test"),
+            MagicMock(leased=False, lease_name="", client_name=""),
+        ])
+        _wire_handle_lease(exporter)
+
+        await exporter.serve()
+
+        assert exporter._stop_requested is True
+
+    async def test_serve_not_triggered_on_startup(self):
+        """serve() does NOT set _stop_requested on startup when no lease
+        has been served yet (previous_leased is False)."""
+        exporter = _make_serve_exporter(exit_on_lease_end=True)
+        _wire_status_stream(exporter, [
+            MagicMock(leased=False, lease_name="", client_name=""),
+        ])
+
+        await exporter.serve()
+
+        assert exporter._stop_requested is False
+
+    async def test_serve_continues_when_disabled(self):
+        """serve() does NOT set _stop_requested after lease ends when
+        exit_on_lease_end is False — the exporter loops for next lease."""
+        exporter = _make_serve_exporter(exit_on_lease_end=False)
+        _wire_status_stream(exporter, [
+            MagicMock(leased=True, lease_name="test-lease", client_name="test"),
+            MagicMock(leased=False, lease_name="", client_name=""),
+        ])
+        _wire_handle_lease(exporter)
+
+        await exporter.serve()
+
+        assert exporter._stop_requested is False


### PR DESCRIPTION
When enabled via CLI flag or YAML config (exitOnLeaseEnd: true), the exporter exits cleanly after serving one lease instead of looping for the next. Uses the existing _stop_requested mechanism, guarded by previous_leased to prevent premature exit on startup before any lease is served.