### PR TITLE
e2e: parallelize WaitForExporters to reduce test runtime

### DIFF
--- a/e2e/test/utils.go
+++ b/e2e/test/utils.go
@@ -591,13 +591,16 @@ func WaitForExporter(name string) {
 
 // WaitForExporters waits for multiple exporters in parallel.
 func WaitForExporters(names ...string) {
-	// Brief delay
-	time.Sleep(exporterPostDelay)
-
+	var wg sync.WaitGroup
 	for _, name := range names {
-		name := name // capture
-		WaitForExporter(name)
+		wg.Add(1)
+		go func(n string) {
+			defer wg.Done()
+			defer GinkgoRecover()
+			WaitForExporter(n)
+		}(name)
 	}
+	wg.Wait()
 }
 
 // WaitForExporterOffline waits for an exporter to go offline.


### PR DESCRIPTION
## Motivation

`WaitForExporters` was running sequentially despite its comment saying "in parallel." For the typical call with 3 exporters, each invocation stacked delays:

- 2s outer `exporterPostDelay` sleep
- 3× (2s inner sleep + `kubectl wait` + `Eventually` polling)
- **Minimum ~8s per call**

This function is called **13+ times** in `e2e_test.go` alone, plus additional calls in the compat test files. The sequential waiting adds up to a significant portion of the total e2e test runtime.

## Change

Parallelize the `WaitForExporter` calls inside `WaitForExporters` using `sync.WaitGroup`:

- Each `WaitForExporter` call already has its own `exporterPostDelay` (2s) sleep, so the duplicate outer sleep is removed
- All exporters are waited on concurrently via goroutines
- `GinkgoRecover()` ensures assertion panics from `MustRunCmd`/`Eventually` inside goroutines are properly caught by the Ginkgo test framework

### Before (sequential, ~8s minimum for 3 exporters)

```
WaitForExporters(a, b, c)
  sleep 2s
  WaitForExporter(a)  // sleep 2s + kubectl wait + poll
  WaitForExporter(b)  // sleep 2s + kubectl wait + poll
  WaitForExporter(c)  // sleep 2s + kubectl wait + poll
```

### After (parallel, ~4s minimum for 3 exporters)

```
WaitForExporters(a, b, c)
  go WaitForExporter(a)  // sleep 2s + kubectl wait + poll ─┐
  go WaitForExporter(b)  // sleep 2s + kubectl wait + poll  ├─ concurrent
  go WaitForExporter(c)  // sleep 2s + kubectl wait + poll ─┘
  wg.Wait()
```

## Expected savings

With 3 exporters per call and 13+ call sites in the core tests: estimated **50-80s** reduction in total e2e runtime.

## What doesn't change

- `WaitForExporter` (singular) — unchanged, keeps its own delay + kubectl wait + polling
- All test logic — same tests, same assertions
- `WaitForExporterOffline` — unchanged
- No new imports — `sync` was already imported, `GinkgoRecover` comes from the Ginkgo v2 dot-import