### PR TITLE
fix: read client config driver settings in env_async()

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/common/utils_test.py
+++ b/python/packages/jumpstarter/jumpstarter/common/utils_test.py
@@ -1,11 +1,12 @@
 import shutil
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from .utils import _build_common_env, _lease_env_vars, launch_shell
-from jumpstarter.utils.env import ExporterMetadata
+from jumpstarter.config.client import ClientConfigV1Alpha1Drivers
+from jumpstarter.utils.env import ExporterMetadata, _resolve_drivers_config
 
 
 def test_launch_shell(tmp_path, monkeypatch):
@@ -271,3 +272,85 @@ async def test_fetch_exporter_labels_failure():
     await lease._fetch_exporter_labels()
 
     assert lease.exporter_labels == {}
+
+
+def test_resolve_drivers_config_env_allow_takes_precedence(monkeypatch):
+    monkeypatch.setenv("JMP_DRIVERS_ALLOW", "UNSAFE")
+    monkeypatch.delenv("JMP_DRIVERS_UNSAFE", raising=False)
+    drivers = _resolve_drivers_config()
+    assert drivers.unsafe is True
+    assert "UNSAFE" in drivers.allow
+
+
+def test_resolve_drivers_config_env_unsafe_takes_precedence(monkeypatch):
+    monkeypatch.delenv("JMP_DRIVERS_ALLOW", raising=False)
+    monkeypatch.setenv("JMP_DRIVERS_UNSAFE", "true")
+    drivers = _resolve_drivers_config()
+    assert drivers.unsafe is True
+
+
+def test_resolve_drivers_config_falls_back_to_client_config(monkeypatch):
+    monkeypatch.delenv("JMP_DRIVERS_ALLOW", raising=False)
+    monkeypatch.delenv("JMP_DRIVERS_UNSAFE", raising=False)
+
+    mock_drivers = ClientConfigV1Alpha1Drivers(allow=["my_driver.*"], unsafe=False)
+    mock_client = MagicMock()
+    mock_client.drivers = mock_drivers
+    mock_user_config = MagicMock()
+    mock_user_config.config.current_client = mock_client
+
+    with patch("jumpstarter.config.user.UserConfigV1Alpha1.load", return_value=mock_user_config):
+        drivers = _resolve_drivers_config()
+
+    assert drivers.allow == ["my_driver.*"]
+    assert drivers.unsafe is False
+
+
+def test_resolve_drivers_config_falls_back_to_client_config_unsafe(monkeypatch):
+    monkeypatch.delenv("JMP_DRIVERS_ALLOW", raising=False)
+    monkeypatch.delenv("JMP_DRIVERS_UNSAFE", raising=False)
+
+    mock_drivers = ClientConfigV1Alpha1Drivers(allow=["UNSAFE"], unsafe=True)
+    mock_client = MagicMock()
+    mock_client.drivers = mock_drivers
+    mock_user_config = MagicMock()
+    mock_user_config.config.current_client = mock_client
+
+    with patch("jumpstarter.config.user.UserConfigV1Alpha1.load", return_value=mock_user_config):
+        drivers = _resolve_drivers_config()
+
+    assert drivers.unsafe is True
+
+
+def test_resolve_drivers_config_defaults_when_no_config(monkeypatch):
+    monkeypatch.delenv("JMP_DRIVERS_ALLOW", raising=False)
+    monkeypatch.delenv("JMP_DRIVERS_UNSAFE", raising=False)
+
+    with patch("jumpstarter.config.user.UserConfigV1Alpha1.load", side_effect=FileNotFoundError("no config")):
+        drivers = _resolve_drivers_config()
+
+    assert drivers.allow == []
+    assert drivers.unsafe is False
+
+
+def test_resolve_drivers_config_defaults_when_no_current_client(monkeypatch):
+    monkeypatch.delenv("JMP_DRIVERS_ALLOW", raising=False)
+    monkeypatch.delenv("JMP_DRIVERS_UNSAFE", raising=False)
+
+    mock_user_config = MagicMock()
+    mock_user_config.config.current_client = None
+
+    with patch("jumpstarter.config.user.UserConfigV1Alpha1.load", return_value=mock_user_config):
+        drivers = _resolve_drivers_config()
+
+    assert drivers.allow == []
+    assert drivers.unsafe is False
+
+
+def test_resolve_drivers_config_propagates_unexpected_errors(monkeypatch):
+    monkeypatch.delenv("JMP_DRIVERS_ALLOW", raising=False)
+    monkeypatch.delenv("JMP_DRIVERS_UNSAFE", raising=False)
+
+    with patch("jumpstarter.config.user.UserConfigV1Alpha1.load", side_effect=RuntimeError("unexpected")):
+        with pytest.raises(RuntimeError, match="unexpected"):
+            _resolve_drivers_config()

--- a/python/packages/jumpstarter/jumpstarter/utils/env.py
+++ b/python/packages/jumpstarter/jumpstarter/utils/env.py
@@ -1,13 +1,16 @@
+import logging
 import os
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 
 from anyio.from_thread import start_blocking_portal
+from pydantic import ValidationError
 
 from jumpstarter.client import client_from_path
 from jumpstarter.common.exceptions import EnvironmentVariableNotSetError
 from jumpstarter.config.client import ClientConfigV1Alpha1Drivers
 from jumpstarter.config.env import (
+    JMP_DRIVERS_ALLOW,
     JMP_EXPORTER,
     JMP_EXPORTER_LABELS,
     JMP_GRPC_INSECURE,
@@ -16,6 +19,8 @@ from jumpstarter.config.env import (
     JUMPSTARTER_GRPC_INSECURE,
     JUMPSTARTER_HOST,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -44,6 +49,27 @@ class ExporterMetadata:
         return cls(name=name, labels=labels, lease=lease)
 
 
+def _resolve_drivers_config() -> ClientConfigV1Alpha1Drivers:
+    """Resolve driver settings from env vars or the current client config.
+
+    Env vars (JMP_DRIVERS_ALLOW / JMP_DRIVERS_UNSAFE) take precedence.
+    Falls back to the active client config's driver settings, then defaults.
+    """
+    if os.environ.get(JMP_DRIVERS_ALLOW) or os.environ.get("JMP_DRIVERS_UNSAFE"):
+        return ClientConfigV1Alpha1Drivers()
+
+    try:
+        from jumpstarter.config.user import UserConfigV1Alpha1
+
+        user_config = UserConfigV1Alpha1.load()
+        if user_config.config.current_client is not None:
+            return user_config.config.current_client.drivers
+    except (FileNotFoundError, ValueError, ValidationError):
+        logger.debug("No client config found, using default driver settings")
+
+    return ClientConfigV1Alpha1Drivers()
+
+
 @asynccontextmanager
 async def env_async(portal, stack):
     """Provide a client for an existing JUMPSTARTER_HOST environment variable.
@@ -57,7 +83,7 @@ async def env_async(portal, stack):
     if host is None:
         raise EnvironmentVariableNotSetError(f"{JUMPSTARTER_HOST} not set")
 
-    drivers = ClientConfigV1Alpha1Drivers()
+    drivers = _resolve_drivers_config()
 
     insecure = os.environ.get(JMP_GRPC_INSECURE, "") == "1" or os.environ.get(JUMPSTARTER_GRPC_INSECURE, "") == "1"
     passphrase = os.environ.get(JMP_GRPC_PASSPHRASE) or None


### PR DESCRIPTION
env_async() created a fresh ClientConfigV1Alpha1Drivers() that only read JMP_DRIVERS_* env vars. When JUMPSTARTER_HOST was set without those env vars, all driver imports were rejected.

Add _resolve_drivers_config() that falls back to the active client config's drivers section from ~/.config/jumpstarter/clients/*.yaml when env vars are absent.