### PR TITLE
cli: add --page-size flag to get commands and reduce e2e pagination test load

### DIFF
--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -402,15 +402,15 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, func() {
 			WaitForExporters("test-exporter-oidc", "test-exporter-sa", "test-exporter-legacy")
 			MustJmp("config", "client", "use", "test-client-oidc")
 
-			for i := 1; i <= 101; i++ {
+			for i := 1; i <= 10; i++ {
 				out, err := Jmp("create", "lease", "--selector", "example.com/board=oidc", "--duration", "1d")
 				Expect(err).NotTo(HaveOccurred(), out)
 			}
 
-			out, err := Jmp("get", "leases", "-o", "name")
+			out, err := Jmp("get", "leases", "--page-size", "5", "-o", "name")
 			Expect(err).NotTo(HaveOccurred(), out)
 			lines := strings.Split(strings.TrimSpace(out), "\n")
-			Expect(lines).To(HaveLen(101))
+			Expect(lines).To(HaveLen(10))
 
 			MustJmp("delete", "leases", "--all")
 		})
@@ -420,7 +420,7 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, func() {
 			MustJmp("config", "client", "use", "test-client-oidc")
 
 			ns := Namespace()
-			for i := 1; i <= 101; i++ {
+			for i := 1; i <= 10; i++ {
 				name := fmt.Sprintf("pagination-exp-%d", i)
 				out, err := Jmp("admin", "create", "exporter", "-n", ns, name,
 					"--nointeractive", "-l", "pagination=true",
@@ -428,12 +428,12 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, func() {
 				Expect(err).NotTo(HaveOccurred(), out)
 			}
 
-			out, err := Jmp("get", "exporters", "--selector", "pagination=true", "-o", "name")
+			out, err := Jmp("get", "exporters", "--selector", "pagination=true", "--page-size", "5", "-o", "name")
 			Expect(err).NotTo(HaveOccurred(), out)
 			lines := strings.Split(strings.TrimSpace(out), "\n")
-			Expect(lines).To(HaveLen(101))
+			Expect(lines).To(HaveLen(10))
 
-			for i := 1; i <= 101; i++ {
+			for i := 1; i <= 10; i++ {
 				MustJmp("admin", "delete", "exporter", "--namespace", ns, fmt.Sprintf("pagination-exp-%d", i), "--delete")
 			}
 		})

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get.py
@@ -37,6 +37,7 @@ def get():
     default=False,
     help="Show labels hidden by controller config",
 )
+@click.option("--page-size", type=click.IntRange(min=1), default=100, help="Number of results per page for pagination")
 @handle_exceptions_with_reauthentication(relogin_client)
 def get_exporters(
     config,
@@ -45,6 +46,7 @@ def get_exporters(
     with_options: list[str],
     allow_disabled: bool,
     show_hidden_labels: bool,
+    page_size: int,
 ):
     """
     Display one or many exporters
@@ -60,6 +62,7 @@ def get_exporters(
         include_status=include_status,
         include_disabled=allow_disabled,
         show_hidden_labels=show_hidden_labels,
+        page_size=page_size,
     )
 
     model_print(exporters, output)
@@ -78,17 +81,24 @@ def get_exporters(
     default=None,
     help="Filter leases by tags (label selector syntax, e.g. build=1234)",
 )
+@click.option("--page-size", type=click.IntRange(min=1), default=100, help="Number of results per page for pagination")
 @handle_exceptions_with_reauthentication(relogin_client)
 def get_leases(
-    config, selector: str | None, output: OutputType, show_all: bool, all_clients: bool, tag_filter: str | None
+    config,
+    selector: str | None,
+    output: OutputType,
+    show_all: bool,
+    all_clients: bool,
+    tag_filter: str | None,
+    page_size: int,
 ):
     """
     Display one or many leases
     """
 
-    leases = config.list_leases(filter=selector, only_active=not show_all, tag_filter=tag_filter).filter_by_selector(
-        selector
-    )
+    leases = config.list_leases(
+        filter=selector, only_active=not show_all, tag_filter=tag_filter, page_size=page_size
+    ).filter_by_selector(selector)
 
     if not all_clients:
         leases = leases.filter_by_client(config.metadata.name)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
@@ -223,12 +223,12 @@ class TestGetExportersCallsPaginatedMethod:
         with patch("jumpstarter_cli.get.model_print"):
             get_exporters.callback.__wrapped__.__wrapped__(
                 config=config, selector=None, output="text", with_options=[], allow_disabled=False,
-                show_hidden_labels=False,
+                show_hidden_labels=False, page_size=100,
             )
 
         config.list_exporters.assert_called_once_with(
             filter=None, include_leases=False, include_online=False, include_status=False, include_disabled=False,
-            show_hidden_labels=False,
+            show_hidden_labels=False, page_size=100,
         )
 
     def test_get_leases_calls_list_leases(self):
@@ -244,9 +244,49 @@ class TestGetExportersCallsPaginatedMethod:
         with patch("jumpstarter_cli.get.model_print"):
             get_leases.callback.__wrapped__.__wrapped__(
                 config=config, selector=None, output="text", show_all=False, all_clients=False, tag_filter=None,
+                page_size=100,
             )
 
-        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None)
+        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None, page_size=100)
+
+    def test_get_exporters_passes_custom_page_size(self):
+        from unittest.mock import patch
+
+        config = Mock()
+        config.list_exporters.return_value = ExporterList(
+            exporters=[], next_page_token=None
+        )
+
+        from jumpstarter_cli.get import get_exporters
+
+        with patch("jumpstarter_cli.get.model_print"):
+            get_exporters.callback.__wrapped__.__wrapped__(
+                config=config, selector=None, output="text", with_options=[], allow_disabled=False,
+                show_hidden_labels=False, page_size=5,
+            )
+
+        config.list_exporters.assert_called_once_with(
+            filter=None, include_leases=False, include_online=False, include_status=False, include_disabled=False,
+            show_hidden_labels=False, page_size=5,
+        )
+
+    def test_get_leases_passes_custom_page_size(self):
+        from unittest.mock import patch
+
+        lease_list = LeaseList(leases=[], next_page_token=None)
+
+        config = Mock()
+        config.list_leases.return_value = lease_list
+
+        from jumpstarter_cli.get import get_leases
+
+        with patch("jumpstarter_cli.get.model_print"):
+            get_leases.callback.__wrapped__.__wrapped__(
+                config=config, selector=None, output="text", show_all=False, all_clients=False, tag_filter=None,
+                page_size=10,
+            )
+
+        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None, page_size=10)
 
 
 class TestGetExportersIntegration:
@@ -436,12 +476,13 @@ class TestGetLeasesClientFiltering:
         with patch("jumpstarter_cli.get.model_print") as mock_print:
             _unwrapped_get_leases(
                 config=config, selector=None, output=None, show_all=False, all_clients=False, tag_filter=None,
+                page_size=100,
             )
 
         printed_leases = mock_print.call_args[0][0]
         assert len(printed_leases.leases) == 1
         assert printed_leases.leases[0].name == "my-lease"
-        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None)
+        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None, page_size=100)
 
     def test_all_flag_requests_inactive_leases_own_only(self):
         from unittest.mock import patch
@@ -453,12 +494,13 @@ class TestGetLeasesClientFiltering:
         with patch("jumpstarter_cli.get.model_print") as mock_print:
             _unwrapped_get_leases(
                 config=config, selector=None, output=None, show_all=True, all_clients=False, tag_filter=None,
+                page_size=100,
             )
 
         printed_leases = mock_print.call_args[0][0]
         assert len(printed_leases.leases) == 1
         assert printed_leases.leases[0].name == "my-lease"
-        config.list_leases.assert_called_once_with(filter=None, only_active=False, tag_filter=None)
+        config.list_leases.assert_called_once_with(filter=None, only_active=False, tag_filter=None, page_size=100)
 
     def test_all_clients_shows_everyone_active(self):
         from unittest.mock import patch
@@ -470,11 +512,12 @@ class TestGetLeasesClientFiltering:
         with patch("jumpstarter_cli.get.model_print") as mock_print:
             _unwrapped_get_leases(
                 config=config, selector=None, output=None, show_all=False, all_clients=True, tag_filter=None,
+                page_size=100,
             )
 
         printed_leases = mock_print.call_args[0][0]
         assert len(printed_leases.leases) == 2
-        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None)
+        config.list_leases.assert_called_once_with(filter=None, only_active=True, tag_filter=None, page_size=100)
 
     def test_all_and_all_clients_shows_everything(self):
         from unittest.mock import patch
@@ -486,8 +529,9 @@ class TestGetLeasesClientFiltering:
         with patch("jumpstarter_cli.get.model_print") as mock_print:
             _unwrapped_get_leases(
                 config=config, selector=None, output=None, show_all=True, all_clients=True, tag_filter=None,
+                page_size=100,
             )
 
         printed_leases = mock_print.call_args[0][0]
         assert len(printed_leases.leases) == 2
-        config.list_leases.assert_called_once_with(filter=None, only_active=False, tag_filter=None)
+        config.list_leases.assert_called_once_with(filter=None, only_active=False, tag_filter=None, page_size=100)


### PR DESCRIPTION
## Motivation

The e2e pagination tests for leases and exporters create **101 elements** each, solely to exceed the hardcoded client-side page size of 100 and force multi-page pagination. This is unnecessarily heavy on CI:

- 101 sequential `create` gRPC calls per test
- 101 sequential `delete` calls for cleanup
- Significant cluster resource consumption

The gRPC server already fully supports arbitrary `page_size` values — it passes the value directly to the Kubernetes API `Limit` parameter. The Python client config layer (`list_leases` / `list_exporters`) also accepts `page_size` as a parameter. The only missing link was the CLI, which hardcoded the default of 100 by never passing it through.

## Changes

### 1. CLI: Add `--page-size` flag (`python/packages/jumpstarter-cli/jumpstarter_cli/get.py`)

- Add `--page-size` option to both `jmp get exporters` and `jmp get leases` commands
- Default remains **100** (no behavior change for existing users)
- The value is passed through to `config.list_exporters(page_size=...)` and `config.list_leases(page_size=...)`

### 2. E2E tests: Reduce pagination test load (`e2e/test/e2e_test.go`)

- **Lease pagination test**: 101 → 10 leases, uses `--page-size 5` (forces 2 pages)
- **Exporter pagination test**: 101 → 10 exporters, uses `--page-size 5` (forces 2 pages)

This is a **10x reduction** in resources created and API calls per test while still validating the full pagination loop (multiple pages, token forwarding, result aggregation).

### What doesn't change

- Default page size for users remains 100
- Python unit tests (`client_config_test.py`) — mocked tests that validate the pagination loop logic at the library level, unaffected
- Server-side Go code — already supports arbitrary `PageSize`
- Proto definitions — `page_size` is already an optional field