### PR TITLE
feat: implement status reporting on ExporterSet resources

### DIFF
--- a/controller/api/virtualtarget/v1alpha1/exporterset_types.go
+++ b/controller/api/virtualtarget/v1alpha1/exporterset_types.go
@@ -119,17 +119,47 @@ type ExporterSetSpec struct {
 
 // ExporterSetStatus defines the observed state of ExporterSet.
 type ExporterSetStatus struct {
-	// Replicas is the total number of exporter instances.
+	// Replicas is the total number of exporter instances owned by this set.
 	Replicas int32 `json:"replicas"`
 
-	// ReadyReplicas is the number of instances that are registered and ready.
+	// ReadyReplicas is the number of instances that are online and registered.
 	ReadyReplicas int32 `json:"readyReplicas"`
 
-	// AvailableReplicas is the number of ready and unleased instances (warm pool).
+	// AvailableReplicas is the number of ready, unleased, and enabled instances (warm pool).
 	AvailableReplicas int32 `json:"availableReplicas"`
+
+	// UnavailableReplicas is the number of enabled instances that are not yet ready.
+	UnavailableReplicas int32 `json:"unavailableReplicas"`
 
 	// LeasedReplicas is the number of instances currently leased.
 	LeasedReplicas int32 `json:"leasedReplicas"`
+
+	// PodsPending is the number of owned pods in Pending phase.
+	PodsPending int32 `json:"podsPending"`
+
+	// PodsRunning is the number of owned pods in Running phase.
+	PodsRunning int32 `json:"podsRunning"`
+
+	// PodsFailed is the number of owned pods in Failed phase.
+	PodsFailed int32 `json:"podsFailed"`
+
+	// PodsUnknown is the number of owned pods in Unknown or Succeeded phase.
+	PodsUnknown int32 `json:"podsUnknown"`
+
+	// ExportersActive is the number of exporters currently serving a lease.
+	ExportersActive int32 `json:"exportersActive"`
+
+	// ExportersIdle is the number of exporters that are online, enabled, and not leased.
+	ExportersIdle int32 `json:"exportersIdle"`
+
+	// ExportersDisabled is the number of exporters with spec.enabled=false.
+	ExportersDisabled int32 `json:"exportersDisabled"`
+
+	// ExportersOffline is the number of enabled exporters that are not online.
+	ExportersOffline int32 `json:"exportersOffline"`
+
+	// Selector is the serialized label selector for HPA compatibility.
+	Selector string `json:"selector,omitempty"`
 
 	// Conditions represent the latest available observations of the ExporterSet state.
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
@@ -139,18 +169,23 @@ type ExporterSetStatus struct {
 type ExporterSetConditionType string
 
 const (
-	// ExporterSetConditionTypeHealthy indicates all desired replicas are ready.
-	ExporterSetConditionTypeHealthy ExporterSetConditionType = "Healthy"
-	// ExporterSetConditionTypeScalingLimited indicates scaling is constrained by limits.
-	ExporterSetConditionTypeScalingLimited ExporterSetConditionType = "ScalingLimited"
+	// ExporterSetConditionAvailable indicates minimum replicas are ready and serving.
+	ExporterSetConditionAvailable ExporterSetConditionType = "Available"
+	// ExporterSetConditionProgressing indicates the set is scaling or updating.
+	ExporterSetConditionProgressing ExporterSetConditionType = "Progressing"
+	// ExporterSetConditionDegraded indicates some replicas are failing or offline.
+	ExporterSetConditionDegraded ExporterSetConditionType = "Degraded"
+	// ExporterSetConditionScalingLimited indicates scaling is constrained by limits.
+	ExporterSetConditionScalingLimited ExporterSetConditionType = "ScalingLimited"
 )
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.maxReplicas,statuspath=.status.replicas
+// +kubebuilder:subresource:scale:specpath=.spec.maxReplicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas"
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"
 // +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.availableReplicas"
+// +kubebuilder:printcolumn:name="Unavailable",type="integer",JSONPath=".status.unavailableReplicas"
 // +kubebuilder:printcolumn:name="Leased",type="integer",JSONPath=".status.leasedReplicas"
 // +kubebuilder:printcolumn:name="Class",type="string",JSONPath=".spec.virtualTargetClassName"
 

--- a/controller/deploy/operator/config/crd/bases/virtualtarget.jumpstarter.dev_exportersets.yaml
+++ b/controller/deploy/operator/config/crd/bases/virtualtarget.jumpstarter.dev_exportersets.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.availableReplicas
       name: Available
       type: integer
+    - jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
     - jsonPath: .status.leasedReplicas
       name: Leased
       type: integer
@@ -204,8 +207,8 @@ spec:
             description: ExporterSetStatus defines the observed state of ExporterSet.
             properties:
               availableReplicas:
-                description: AvailableReplicas is the number of ready and unleased
-                  instances (warm pool).
+                description: AvailableReplicas is the number of ready, unleased, and
+                  enabled instances (warm pool).
                 format: int32
                 type: integer
               conditions:
@@ -266,30 +269,85 @@ spec:
                   - type
                   type: object
                 type: array
+              exportersActive:
+                description: ExportersActive is the number of exporters currently
+                  serving a lease.
+                format: int32
+                type: integer
+              exportersDisabled:
+                description: ExportersDisabled is the number of exporters with spec.enabled=false.
+                format: int32
+                type: integer
+              exportersIdle:
+                description: ExportersIdle is the number of exporters that are online,
+                  enabled, and not leased.
+                format: int32
+                type: integer
+              exportersOffline:
+                description: ExportersOffline is the number of enabled exporters that
+                  are not online.
+                format: int32
+                type: integer
               leasedReplicas:
                 description: LeasedReplicas is the number of instances currently leased.
                 format: int32
                 type: integer
+              podsFailed:
+                description: PodsFailed is the number of owned pods in Failed phase.
+                format: int32
+                type: integer
+              podsPending:
+                description: PodsPending is the number of owned pods in Pending phase.
+                format: int32
+                type: integer
+              podsRunning:
+                description: PodsRunning is the number of owned pods in Running phase.
+                format: int32
+                type: integer
+              podsUnknown:
+                description: PodsUnknown is the number of owned pods in Unknown or
+                  Succeeded phase.
+                format: int32
+                type: integer
               readyReplicas:
-                description: ReadyReplicas is the number of instances that are registered
-                  and ready.
+                description: ReadyReplicas is the number of instances that are online
+                  and registered.
                 format: int32
                 type: integer
               replicas:
-                description: Replicas is the total number of exporter instances.
+                description: Replicas is the total number of exporter instances owned
+                  by this set.
+                format: int32
+                type: integer
+              selector:
+                description: Selector is the serialized label selector for HPA compatibility.
+                type: string
+              unavailableReplicas:
+                description: UnavailableReplicas is the number of enabled instances
+                  that are not yet ready.
                 format: int32
                 type: integer
             required:
             - availableReplicas
+            - exportersActive
+            - exportersDisabled
+            - exportersIdle
+            - exportersOffline
             - leasedReplicas
+            - podsFailed
+            - podsPending
+            - podsRunning
+            - podsUnknown
             - readyReplicas
             - replicas
+            - unavailableReplicas
             type: object
         type: object
     served: true
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.maxReplicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/controller/internal/exporterset/reconciler.go
+++ b/controller/internal/exporterset/reconciler.go
@@ -22,6 +22,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -82,7 +84,42 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if apierrors.IsNotFound(err) {
 			logger.Info("VirtualTargetClass not found",
 				"virtualTargetClassName", exporterSet.Spec.VirtualTargetClassName)
-			// TODO: set a condition on the ExporterSet indicating the class is missing
+
+			prevAvailable := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+			)
+			prevDegraded := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
+			)
+			prevProgressing := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
+			)
+			prevScalingLimited := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
+			)
+
+			if countErr := r.reconcileStatusCounts(ctx, &exporterSet); countErr != nil {
+				return ctrl.Result{}, countErr
+			}
+			r.reconcileConditions(&exporterSet)
+
+			meta.SetStatusCondition(&exporterSet.Status.Conditions, metav1.Condition{
+				Type:               string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: exporterSet.Generation,
+				Reason:             "VirtualTargetClassNotFound",
+				Message: fmt.Sprintf("VirtualTargetClass %q not found",
+					exporterSet.Spec.VirtualTargetClassName),
+			})
+
+			if updateErr := r.Status().Update(ctx, &exporterSet); updateErr != nil {
+				return requeueConflict(logger, updateErr)
+			}
+			r.emitConditionEvents(&exporterSet, prevAvailable, prevProgressing, prevDegraded, prevScalingLimited)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("unable to get VirtualTargetClass %q: %w",
@@ -102,19 +139,369 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		"minAvailableReplicas", exporterSet.Spec.MinAvailableReplicas,
 	)
 
-	// TODO: Phase 2 implementation
-	// 1. Count owned Exporter CRs: replicas, readyReplicas, leasedReplicas, availableReplicas
-	// 2. Deep-merge parameters from VirtualTargetClass + ExporterSet overrides
-	// 3. Scale up if availableReplicas < minAvailableReplicas and replicas < maxReplicas
-	//    - Use r.Provisioner.RenderPod() to create Pods
-	//    - Set OwnerReferences on the Pod via ctrl.SetControllerReference
-	//      before creation so that ExporterSet deletion cascades to Pods
-	// 4. Scale up on demand if pending leases match selector
-	// 5. Scale down if availableReplicas > minAvailableReplicas after cooldown
-	//    - Use r.Provisioner.Cleanup() before deleting
-	// 6. Update ExporterSet.status
+	prevAvailable := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+	)
+	prevDegraded := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
+	)
+	prevProgressing := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
+	)
+	prevScalingLimited := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
+	)
+
+	if err := r.reconcileStatusCounts(ctx, &exporterSet); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	r.reconcileConditions(&exporterSet)
+
+	if err := r.Status().Update(ctx, &exporterSet); err != nil {
+		return requeueConflict(logger, err)
+	}
+
+	r.emitConditionEvents(&exporterSet, prevAvailable, prevProgressing, prevDegraded, prevScalingLimited)
 
 	return ctrl.Result{}, nil
+}
+
+func (r *ExporterSetReconciler) reconcileStatusCounts(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+) error {
+	selector, err := metav1.LabelSelectorAsSelector(&es.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("invalid label selector: %w", err)
+	}
+
+	es.Status.Selector = selector.String()
+
+	var exporterList jumpstarterdevv1alpha1.ExporterList
+	if err := r.List(ctx, &exporterList,
+		client.InNamespace(es.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return fmt.Errorf("unable to list Exporters: %w", err)
+	}
+
+	ownedExporters := filterOwnedExporters(exporterList.Items, es.UID)
+
+	var replicas, ready, available, leased int32
+	var active, idle, disabled, offline int32
+
+	for i := range ownedExporters {
+		exp := &ownedExporters[i]
+		replicas++
+
+		isOnline := meta.IsStatusConditionTrue(
+			exp.Status.Conditions,
+			string(jumpstarterdevv1alpha1.ExporterConditionTypeOnline),
+		)
+		isEnabled := exp.IsEnabled()
+		isLeased := exp.Status.LeaseRef != nil
+
+		if isOnline {
+			ready++
+		}
+		if isLeased {
+			leased++
+		}
+		if isOnline && isEnabled && !isLeased {
+			available++
+		}
+
+		if !isEnabled {
+			disabled++
+		} else if isLeased && isOnline {
+			active++
+		} else if isOnline {
+			idle++
+		} else {
+			offline++
+		}
+	}
+
+	es.Status.Replicas = replicas
+	es.Status.ReadyReplicas = ready
+	es.Status.AvailableReplicas = available
+	es.Status.UnavailableReplicas = offline
+	es.Status.LeasedReplicas = leased
+	es.Status.ExportersActive = active
+	es.Status.ExportersIdle = idle
+	es.Status.ExportersDisabled = disabled
+	es.Status.ExportersOffline = offline
+
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList,
+		client.InNamespace(es.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return fmt.Errorf("unable to list Pods: %w", err)
+	}
+
+	var pending, running, failed, unknown int32
+
+	for i := range podList.Items {
+		if !isOwnedBy(&podList.Items[i], es.UID) {
+			continue
+		}
+		switch podList.Items[i].Status.Phase {
+		case corev1.PodPending:
+			pending++
+		case corev1.PodRunning:
+			running++
+		case corev1.PodFailed:
+			failed++
+		default:
+			unknown++
+		}
+	}
+
+	es.Status.PodsPending = pending
+	es.Status.PodsRunning = running
+	es.Status.PodsFailed = failed
+	es.Status.PodsUnknown = unknown
+
+	return nil
+}
+
+func (r *ExporterSetReconciler) reconcileConditions(es *virtualtargetv1alpha1.ExporterSet) {
+	r.reconcileConditionAvailable(es)
+	r.reconcileConditionProgressing(es)
+	r.reconcileConditionDegraded(es)
+	r.reconcileConditionScalingLimited(es)
+}
+
+func (r *ExporterSetReconciler) reconcileConditionAvailable(es *virtualtargetv1alpha1.ExporterSet) {
+	condType := string(virtualtargetv1alpha1.ExporterSetConditionAvailable)
+
+	if es.Spec.MinReplicas == 0 && es.Status.Replicas == 0 {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "NoReplicasRequired",
+			Message:            "No minimum replicas configured",
+		})
+		return
+	}
+
+	if es.Status.ReadyReplicas >= es.Spec.MinReplicas {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "MinimumReplicasAvailable",
+			Message: fmt.Sprintf("%d/%d replicas ready",
+				es.Status.ReadyReplicas, es.Spec.MinReplicas),
+		})
+		return
+	}
+
+	meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: es.Generation,
+		Reason:             "MinimumReplicasUnavailable",
+		Message: fmt.Sprintf("%d/%d replicas ready, need %d",
+			es.Status.ReadyReplicas, es.Status.Replicas, es.Spec.MinReplicas),
+	})
+}
+
+func (r *ExporterSetReconciler) reconcileConditionProgressing(es *virtualtargetv1alpha1.ExporterSet) {
+	condType := string(virtualtargetv1alpha1.ExporterSetConditionProgressing)
+
+	if es.Status.PodsPending > 0 {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "PodsStarting",
+			Message:            fmt.Sprintf("%d pod(s) pending", es.Status.PodsPending),
+		})
+		return
+	}
+
+	if es.Status.UnavailableReplicas > 0 {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "ReplicasNotReady",
+			Message: fmt.Sprintf("%d replica(s) not yet ready",
+				es.Status.UnavailableReplicas),
+		})
+		return
+	}
+
+	meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: es.Generation,
+		Reason:             "AllReplicasReady",
+		Message:            "All replicas are ready",
+	})
+}
+
+func (r *ExporterSetReconciler) reconcileConditionDegraded(es *virtualtargetv1alpha1.ExporterSet) {
+	condType := string(virtualtargetv1alpha1.ExporterSetConditionDegraded)
+
+	if es.Status.PodsFailed > 0 {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "PodsFailing",
+			Message:            fmt.Sprintf("%d pod(s) in Failed state", es.Status.PodsFailed),
+		})
+		return
+	}
+
+	if es.Status.UnavailableReplicas > 0 && es.Status.PodsPending == 0 {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "ExportersOffline",
+			Message: fmt.Sprintf("%d exporter(s) not ready with no pending pods",
+				es.Status.UnavailableReplicas),
+		})
+		return
+	}
+
+	meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: es.Generation,
+		Reason:             "AllReplicasHealthy",
+		Message:            "No degraded replicas",
+	})
+}
+
+func (r *ExporterSetReconciler) reconcileConditionScalingLimited(es *virtualtargetv1alpha1.ExporterSet) {
+	condType := string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited)
+
+	atMax := es.Spec.MaxReplicas > 0 && es.Status.Replicas >= es.Spec.MaxReplicas
+	needMore := es.Status.AvailableReplicas < es.Spec.MinAvailableReplicas
+
+	if atMax && needMore {
+		meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+			Type:               condType,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: es.Generation,
+			Reason:             "AtMaxReplicas",
+			Message: fmt.Sprintf("Cannot scale beyond %d replicas; %d available, need %d",
+				es.Spec.MaxReplicas, es.Status.AvailableReplicas,
+				es.Spec.MinAvailableReplicas),
+		})
+		return
+	}
+
+	meta.SetStatusCondition(&es.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: es.Generation,
+		Reason:             "WithinLimits",
+		Message:            "Scaling is not constrained",
+	})
+}
+
+func (r *ExporterSetReconciler) emitConditionEvents(
+	es *virtualtargetv1alpha1.ExporterSet,
+	prevAvailable, prevProgressing, prevDegraded, prevScalingLimited bool,
+) {
+	if r.Recorder == nil {
+		return
+	}
+
+	nowAvailable := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+	)
+	nowProgressing := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
+	)
+	nowDegraded := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
+	)
+	nowScalingLimited := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
+	)
+
+	if !prevAvailable && nowAvailable {
+		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ExporterSetAvailable",
+			"ExporterSet %s is available: %d ready replicas",
+			es.Name, es.Status.ReadyReplicas)
+	} else if prevAvailable && !nowAvailable {
+		r.Recorder.Eventf(es, corev1.EventTypeWarning, "ExporterSetUnavailable",
+			"ExporterSet %s is unavailable: %d/%d replicas ready",
+			es.Name, es.Status.ReadyReplicas, es.Spec.MinReplicas)
+	}
+
+	if !prevProgressing && nowProgressing {
+		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ExporterSetProgressing",
+			"ExporterSet %s is progressing: %d pending pods, %d unavailable replicas",
+			es.Name, es.Status.PodsPending, es.Status.UnavailableReplicas)
+	} else if prevProgressing && !nowProgressing {
+		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ExporterSetSettled",
+			"ExporterSet %s finished progressing: all replicas ready", es.Name)
+	}
+
+	if !prevDegraded && nowDegraded {
+		r.Recorder.Eventf(es, corev1.EventTypeWarning, "ExporterSetDegraded",
+			"ExporterSet %s is degraded: %d failed pods, %d unavailable replicas",
+			es.Name, es.Status.PodsFailed, es.Status.UnavailableReplicas)
+	} else if prevDegraded && !nowDegraded {
+		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ExporterSetRecovered",
+			"ExporterSet %s recovered: all replicas healthy", es.Name)
+	}
+
+	if !prevScalingLimited && nowScalingLimited {
+		r.Recorder.Eventf(es, corev1.EventTypeWarning, "ScalingLimited",
+			"ExporterSet %s scaling limited at %d replicas",
+			es.Name, es.Spec.MaxReplicas)
+	} else if prevScalingLimited && !nowScalingLimited {
+		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ScalingUnlimited",
+			"ExporterSet %s scaling no longer limited", es.Name)
+	}
+}
+
+func filterOwnedExporters(
+	exporters []jumpstarterdevv1alpha1.Exporter,
+	ownerUID types.UID,
+) []jumpstarterdevv1alpha1.Exporter {
+	owned := make([]jumpstarterdevv1alpha1.Exporter, 0, len(exporters))
+	for i := range exporters {
+		if isOwnedBy(&exporters[i], ownerUID) {
+			owned = append(owned, exporters[i])
+		}
+	}
+	return owned
+}
+
+func isOwnedBy(obj client.Object, ownerUID types.UID) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == ownerUID && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
+func requeueConflict(logger interface{ Info(string, ...interface{}) }, err error) (ctrl.Result, error) {
+	if apierrors.IsConflict(err) {
+		logger.Info("conflict on status update, will retry")
+	}
+	return ctrl.Result{}, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/internal/exporterset/reconciler_test.go
+++ b/controller/internal/exporterset/reconciler_test.go
@@ -24,9 +24,11 @@ import (
 	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/exporterset/provisioners/qemu"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -54,7 +56,11 @@ func TestReconcile_virtualTargetClassNotFound(t *testing.T) {
 			VirtualTargetClassName: "missing-class",
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(exporterSet).Build()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(exporterSet).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		Build()
 	r := &ExporterSetReconciler{
 		Client:      c,
 		Scheme:      scheme,
@@ -69,6 +75,21 @@ func TestReconcile_virtualTargetClassNotFound(t *testing.T) {
 	}
 	if result.RequeueAfter != 0 {
 		t.Fatalf("Reconcile() result = %#v, want no requeue", result)
+	}
+
+	var updated virtualtargetv1alpha1.ExporterSet
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "demo-set", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatal("Expected Available condition to be set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Available status = %v, want False", cond.Status)
+	}
+	if cond.Reason != "VirtualTargetClassNotFound" {
+		t.Errorf("Available reason = %q, want VirtualTargetClassNotFound", cond.Reason)
 	}
 }
 
@@ -153,5 +174,531 @@ func TestFindExporterSetsForVTC_ignoresNonVTC(t *testing.T) {
 	})
 	if requests != nil {
 		t.Errorf("got %#v, want nil", requests)
+	}
+}
+
+// --- Status reconciliation tests ---
+
+const testExporterSetUID = types.UID("es-uid-1234")
+
+func makeExporterSet() *virtualtargetv1alpha1.ExporterSet {
+	return &virtualtargetv1alpha1.ExporterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "demo-set",
+			Namespace:  "default",
+			UID:        testExporterSetUID,
+			Generation: 1,
+		},
+		Spec: virtualtargetv1alpha1.ExporterSetSpec{
+			MinReplicas:            2,
+			MaxReplicas:            4,
+			MinAvailableReplicas:   1,
+			VirtualTargetClassName: "qemu-class",
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"exporterset": "demo-set"},
+			},
+		},
+	}
+}
+
+func makeVTC() *virtualtargetv1alpha1.VirtualTargetClass {
+	return &virtualtargetv1alpha1.VirtualTargetClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "qemu-class", Namespace: "default"},
+		Spec: virtualtargetv1alpha1.VirtualTargetClassSpec{
+			Provisioner: qemu.ProvisionerName,
+		},
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func makeExporter(name string, online bool, leased bool, enabled bool) *jumpstarterdevv1alpha1.Exporter {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"exporterset": "demo-set"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "virtualtarget.jumpstarter.dev/v1alpha1",
+				Kind:       "ExporterSet",
+				Name:       "demo-set",
+				UID:        testExporterSetUID,
+				Controller: boolPtr(true),
+			}},
+		},
+		Spec: jumpstarterdevv1alpha1.ExporterSpec{
+			Enabled: boolPtr(enabled),
+		},
+	}
+
+	onlineStatus := metav1.ConditionFalse
+	if online {
+		onlineStatus = metav1.ConditionTrue
+	}
+	exp.Status.Conditions = []metav1.Condition{{
+		Type:   string(jumpstarterdevv1alpha1.ExporterConditionTypeOnline),
+		Status: onlineStatus,
+	}}
+
+	if leased {
+		exp.Status.LeaseRef = &corev1.LocalObjectReference{Name: name + "-lease"}
+	}
+
+	return exp
+}
+
+func makePod(name string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"exporterset": "demo-set"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "virtualtarget.jumpstarter.dev/v1alpha1",
+				Kind:       "ExporterSet",
+				Name:       "demo-set",
+				UID:        testExporterSetUID,
+				Controller: boolPtr(true),
+			}},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func reconcileAndGet(t *testing.T, objs ...client.Object) virtualtargetv1alpha1.ExporterSet {
+	t.Helper()
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		Build()
+	r := &ExporterSetReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		Provisioner: qemu.New(),
+	}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var updated virtualtargetv1alpha1.ExporterSet
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "demo-set", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	return updated
+}
+
+func TestReconcile_statusCounts_allOnlineNotLeased(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makePod("pod-1", corev1.PodRunning),
+		makePod("pod-2", corev1.PodRunning),
+	)
+
+	assertInt32(t, "Replicas", es.Status.Replicas, 2)
+	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 2)
+	assertInt32(t, "AvailableReplicas", es.Status.AvailableReplicas, 2)
+	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 0)
+	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 0)
+	assertInt32(t, "ExportersActive", es.Status.ExportersActive, 0)
+	assertInt32(t, "ExportersIdle", es.Status.ExportersIdle, 2)
+	assertInt32(t, "ExportersDisabled", es.Status.ExportersDisabled, 0)
+	assertInt32(t, "ExportersOffline", es.Status.ExportersOffline, 0)
+	assertInt32(t, "PodsRunning", es.Status.PodsRunning, 2)
+	assertInt32(t, "PodsPending", es.Status.PodsPending, 0)
+}
+
+func TestReconcile_statusCounts_mixedStates(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, true, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-3", false, false, true),
+		makeExporter("exp-4", true, false, false),
+		makePod("pod-1", corev1.PodRunning),
+		makePod("pod-2", corev1.PodRunning),
+		makePod("pod-3", corev1.PodFailed),
+		makePod("pod-4", corev1.PodPending),
+	)
+
+	assertInt32(t, "Replicas", es.Status.Replicas, 4)
+	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 3)
+	assertInt32(t, "AvailableReplicas", es.Status.AvailableReplicas, 1)
+	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 1)
+	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 1)
+	assertInt32(t, "ExportersActive", es.Status.ExportersActive, 1)
+	assertInt32(t, "ExportersIdle", es.Status.ExportersIdle, 1)
+	assertInt32(t, "ExportersDisabled", es.Status.ExportersDisabled, 1)
+	assertInt32(t, "ExportersOffline", es.Status.ExportersOffline, 1)
+	assertInt32(t, "PodsRunning", es.Status.PodsRunning, 2)
+	assertInt32(t, "PodsFailed", es.Status.PodsFailed, 1)
+	assertInt32(t, "PodsPending", es.Status.PodsPending, 1)
+}
+
+func TestReconcile_conditionAvailable_meetsMinReplicas(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatal("Expected Available condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Available = %v, want True", cond.Status)
+	}
+	if cond.Reason != "MinimumReplicasAvailable" {
+		t.Errorf("Reason = %q, want MinimumReplicasAvailable", cond.Reason)
+	}
+}
+
+func TestReconcile_conditionAvailable_belowMinReplicas(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatal("Expected Available condition")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Available = %v, want False", cond.Status)
+	}
+	if cond.Reason != "MinimumReplicasUnavailable" {
+		t.Errorf("Reason = %q, want MinimumReplicasUnavailable", cond.Reason)
+	}
+}
+
+func TestReconcile_conditionProgressing_podsPending(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makePod("pod-1", corev1.PodRunning),
+		makePod("pod-2", corev1.PodPending),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Progressing")
+	if cond == nil {
+		t.Fatal("Expected Progressing condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Progressing = %v, want True", cond.Status)
+	}
+	if cond.Reason != "PodsStarting" {
+		t.Errorf("Reason = %q, want PodsStarting", cond.Reason)
+	}
+}
+
+func TestReconcile_conditionProgressing_allReady(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Progressing")
+	if cond == nil {
+		t.Fatal("Expected Progressing condition")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Progressing = %v, want False", cond.Status)
+	}
+}
+
+func TestReconcile_conditionDegraded_failedPods(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", false, false, true),
+		makePod("pod-1", corev1.PodRunning),
+		makePod("pod-2", corev1.PodFailed),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Degraded")
+	if cond == nil {
+		t.Fatal("Expected Degraded condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Degraded = %v, want True", cond.Status)
+	}
+	if cond.Reason != "PodsFailing" {
+		t.Errorf("Reason = %q, want PodsFailing", cond.Reason)
+	}
+}
+
+func TestReconcile_conditionDegraded_healthy(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makePod("pod-1", corev1.PodRunning),
+		makePod("pod-2", corev1.PodRunning),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Degraded")
+	if cond == nil {
+		t.Fatal("Expected Degraded condition")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Degraded = %v, want False", cond.Status)
+	}
+}
+
+func TestReconcile_conditionScalingLimited_atMax(t *testing.T) {
+	esObj := makeExporterSet()
+	esObj.Spec.MaxReplicas = 2
+	esObj.Spec.MinAvailableReplicas = 2
+
+	es := reconcileAndGet(t,
+		esObj,
+		makeVTC(),
+		makeExporter("exp-1", true, true, true),
+		makeExporter("exp-2", true, true, true),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "ScalingLimited")
+	if cond == nil {
+		t.Fatal("Expected ScalingLimited condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("ScalingLimited = %v, want True", cond.Status)
+	}
+	if cond.Reason != "AtMaxReplicas" {
+		t.Errorf("Reason = %q, want AtMaxReplicas", cond.Reason)
+	}
+}
+
+func TestReconcile_conditionScalingLimited_withinLimits(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+	)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "ScalingLimited")
+	if cond == nil {
+		t.Fatal("Expected ScalingLimited condition")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("ScalingLimited = %v, want False", cond.Status)
+	}
+}
+
+func TestReconcile_selectorField_populated(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+	)
+
+	if es.Status.Selector != "exporterset=demo-set" {
+		t.Errorf("Selector = %q, want %q", es.Status.Selector, "exporterset=demo-set")
+	}
+}
+
+func TestReconcile_ignoresUnownedExporters(t *testing.T) {
+	unowned := makeExporter("unowned", true, false, true)
+	unowned.OwnerReferences = nil
+
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		unowned,
+	)
+
+	assertInt32(t, "Replicas", es.Status.Replicas, 0)
+}
+
+func TestReconcile_ignoresUnownedPods(t *testing.T) {
+	unowned := makePod("unowned-pod", corev1.PodRunning)
+	unowned.OwnerReferences = nil
+
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		unowned,
+	)
+
+	assertInt32(t, "PodsRunning", es.Status.PodsRunning, 0)
+}
+
+func TestReconcile_idempotent(t *testing.T) {
+	scheme := newScheme(t)
+	objs := []client.Object{
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, true, true),
+		makePod("pod-1", corev1.PodRunning),
+		makePod("pod-2", corev1.PodRunning),
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		Build()
+	r := &ExporterSetReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		Provisioner: qemu.New(),
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
+	}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+
+	var es virtualtargetv1alpha1.ExporterSet
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "demo-set", Namespace: "default"}, &es); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	assertInt32(t, "Replicas", es.Status.Replicas, 2)
+	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 2)
+	assertInt32(t, "AvailableReplicas", es.Status.AvailableReplicas, 1)
+	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 1)
+}
+
+func TestReconcile_offlineLeasedExporter_notCountedAsActive(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-online-idle", true, false, true),
+		makeExporter("exp-online-leased", true, true, true),
+		makeExporter("exp-offline-leased", false, true, true),
+	)
+
+	assertInt32(t, "ExportersActive", es.Status.ExportersActive, 1)
+	assertInt32(t, "ExportersOffline", es.Status.ExportersOffline, 1)
+	assertInt32(t, "ExportersIdle", es.Status.ExportersIdle, 1)
+	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 2)
+	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 1)
+}
+
+func TestReconcile_disabledExporters_dontInflateUnavailable(t *testing.T) {
+	es := reconcileAndGet(t,
+		makeExporterSet(),
+		makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-disabled-offline", false, false, false),
+		makeExporter("exp-disabled-online", true, false, false),
+	)
+
+	assertInt32(t, "Replicas", es.Status.Replicas, 4)
+	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 3)
+	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 0)
+	assertInt32(t, "ExportersDisabled", es.Status.ExportersDisabled, 2)
+
+	cond := meta.FindStatusCondition(es.Status.Conditions, "Progressing")
+	if cond == nil {
+		t.Fatal("Expected Progressing condition")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Progressing = %v, want False (disabled exporters should not trigger)", cond.Status)
+	}
+
+	degraded := meta.FindStatusCondition(es.Status.Conditions, "Degraded")
+	if degraded == nil {
+		t.Fatal("Expected Degraded condition")
+	}
+	if degraded.Status != metav1.ConditionFalse {
+		t.Errorf("Degraded = %v, want False (disabled exporters should not trigger)", degraded.Status)
+	}
+}
+
+func TestReconcile_vtcNotFound_updatesAllConditionsAndCounters(t *testing.T) {
+	scheme := newScheme(t)
+	esObj := makeExporterSet()
+	exp1 := makeExporter("exp-1", true, false, true)
+	exp2 := makeExporter("exp-2", false, false, true)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(esObj, makeVTC(), exp1, exp2).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		Build()
+	r := &ExporterSetReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		Provisioner: qemu.New(),
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
+	}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+
+	// Delete VTC to trigger not-found path
+	vtc := makeVTC()
+	if err := c.Delete(context.Background(), vtc); err != nil {
+		t.Fatalf("Delete VTC error = %v", err)
+	}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+
+	var es virtualtargetv1alpha1.ExporterSet
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "demo-set", Namespace: "default"}, &es); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Available should be False with VTC reason
+	avail := meta.FindStatusCondition(es.Status.Conditions, "Available")
+	if avail == nil {
+		t.Fatal("Expected Available condition")
+	}
+	if avail.Status != metav1.ConditionFalse {
+		t.Errorf("Available = %v, want False", avail.Status)
+	}
+	if avail.Reason != "VirtualTargetClassNotFound" {
+		t.Errorf("Available reason = %q, want VirtualTargetClassNotFound", avail.Reason)
+	}
+
+	// Counters should reflect current exporter state, not be stale
+	assertInt32(t, "Replicas", es.Status.Replicas, 2)
+	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 1)
+	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 1)
+
+	// Degraded should reflect current state
+	degraded := meta.FindStatusCondition(es.Status.Conditions, "Degraded")
+	if degraded == nil {
+		t.Fatal("Expected Degraded condition")
+	}
+}
+
+func assertInt32(t *testing.T, field string, got, want int32) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %d, want %d", field, got, want)
 	}
 }


### PR DESCRIPTION
Add deployment-style status conditions and replica counters to ExporterSet CRs, providing visibility into pod health, exporter availability, and scaling state on every reconcile loop.

depends on https://github.com/jumpstarter-dev/jumpstarter/pull/864

tested with:
```shell
  go build -o bin/exporter-set-controller cmd/exporter-set-controller/main.go
 ./bin/exporter-set-controller --provisioner=qemu.jumpstarter.dev --health-probe-bind-address=:8082

kubectl apply -f - <<'EOF'
  apiVersion: virtualtarget.jumpstarter.dev/v1alpha1
  kind: VirtualTargetClass
  metadata:
    name: qemu-test
    namespace: jumpstarter
  spec:
    provisioner: qemu.jumpstarter.dev
    bindingMode: Immediate
    reclaimPolicy: Delete
  ---
  apiVersion: virtualtarget.jumpstarter.dev/v1alpha1
  kind: ExporterSet
  metadata:
    name: test-set
    namespace: jumpstarter
  spec:
    minReplicas: 2
    maxReplicas: 4
    minAvailableReplicas: 1
    virtualTargetClassName: qemu-test
    selector:
      matchLabels:
        exporterset: test-set
    template:
      metadata:
        labels:
          exporterset: test-set
  EOF

kubectl apply -f - <<EOF
  apiVersion: jumpstarter.dev/v1alpha1
  kind: Exporter
  metadata:
    name: exp-1
    namespace: jumpstarter
    labels:
      exporterset: test-set
    ownerReferences:
    - apiVersion: virtualtarget.jumpstarter.dev/v1alpha1
      kind: ExporterSet
      name: test-set
      uid: "$ES_UID"
      controller: true
      blockOwnerDeletion: true
  spec:
    enabled: true
  ---
  apiVersion: jumpstarter.dev/v1alpha1
  kind: Exporter
  metadata:
    name: exp-2
    namespace: jumpstarter
    labels:
      exporterset: test-set
    ownerReferences:
    - apiVersion: virtualtarget.jumpstarter.dev/v1alpha1
      kind: ExporterSet
      name: test-set
      uid: "$ES_UID"
      controller: true
      blockOwnerDeletion: true
  spec:
    enabled: true
  ---
  apiVersion: jumpstarter.dev/v1alpha1
  kind: Exporter
  metadata:
    name: exp-3
    namespace: jumpstarter
    labels:
      exporterset: test-set
    ownerReferences:
    - apiVersion: virtualtarget.jumpstarter.dev/v1alpha1
      kind: ExporterSet
      name: test-set
      uid: "$ES_UID"
      controller: true
      blockOwnerDeletion: true
  spec:
    enabled: true
  ---
  apiVersion: jumpstarter.dev/v1alpha1
  kind: Exporter
  metadata:
    name: exp-4
    namespace: jumpstarter
    labels:
      exporterset: test-set
    ownerReferences:
    - apiVersion: virtualtarget.jumpstarter.dev/v1alpha1
      kind: ExporterSet
      name: test-set
      uid: "$ES_UID"
      controller: true
      blockOwnerDeletion: true
  spec:
    enabled: false
  EOF

  # exp-1: online, idle
  kubectl patch exporter exp-1 -n jumpstarter --type=merge --subresource=status -p '{
    "status": {
      "conditions": [{"type":"Online","status":"True","lastTransitionTime":"2026-07-21T13:00:00Z","reason":"Connected","message":"connected"}]
    }
  }'

  # exp-2: online, leased
  kubectl patch exporter exp-2 -n jumpstarter --type=merge --subresource=status -p '{
    "status": {
      "conditions": [{"type":"Online","status":"True","lastTransitionTime":"2026-07-21T13:00:00Z","reason":"Connected","message":"connected"}],
      "leaseRef": {"name": "test-lease"}
    }
  }'

  # exp-3: offline
  kubectl patch exporter exp-3 -n jumpstarter --type=merge --subresource=status -p '{
    "status": {
      "conditions": [{"type":"Online","status":"False","lastTransitionTime":"2026-07-21T13:00:00Z","reason":"Disconnected","message":"offline"}]
    }
  }'

  # exp-4: online but disabled
  kubectl patch exporter exp-4 -n jumpstarter --type=merge --subresource=status -p '{
    "status": {
      "conditions": [{"type":"Online","status":"True","lastTransitionTime":"2026-07-21T13:00:00Z","reason":"Connected","message":"connected"}]
    }
  }'

kubectl get exporterset -n jumpstarter -o wide
NAME       REPLICAS   READY   AVAILABLE   UNAVAILABLE   LEASED   CLASS
test-set   4          3       1           1             1        qemu-test

kubectl get events -n jumpstarter --field-selector involvedObject.name=test-set
LAST SEEN   TYPE      REASON                 OBJECT                 MESSAGE
18m         Warning   ExporterSetDegraded    exporterset/test-set   ExporterSet test-set is degraded: 0 failed pods, 1 unavailable replicas
18m         Warning   ScalingLimited         exporterset/test-set   ExporterSet test-set scaling limited at 4 replicas
18m         Normal    ScalingUnlimited       exporterset/test-set   ExporterSet test-set scaling no longer limited
18m         Normal    ExporterSetAvailable   exporterset/test-set   ExporterSet test-set is available: 2 ready replicas
18m         Normal    ExporterSetRecovered   exporterset/test-set   ExporterSet test-set recovered: all replicas healthy
18m         Warning   ExporterSetDegraded    exporterset/test-set   ExporterSet test-set is degraded: 1 failed pods, 1 unavailable replicas