### PR TITLE
ci: trust renode/tap before installing renode on macOS

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -137,6 +137,7 @@ jobs:
           && (needs.changes.outputs.renode_driver == 'true'
           || github.event_name == 'workflow_dispatch')
         run: |
+          brew trust renode/tap
           brew install renode/tap/renode
 
       - name: Cache Fedora Cloud images


### PR DESCRIPTION
## Problem

macOS CI jobs in the merge queue are failing with:

```
Error: Refusing to load formula renode/tap/renode-nightly from untrusted tap renode/tap.
Run brew trust --formula renode/tap/renode-nightly or brew trust renode/tap to trust it.
```

## Cause

Recent Homebrew versions introduced chain-of-trust support for third-party taps. Formulas from untrusted taps are now refused by default, which breaks our `brew install renode/tap/renode` step.

## Fix

Add `brew trust renode/tap` before the install command. This is the only third-party tap used in our CI (`qemu` comes from Homebrew core and is unaffected).