### PR TITLE
fix: retry transient gRPC failures in status reports

### DIFF
--- a/controller/internal/service/auth/auth.go
+++ b/controller/internal/service/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/authorization"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/oidc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,6 +93,17 @@ func (s *Auth) VerifyExporter(ctx context.Context) (*jumpstarterdevv1alpha1.Expo
 	}
 
 	return jexporter, nil
+}
+
+// IsExporter checks the jumpstarter-kind metadata to determine if the caller
+// is an exporter without performing full authentication.
+func (s *Auth) IsExporter(ctx context.Context) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	kinds := md.Get("jumpstarter-kind")
+	return len(kinds) == 1 && kinds[0] == "Exporter"
 }
 
 func (s *Auth) AuthExporter(ctx context.Context, namespace string) (*jumpstarterdevv1alpha1.Exporter, error) {

--- a/controller/internal/service/auth/auth.go
+++ b/controller/internal/service/auth/auth.go
@@ -96,7 +96,7 @@ func (s *Auth) VerifyExporter(ctx context.Context) (*jumpstarterdevv1alpha1.Expo
 }
 
 // IsExporter checks the jumpstarter-kind metadata to determine if the caller
-// is an exporter without performing full authentication.
+// is an exporter.
 func (s *Auth) IsExporter(ctx context.Context) bool {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {

--- a/controller/internal/service/auth/auth_test.go
+++ b/controller/internal/service/auth/auth_test.go
@@ -500,3 +500,55 @@ func TestAuthExporter_NoTokenLeak(t *testing.T) {
 		t.Errorf("raw bearer header leaked in auth log output:\n%s", logged)
 	}
 }
+
+func TestIsExporter(t *testing.T) {
+	authn := &stubAuthenticator{}
+	attr := &stubAttributesGetter{}
+	authz := &stubAuthorizer{}
+	a := newAuth(authn, authz, attr)
+
+	tests := []struct {
+		name     string
+		metadata metadata.MD
+		want     bool
+	}{
+		{
+			name:     "exporter kind",
+			metadata: metadata.Pairs("jumpstarter-kind", "Exporter"),
+			want:     true,
+		},
+		{
+			name:     "client kind",
+			metadata: metadata.Pairs("jumpstarter-kind", "Client"),
+			want:     false,
+		},
+		{
+			name:     "no metadata",
+			metadata: metadata.MD{},
+			want:     false,
+		},
+		{
+			name:     "missing kind",
+			metadata: metadata.Pairs("jumpstarter-namespace", "default"),
+			want:     false,
+		},
+		{
+			name:     "multiple kind values",
+			metadata: metadata.Pairs("jumpstarter-kind", "Exporter", "jumpstarter-kind", "Client"),
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if len(tt.metadata) > 0 {
+				ctx = metadata.NewIncomingContext(ctx, tt.metadata)
+			}
+			got := a.IsExporter(ctx)
+			if got != tt.want {
+				t.Errorf("IsExporter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/internal/service/controller_service.go
+++ b/controller/internal/service/controller_service.go
@@ -54,6 +54,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -1051,11 +1052,15 @@ func (s *ControllerService) releaseLeaseAsExporter(
 		Namespace: exporter.Namespace,
 		Name:      req.Name,
 	}, &lease); err != nil {
-		return nil, fmt.Errorf("failed to get lease: %w", err)
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "lease %s not found", req.Name)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get lease: %s", err)
 	}
 
 	if lease.Status.ExporterRef == nil || lease.Status.ExporterRef.Name != exporter.Name {
-		return nil, fmt.Errorf("ReleaseLease permission denied")
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"lease %s is not held by exporter %s", req.Name, exporter.Name)
 	}
 
 	// Idempotent: already ended or marked for release
@@ -1067,7 +1072,7 @@ func (s *ControllerService) releaseLeaseAsExporter(
 	lease.Spec.Release = true
 
 	if err := s.Client.Patch(ctx, &lease, original); err != nil {
-		return nil, fmt.Errorf("failed to mark lease for release: %w", err)
+		return nil, status.Errorf(codes.Internal, "failed to mark lease for release: %s", err)
 	}
 
 	return &pb.ReleaseLeaseResponse{}, nil
@@ -1077,8 +1082,12 @@ func (s *ControllerService) ReleaseLease(
 	ctx context.Context,
 	req *pb.ReleaseLeaseRequest,
 ) (*pb.ReleaseLeaseResponse, error) {
-	// Try exporter auth first, then client auth
-	if exporter, err := s.authenticateExporter(ctx); err == nil {
+	// Route based on jumpstarter-kind metadata to avoid spurious auth failures
+	if s.getAuth().IsExporter(ctx) {
+		exporter, err := s.authenticateExporter(ctx)
+		if err != nil {
+			return nil, err
+		}
 		return s.releaseLeaseAsExporter(ctx, exporter, req)
 	}
 

--- a/controller/internal/service/controller_service.go
+++ b/controller/internal/service/controller_service.go
@@ -1041,10 +1041,47 @@ func (s *ControllerService) RequestLease(
 	}, nil
 }
 
+func (s *ControllerService) releaseLeaseAsExporter(
+	ctx context.Context,
+	exporter *jumpstarterdevv1alpha1.Exporter,
+	req *pb.ReleaseLeaseRequest,
+) (*pb.ReleaseLeaseResponse, error) {
+	var lease jumpstarterdevv1alpha1.Lease
+	if err := s.Client.Get(ctx, types.NamespacedName{
+		Namespace: exporter.Namespace,
+		Name:      req.Name,
+	}, &lease); err != nil {
+		return nil, fmt.Errorf("failed to get lease: %w", err)
+	}
+
+	if lease.Status.ExporterRef == nil || lease.Status.ExporterRef.Name != exporter.Name {
+		return nil, fmt.Errorf("ReleaseLease permission denied")
+	}
+
+	// Idempotent: already ended or marked for release
+	if lease.Status.Ended || lease.Spec.Release {
+		return &pb.ReleaseLeaseResponse{}, nil
+	}
+
+	original := client.MergeFrom(lease.DeepCopy())
+	lease.Spec.Release = true
+
+	if err := s.Client.Patch(ctx, &lease, original); err != nil {
+		return nil, fmt.Errorf("failed to mark lease for release: %w", err)
+	}
+
+	return &pb.ReleaseLeaseResponse{}, nil
+}
+
 func (s *ControllerService) ReleaseLease(
 	ctx context.Context,
 	req *pb.ReleaseLeaseRequest,
 ) (*pb.ReleaseLeaseResponse, error) {
+	// Try exporter auth first, then client auth
+	if exporter, err := s.authenticateExporter(ctx); err == nil {
+		return s.releaseLeaseAsExporter(ctx, exporter, req)
+	}
+
 	jclient, err := s.authenticateClient(ctx)
 	if err != nil {
 		return nil, err
@@ -1060,6 +1097,11 @@ func (s *ControllerService) ReleaseLease(
 
 	if lease.Spec.ClientRef.Name != jclient.Name {
 		return nil, fmt.Errorf("ReleaseLease permission denied")
+	}
+
+	// Idempotent: already ended or marked for release
+	if lease.Status.Ended || lease.Spec.Release {
+		return &pb.ReleaseLeaseResponse{}, nil
 	}
 
 	original := client.MergeFrom(lease.DeepCopy())

--- a/controller/internal/service/controller_service_integration_test.go
+++ b/controller/internal/service/controller_service_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
+	pb "github.com/jumpstarter-dev/jumpstarter/controller/internal/protocol/jumpstarter/v1"
 )
 
 var _ = Describe("ControllerService Integration", func() {
@@ -267,6 +268,190 @@ var _ = Describe("ControllerService Integration", func() {
 			err := controllerService.handleExporterLeaseRelease(ctx, exporter)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not held by exporter"))
+		})
+	})
+
+	Context("releaseLeaseAsExporter", func() {
+		var (
+			controllerService *ControllerService
+			exporter          *jumpstarterdevv1alpha1.Exporter
+			lease             *jumpstarterdevv1alpha1.Lease
+		)
+
+		BeforeEach(func() {
+			controllerService = &ControllerService{
+				Client: k8sClient,
+			}
+		})
+
+		AfterEach(func() {
+			// Clean up resources
+			if exporter != nil {
+				_ = k8sClient.Delete(ctx, exporter)
+			}
+			if lease != nil {
+				_ = k8sClient.Delete(ctx, lease)
+			}
+		})
+
+		It("should release lease when called by owning exporter", func() {
+			// Create lease
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-release-by-exporter",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status to have ExporterRef
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "test-exporter"},
+				Ended:       false,
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-release-by-exporter"}
+			resp, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+
+			// Verify lease was marked for release
+			var updatedLease jumpstarterdevv1alpha1.Lease
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "lease-release-by-exporter",
+			}, &updatedLease)).To(Succeed())
+			Expect(updatedLease.Spec.Release).To(BeTrue())
+		})
+
+		It("should return permission denied when exporter doesn't own lease", func() {
+			// Create lease owned by different exporter
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-owned-by-other",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status with different exporter
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "other-exporter"},
+				Ended:       false,
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-owned-by-other"}
+			_, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("permission denied"))
+		})
+
+		It("should be idempotent when lease already marked for release", func() {
+			// Create lease already marked for release
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-already-releasing",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   true, // Already marked for release
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "test-exporter"},
+				Ended:       false,
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-already-releasing"}
+			resp, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("should be idempotent when lease already ended", func() {
+			// Create ended lease
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-already-ended",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status as ended
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "test-exporter"},
+				Ended:       true, // Already ended
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-already-ended"}
+			resp, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
 		})
 	})
 })

--- a/controller/internal/service/controller_service_integration_test.go
+++ b/controller/internal/service/controller_service_integration_test.go
@@ -375,7 +375,7 @@ var _ = Describe("ControllerService Integration", func() {
 			req := &pb.ReleaseLeaseRequest{Name: "lease-owned-by-other"}
 			_, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("permission denied"))
+			Expect(err.Error()).To(ContainSubstring("not held by exporter"))
 		})
 
 		It("should be idempotent when lease already marked for release", func() {

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# ReportStatus retry configuration
+_TRANSIENT_GRPC_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED})
+_REPORT_STATUS_MAX_RETRIES = 3
+_REPORT_STATUS_BACKOFF_BASE = 1.0
+
 
 async def _standalone_shutdown_waiter():
     """Wait forever; used so serve_standalone_tcp can be cancelled by stop()."""
@@ -348,6 +353,42 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         if self._lease_context is None:
             await self._report_status(ExporterStatus.AVAILABLE, "Exporter registered and available")
 
+    async def _send_report_status_rpc(self, request: jumpstarter_pb2.ReportStatusRequest) -> bool:
+        """Send ReportStatus RPC to the controller with retry on transient errors.
+
+        Args:
+            request: The ReportStatusRequest protobuf message to send
+
+        Returns:
+            True if the RPC succeeded (or controller doesn't support it), False otherwise
+        """
+        for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
+            try:
+                async with self._controller_stub() as controller:
+                    await controller.ReportStatus(request)
+                return True
+            except grpc.aio.AioRpcError as e:
+                if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                    logger.warning("ReportStatus not supported by controller, status updates will be skipped")
+                    return False
+                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
+                    backoff = _REPORT_STATUS_BACKOFF_BASE * (2**attempt)
+                    logger.warning(
+                        "Transient error reporting status (attempt %d/%d), retrying in %.1fs: %s",
+                        attempt + 1,
+                        _REPORT_STATUS_MAX_RETRIES + 1,
+                        backoff,
+                        e,
+                    )
+                    await anyio.sleep(backoff)
+                    continue
+                logger.error("Failed to update status: %s", e)
+                return False
+            except Exception as e:
+                logger.error("Failed to update status: %s", e)
+                return False
+        return False
+
     async def _report_status(self, status: ExporterStatus, message: str = ""):
         """Report the exporter status with the controller and session."""
         self._exporter_status = status
@@ -361,22 +402,14 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             logger.debug("Updated status to %s: %s (standalone, no controller)", status, message)
             return
 
-        try:
-            async with self._controller_stub() as controller:
-                await controller.ReportStatus(
-                    jumpstarter_pb2.ReportStatusRequest(
-                        status=status.to_proto(),
-                        message=message,
-                    )
-                )
-            logger.info(f"Updated status to {status}: {message}")
-        except grpc.aio.AioRpcError as e:
-            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
-                logger.warning("ReportStatus not supported by controller, status updates will be skipped")
-            else:
-                logger.error(f"Failed to update status: {e}")
-        except Exception as e:
-            logger.error(f"Failed to update status: {e}")
+        success = await self._send_report_status_rpc(
+            jumpstarter_pb2.ReportStatusRequest(
+                status=status.to_proto(),
+                message=message,
+            )
+        )
+        if success:
+            logger.info("Updated status to %s: %s", status, message)
 
     async def _request_lease_release(self):
         """Request the controller to release the current lease.
@@ -400,20 +433,17 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             self._lease_context.lease_ended.set()
             return
 
-        try:
-            async with self._controller_stub() as controller:
-                await controller.ReportStatus(
-                    jumpstarter_pb2.ReportStatusRequest(
-                        status=ExporterStatus.AVAILABLE.to_proto(),
-                        message="Lease released after afterLease hook",
-                        release_lease=True,
-                    )
-                )
+        success = await self._send_report_status_rpc(
+            jumpstarter_pb2.ReportStatusRequest(
+                status=ExporterStatus.AVAILABLE.to_proto(),
+                message="Lease released after afterLease hook",
+                release_lease=True,
+            )
+        )
+        if success:
             logger.info("Requested controller to release lease %s", self._lease_context.lease_name)
-        except Exception as e:
-            logger.error("Failed to request lease release: %s", e)
-            # Fall through - the client can still release the lease as a fallback,
-            # or the lease will eventually expire
+        else:
+            logger.error("Failed to request lease release")
 
         # Directly signal lease ended so handle_lease can exit.
         # The controller may not send another leased=False after our release request,

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -389,7 +389,6 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             except Exception as e:
                 logger.error("Failed to update status: %s", e)
                 return False
-        return False
 
     async def _report_status(self, status: ExporterStatus, message: str = ""):
         """Report the exporter status with the controller and session."""
@@ -439,8 +438,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         # If the controller processed the request but response was lost, retrying could
         # release a newly-assigned lease. The controller has already ended the lease
         # (it sent leased=false which triggered this hook), so this is a courtesy confirmation.
-        released = False
-        unimplemented = False
+        should_retry = False
         try:
             async with self._controller_stub() as controller:
                 await controller.ReportStatus(
@@ -450,7 +448,6 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                         release_lease=True,
                     )
                 )
-            released = True
             logger.info("Requested controller to release lease %s", self._lease_context.lease_name)
         except grpc.aio.AioRpcError as e:
             if e.code() == grpc.StatusCode.UNIMPLEMENTED:
@@ -459,16 +456,16 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 # guard for compatibility with any controllers built from commits before
                 # b76f6c87 (2025-11-25). Safe to remove in future versions.
                 logger.warning("ReportStatus not supported by controller, status updates will be skipped")
-                unimplemented = True
+                # Don't retry - controller doesn't support status reporting at all
             else:
                 logger.warning("Lease release RPC failed, will retry status update: %s", e)
+                should_retry = True
         except Exception as e:
             logger.warning("Lease release RPC failed, will retry status update: %s", e)
+            should_retry = True
 
-        # Phase 2: if release failed (but not UNIMPLEMENTED), retry just the AVAILABLE status
-        # (idempotent, safe to retry). The UNIMPLEMENTED check is legacy compatibility - skip
-        # fallback since old controllers don't support status reporting at all.
-        if not released and not unimplemented:
+        # Phase 2: retry just the AVAILABLE status if Phase 1 failed (idempotent, safe to retry)
+        if should_retry:
             await self._report_status(ExporterStatus.AVAILABLE, "Recovery after failed lease release")
 
         # Directly signal lease ended so handle_lease can exit.

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -456,9 +456,15 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 logger.warning("ReportStatus not supported by controller, status updates will be skipped")
                 # Don't retry - controller doesn't support status reporting at all
             else:
+                # Conservative: retry all other gRPC errors (transient and non-transient).
+                # Phase 2 uses a fresh stub, so temporary connection issues may resolve.
+                # Alternative: restrict to only UNAVAILABLE/DEADLINE_EXCEEDED to avoid
+                # retrying auth failures (PERMISSION_DENIED) that would hit the same barrier.
                 logger.warning("Lease release RPC failed, will retry status update: %s", e)
                 should_retry = True
         except Exception as e:
+            # Conservative: retry non-gRPC exceptions. In practice, gRPC wraps all network
+            # errors in AioRpcError, so this catches unexpected cases defensively.
             logger.warning("Lease release RPC failed, will retry status update: %s", e)
             should_retry = True
 

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -403,13 +403,13 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             logger.debug("Updated status to %s: %s (standalone, no controller)", status, message)
             return
 
-        success = await self._send_report_status_rpc(
+        # Log success; _send_report_status_rpc already logs errors
+        if await self._send_report_status_rpc(
             jumpstarter_pb2.ReportStatusRequest(
                 status=status.to_proto(),
                 message=message,
             )
-        )
-        if success:
+        ):
             logger.info("Updated status to %s: %s", status, message)
 
     async def _request_lease_release(self):
@@ -451,10 +451,8 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             logger.info("Requested controller to release lease %s", self._lease_context.lease_name)
         except grpc.aio.AioRpcError as e:
             if e.code() == grpc.StatusCode.UNIMPLEMENTED:
-                # Legacy support: ReportStatus was added to the controller in Nov 2025.
-                # All production controllers deployed today support it, but we retain this
-                # guard for compatibility with any controllers built from commits before
-                # b76f6c87 (2025-11-25). Safe to remove in future versions.
+                # Legacy support (see _send_report_status_rpc for details): controllers before
+                # Nov 2025 don't support ReportStatus. Safe to remove in future versions.
                 logger.warning("ReportStatus not supported by controller, status updates will be skipped")
                 # Don't retry - controller doesn't support status reporting at all
             else:

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -360,7 +360,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             request: The ReportStatusRequest protobuf message to send
 
         Returns:
-            True if the RPC succeeded (or controller doesn't support it), False otherwise
+            True if the RPC succeeded, False otherwise
         """
         for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
             try:
@@ -369,6 +369,8 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 return True
             except grpc.aio.AioRpcError as e:
                 if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                    # Legacy support: ReportStatus added Nov 2025 (commit b76f6c87).
+                    # All production controllers support it; safe to remove in future versions.
                     logger.warning("ReportStatus not supported by controller, status updates will be skipped")
                     return False
                 if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
@@ -433,17 +435,41 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             self._lease_context.lease_ended.set()
             return
 
-        success = await self._send_report_status_rpc(
-            jumpstarter_pb2.ReportStatusRequest(
-                status=ExporterStatus.AVAILABLE.to_proto(),
-                message="Lease released after afterLease hook",
-                release_lease=True,
-            )
-        )
-        if success:
+        # Phase 1: attempt release_lease=true once (non-idempotent, not safe to retry)
+        # If the controller processed the request but response was lost, retrying could
+        # release a newly-assigned lease. The controller has already ended the lease
+        # (it sent leased=false which triggered this hook), so this is a courtesy confirmation.
+        released = False
+        unimplemented = False
+        try:
+            async with self._controller_stub() as controller:
+                await controller.ReportStatus(
+                    jumpstarter_pb2.ReportStatusRequest(
+                        status=ExporterStatus.AVAILABLE.to_proto(),
+                        message="Lease released after afterLease hook",
+                        release_lease=True,
+                    )
+                )
+            released = True
             logger.info("Requested controller to release lease %s", self._lease_context.lease_name)
-        else:
-            logger.error("Failed to request lease release")
+        except grpc.aio.AioRpcError as e:
+            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                # Legacy support: ReportStatus was added to the controller in Nov 2025.
+                # All production controllers deployed today support it, but we retain this
+                # guard for compatibility with any controllers built from commits before
+                # b76f6c87 (2025-11-25). Safe to remove in future versions.
+                logger.warning("ReportStatus not supported by controller, status updates will be skipped")
+                unimplemented = True
+            else:
+                logger.warning("Lease release RPC failed, will retry status update: %s", e)
+        except Exception as e:
+            logger.warning("Lease release RPC failed, will retry status update: %s", e)
+
+        # Phase 2: if release failed (but not UNIMPLEMENTED), retry just the AVAILABLE status
+        # (idempotent, safe to retry). The UNIMPLEMENTED check is legacy compatibility - skip
+        # fallback since old controllers don't support status reporting at all.
+        if not released and not unimplemented:
+            await self._report_status(ExporterStatus.AVAILABLE, "Recovery after failed lease release")
 
         # Directly signal lease ended so handle_lease can exit.
         # The controller may not send another leased=False after our release request,

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -2,7 +2,6 @@ import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Self
 
 import anyio
@@ -37,18 +36,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# ReportStatus retry configuration
+# gRPC retry configuration
 _TRANSIENT_GRPC_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED})
 _REPORT_STATUS_MAX_RETRIES = 3
 _REPORT_STATUS_BACKOFF_BASE = 1.0
 
-
-class _ReleaseLeaseResult(Enum):
-    """Result of _send_release_lease_rpc."""
-
-    SUCCESS = "success"
-    UNSUPPORTED = "unsupported"
-    FAILURE = "failure"
+# Status codes indicating old controller without exporter auth on ReleaseLease
+_RELEASE_LEASE_UNSUPPORTED_CODES = frozenset({
+    grpc.StatusCode.PERMISSION_DENIED,
+    grpc.StatusCode.INVALID_ARGUMENT,
+    grpc.StatusCode.UNAUTHENTICATED,
+    grpc.StatusCode.UNIMPLEMENTED,
+})
 
 
 async def _standalone_shutdown_waiter():
@@ -371,89 +370,68 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         if self._lease_context is None:
             await self._report_status(ExporterStatus.AVAILABLE, "Exporter registered and available")
 
+    async def _retry_rpc(
+        self,
+        rpc_call: Callable,
+        description: str,
+        *,
+        non_retryable_codes: frozenset[grpc.StatusCode] = frozenset(),
+    ) -> tuple[bool, grpc.StatusCode | None]:
+        """Retry a unary gRPC call with exponential backoff.
+
+        Args:
+            rpc_call: Async callable that takes a controller stub and performs the RPC
+            description: Human-readable description for log messages
+            non_retryable_codes: gRPC status codes that should cause immediate return
+                without retry (e.g. UNIMPLEMENTED for unsupported RPCs)
+
+        Returns:
+            (True, None) on success.
+            (False, status_code) on non-retryable error or retry exhaustion.
+            (False, None) on non-gRPC exception.
+        """
+        for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
+            try:
+                async with self._controller_stub() as controller:
+                    await rpc_call(controller)
+                return True, None
+            except grpc.aio.AioRpcError as e:
+                if e.code() in non_retryable_codes:
+                    return False, e.code()
+                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
+                    backoff = _REPORT_STATUS_BACKOFF_BASE * (2**attempt)
+                    logger.warning(
+                        "Transient error %s (attempt %d/%d), retrying in %.1fs: %s",
+                        description,
+                        attempt + 1,
+                        _REPORT_STATUS_MAX_RETRIES + 1,
+                        backoff,
+                        e,
+                    )
+                    await anyio.sleep(backoff)
+                    continue
+                logger.error("Failed to %s: %s", description, e)
+                return False, e.code()
+            except Exception as e:
+                logger.error("Failed to %s: %s", description, e)
+                return False, None
+
     async def _send_report_status_rpc(self, request: jumpstarter_pb2.ReportStatusRequest) -> bool:
         """Send ReportStatus RPC to the controller with retry on transient errors.
 
-        Args:
-            request: The ReportStatusRequest protobuf message to send
-
         Returns:
-            True if the RPC succeeded, False if the controller doesn't support it or retries were exhausted
+            True if the RPC succeeded, False if unsupported or retries exhausted
         """
-        for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
-            try:
-                async with self._controller_stub() as controller:
-                    await controller.ReportStatus(request)
-                return True
-            except grpc.aio.AioRpcError as e:
-                if e.code() == grpc.StatusCode.UNIMPLEMENTED:
-                    # Legacy support: ReportStatus added Nov 2025 (commit b76f6c87).
-                    # All production controllers support it; safe to remove in future versions.
-                    logger.warning("ReportStatus not supported by controller, status updates will be skipped")
-                    return False
-                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
-                    backoff = _REPORT_STATUS_BACKOFF_BASE * (2**attempt)
-                    logger.warning(
-                        "Transient error reporting status (attempt %d/%d), retrying in %.1fs: %s",
-                        attempt + 1,
-                        _REPORT_STATUS_MAX_RETRIES + 1,
-                        backoff,
-                        e,
-                    )
-                    await anyio.sleep(backoff)
-                    continue
-                logger.error("Failed to update status: %s", e)
-                return False
-            except Exception as e:
-                logger.error("Failed to update status: %s", e)
-                return False
-
-    async def _send_release_lease_rpc(self, lease_name: str) -> _ReleaseLeaseResult:
-        """Send ReleaseLease RPC with retry on transient errors.
-
-        Args:
-            lease_name: The name of the lease to release
-
-        Returns:
-            SUCCESS if the lease was released,
-            UNSUPPORTED if the controller doesn't support exporter auth on ReleaseLease,
-            FAILURE if retries were exhausted
-        """
-        for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
-            try:
-                async with self._controller_stub() as controller:
-                    await controller.ReleaseLease(jumpstarter_pb2.ReleaseLeaseRequest(name=lease_name))
-                return _ReleaseLeaseResult.SUCCESS
-            except grpc.aio.AioRpcError as e:
-                # Auth rejection codes indicate old controller without exporter auth support
-                if e.code() in (
-                    grpc.StatusCode.PERMISSION_DENIED,
-                    grpc.StatusCode.INVALID_ARGUMENT,
-                    grpc.StatusCode.UNAUTHENTICATED,
-                    grpc.StatusCode.UNIMPLEMENTED,
-                ):
-                    logger.info(
-                        "Controller doesn't support ReleaseLease for exporters (%s), "
-                        "falling back to ReportStatus with release_lease",
-                        e.code().name,
-                    )
-                    return _ReleaseLeaseResult.UNSUPPORTED
-                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
-                    backoff = _REPORT_STATUS_BACKOFF_BASE * (2**attempt)
-                    logger.warning(
-                        "Transient error releasing lease (attempt %d/%d), retrying in %.1fs: %s",
-                        attempt + 1,
-                        _REPORT_STATUS_MAX_RETRIES + 1,
-                        backoff,
-                        e,
-                    )
-                    await anyio.sleep(backoff)
-                    continue
-                logger.error("Failed to release lease: %s", e)
-                return _ReleaseLeaseResult.FAILURE
-            except Exception as e:
-                logger.error("Failed to release lease: %s", e)
-                return _ReleaseLeaseResult.FAILURE
+        ok, code = await self._retry_rpc(
+            lambda ctrl: ctrl.ReportStatus(request),
+            "report status",
+            non_retryable_codes=frozenset({grpc.StatusCode.UNIMPLEMENTED}),
+        )
+        if not ok and code == grpc.StatusCode.UNIMPLEMENTED:
+            # Legacy support: ReportStatus added Nov 2025 (commit b76f6c87).
+            # All production controllers support it; safe to remove in future versions.
+            logger.warning("ReportStatus not supported by controller, status updates will be skipped")
+        return ok
 
     async def _report_status(self, status: ExporterStatus, message: str = ""):
         """Report the exporter status with the controller and session."""
@@ -477,7 +455,30 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         ):
             logger.info("Updated status to %s: %s", status, message)
 
-    async def _request_lease_release(self):  # noqa: C901
+    async def _send_compat_release(self, lease_name: str):
+        """Release lease via ReportStatus with release_lease=true (DEPRECATED).
+
+        Backward-compat fallback for controllers that don't support exporter auth
+        on ReleaseLease. Uses non-AVAILABLE status to block new lease assignment
+        (filterOutNotReadyExporters) until the final AVAILABLE status, preventing
+        retry from releasing a newly-assigned lease.
+
+        TODO: Remove when all controllers support ReleaseLease for exporters.
+        """
+        release_status = self._exporter_status
+        if release_status == ExporterStatus.AVAILABLE:
+            release_status = ExporterStatus.AFTER_LEASE_HOOK
+
+        if await self._send_report_status_rpc(
+            jumpstarter_pb2.ReportStatusRequest(
+                status=release_status.to_proto(),
+                message="Lease released (compat: ReportStatus with release_lease)",
+                release_lease=True,
+            )
+        ):
+            logger.info("Requested controller to release lease %s (compat path)", lease_name)
+
+    async def _request_lease_release(self):
         """Request the controller to release the current lease.
 
         Called after the afterLease hook completes to ensure the lease is
@@ -504,57 +505,28 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
         lease_name = self._lease_context.lease_name
 
-        # Try ReleaseLease RPC unless we've already discovered it's unsupported
-        use_compat_fallback = self._release_lease_unsupported
+        if self._release_lease_unsupported:
+            await self._send_compat_release(lease_name)
+        else:
+            ok, code = await self._retry_rpc(
+                lambda ctrl: ctrl.ReleaseLease(jumpstarter_pb2.ReleaseLeaseRequest(name=lease_name)),
+                "release lease",
+                non_retryable_codes=_RELEASE_LEASE_UNSUPPORTED_CODES,
+            )
 
-        if not self._release_lease_unsupported:
-            result = await self._send_release_lease_rpc(lease_name)
-
-            if result == _ReleaseLeaseResult.SUCCESS:
+            if ok:
                 logger.info("Released lease %s via ReleaseLease RPC", lease_name)
-                # Make exporter available and signal lease ended
-                await self._report_status(ExporterStatus.AVAILABLE, "Exporter available after lease release")
-                if self._lease_context and not self._lease_context.lease_ended.is_set():
-                    self._lease_context.lease_ended.set()
-                return
-
-            if result == _ReleaseLeaseResult.UNSUPPORTED:
-                # Cache the detection so we skip ReleaseLease on subsequent leases
+            elif code in _RELEASE_LEASE_UNSUPPORTED_CODES:
                 self._release_lease_unsupported = True
-                use_compat_fallback = True
                 logger.info(
-                    "Controller doesn't support exporter auth on ReleaseLease, using fallback for all future releases"
+                    "Controller doesn't support ReleaseLease for exporters (%s), "
+                    "falling back to ReportStatus with release_lease",
+                    code.name,
                 )
-                # Fall through to backward-compat path
+                await self._send_compat_release(lease_name)
+            else:
+                logger.warning("Failed to release lease %s after retries, proceeding to AVAILABLE", lease_name)
 
-            # result == FAILURE: couldn't reach controller after retries. Proceed to AVAILABLE
-            # to avoid blocking the exporter indefinitely.
-            if result == _ReleaseLeaseResult.FAILURE:
-                logger.warning("Failed to release lease %s after retries, exporter proceeding to AVAILABLE", lease_name)
-
-        # Backward-compat fallback (DEPRECATED)
-        # When the controller doesn't support exporter auth on ReleaseLease, fall back
-        # to ReportStatus with release_lease=true.
-        # TODO: Remove when all controllers support ReleaseLease for exporters.
-        if use_compat_fallback:
-            # Use current status unless it's AVAILABLE, in which case revert to AFTER_LEASE_HOOK.
-            # Non-AVAILABLE blocks new lease assignment (filterOutNotReadyExporters) until the
-            # final AVAILABLE status below, preventing retry from releasing a newly-assigned lease.
-            release_status = self._exporter_status
-            if release_status == ExporterStatus.AVAILABLE:
-                release_status = ExporterStatus.AFTER_LEASE_HOOK
-
-            # Send release_lease=true with non-AVAILABLE status (retry-safe: blocks lease assignment)
-            if await self._send_report_status_rpc(
-                jumpstarter_pb2.ReportStatusRequest(
-                    status=release_status.to_proto(),
-                    message="Lease released (compat: ReportStatus with release_lease)",
-                    release_lease=True,
-                )
-            ):
-                logger.info("Requested controller to release lease %s (compat path)", lease_name)
-
-        # Make exporter available (both paths converge here)
         await self._report_status(ExporterStatus.AVAILABLE, "Exporter available after lease release")
 
         # Directly signal lease ended so handle_lease can exit.

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -37,9 +37,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # gRPC retry configuration
+# Worst case ~18 min (21 attempts × 30s timeout + backoff sum ~8 min).
+# The exporter has nothing useful to do while the controller is unreachable —
+# even a restart just fails at _register_with_controller (no retry).
 _TRANSIENT_GRPC_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED})
-_REPORT_STATUS_MAX_RETRIES = 3
-_REPORT_STATUS_BACKOFF_BASE = 1.0
+_RPC_MAX_RETRIES = 20
+_RPC_BACKOFF_BASE = 1.0
+_RPC_BACKOFF_CAP = 30.0
+_RPC_TIMEOUT = 30
 
 # Status codes indicating old controller without exporter auth on ReleaseLease
 _RELEASE_LEASE_UNSUPPORTED_CODES = frozenset({
@@ -219,6 +224,23 @@ class Exporter(AsyncContextManagerMixin, Metadata):
     TODO: Remove this field when all controllers support ReleaseLease for exporters.
     """
 
+    _status_drain_active: bool = field(init=False, default=False)
+    """True only while serve()'s task group is running and the drain task is active.
+
+    When True, _report_status enqueues status updates for background processing.
+    When False (registration, unregistration), _report_status awaits directly.
+    """
+
+    _pending_status_request: jumpstarter_pb2.ReportStatusRequest | None = field(init=False, default=None)
+    """Latest status update pending delivery by the background drain task.
+
+    "Latest wins" semantics: if multiple _report_status calls happen while the
+    drain task is busy retrying, only the most recent one is sent.
+    """
+
+    _status_rpc_event: Event = field(init=False, default_factory=Event)
+    """Signals the drain task that a new status update is pending."""
+
     def stop(self, wait_for_lease_exit=False, should_unregister=False, exit_code: int | None = None):
         """Signal the exporter to stop.
 
@@ -390,7 +412,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             (False, status_code) on non-retryable error or retry exhaustion.
             (False, None) on non-gRPC exception.
         """
-        for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
+        for attempt in range(_RPC_MAX_RETRIES + 1):
             try:
                 async with self._controller_stub() as controller:
                     await rpc_call(controller)
@@ -398,13 +420,13 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             except grpc.aio.AioRpcError as e:
                 if e.code() in non_retryable_codes:
                     return False, e.code()
-                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
-                    backoff = _REPORT_STATUS_BACKOFF_BASE * (2**attempt)
+                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _RPC_MAX_RETRIES:
+                    backoff = min(_RPC_BACKOFF_BASE * (2**attempt), _RPC_BACKOFF_CAP)
                     logger.warning(
                         "Transient error %s (attempt %d/%d), retrying in %.1fs: %s",
                         description,
                         attempt + 1,
-                        _REPORT_STATUS_MAX_RETRIES + 1,
+                        _RPC_MAX_RETRIES + 1,
                         backoff,
                         e,
                     )
@@ -423,7 +445,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             True if the RPC succeeded, False if unsupported or retries exhausted
         """
         ok, code = await self._retry_rpc(
-            lambda ctrl: ctrl.ReportStatus(request),
+            lambda ctrl: ctrl.ReportStatus(request, timeout=_RPC_TIMEOUT),
             "report status",
             non_retryable_codes=frozenset({grpc.StatusCode.UNIMPLEMENTED}),
         )
@@ -432,6 +454,25 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             # All production controllers support it; safe to remove in future versions.
             logger.warning("ReportStatus not supported by controller, status updates will be skipped")
         return ok
+
+    async def _drain_status_reports(self):
+        """Background task that sends status updates to the controller.
+
+        Runs during serve() to make _report_status non-blocking. Uses "latest wins"
+        semantics: if multiple status updates arrive while retrying, only the most
+        recent one is sent. This prevents blocking the client connection path when
+        the controller is temporarily unreachable.
+        """
+        while True:
+            await self._status_rpc_event.wait()
+            self._status_rpc_event = Event()  # Reset for next update
+            request = self._pending_status_request
+            if request and await self._send_report_status_rpc(request):
+                logger.info(
+                    "Updated status to %s: %s",
+                    ExporterStatus.from_proto(request.status),
+                    request.message,
+                )
 
     async def _report_status(self, status: ExporterStatus, message: str = ""):
         """Report the exporter status with the controller and session."""
@@ -446,14 +487,19 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             logger.debug("Updated status to %s: %s (standalone, no controller)", status, message)
             return
 
-        # Log success; _send_report_status_rpc already logs errors
-        if await self._send_report_status_rpc(
-            jumpstarter_pb2.ReportStatusRequest(
-                status=status.to_proto(),
-                message=message,
-            )
-        ):
-            logger.info("Updated status to %s: %s", status, message)
+        request = jumpstarter_pb2.ReportStatusRequest(
+            status=status.to_proto(),
+            message=message,
+        )
+
+        if self._status_drain_active:
+            # During serve(): enqueue for background drain (non-blocking)
+            self._pending_status_request = request
+            self._status_rpc_event.set()
+        else:
+            # Outside serve() (registration, unregistration): send directly
+            if await self._send_report_status_rpc(request):
+                logger.info("Updated status to %s: %s", status, message)
 
     async def _send_compat_release(self, lease_name: str):
         """Release lease via ReportStatus with release_lease=true (DEPRECATED).
@@ -509,7 +555,9 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             await self._send_compat_release(lease_name)
         else:
             ok, code = await self._retry_rpc(
-                lambda ctrl: ctrl.ReleaseLease(jumpstarter_pb2.ReleaseLeaseRequest(name=lease_name)),
+                lambda ctrl: ctrl.ReleaseLease(
+                    jumpstarter_pb2.ReleaseLeaseRequest(name=lease_name), timeout=_RPC_TIMEOUT
+                ),
                 "release lease",
                 non_retryable_codes=_RELEASE_LEASE_UNSUPPORTED_CODES,
             )
@@ -962,6 +1010,11 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
         async with create_task_group() as tg:
             self._tg = tg
+            # Start background status drain (makes _report_status non-blocking)
+            self._status_rpc_event = Event()
+            self._pending_status_request = None
+            self._status_drain_active = True
+            tg.start_soon(self._drain_status_reports)
             # Start status stream with retry logic
             tg.start_soon(
                 self._retry_stream,
@@ -1048,6 +1101,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
                 self._previous_leased = current_leased
         self._tg = None
+        self._status_drain_active = False
         clear_log_context()
 
     async def serve_standalone_tcp(

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Self
 
 import anyio
@@ -40,6 +41,14 @@ logger = logging.getLogger(__name__)
 _TRANSIENT_GRPC_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED})
 _REPORT_STATUS_MAX_RETRIES = 3
 _REPORT_STATUS_BACKOFF_BASE = 1.0
+
+
+class _ReleaseLeaseResult(Enum):
+    """Result of _send_release_lease_rpc."""
+
+    SUCCESS = "success"
+    UNSUPPORTED = "unsupported"
+    FAILURE = "failure"
 
 
 async def _standalone_shutdown_waiter():
@@ -202,6 +211,15 @@ class Exporter(AsyncContextManagerMixin, Metadata):
     a reference holder and doesn't manage resource lifecycles directly.
     """
 
+    _release_lease_unsupported: bool = field(init=False, default=False)
+    """Caches whether the controller doesn't support exporter auth on ReleaseLease.
+
+    When True, _request_lease_release skips the ReleaseLease RPC and goes straight
+    to the deprecated ReportStatus(release_lease=true) fallback. Avoids rediscovering
+    the auth rejection on every lease cycle.
+    TODO: Remove this field when all controllers support ReleaseLease for exporters.
+    """
+
     def stop(self, wait_for_lease_exit=False, should_unregister=False, exit_code: int | None = None):
         """Signal the exporter to stop.
 
@@ -360,7 +378,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             request: The ReportStatusRequest protobuf message to send
 
         Returns:
-            True if the RPC succeeded, False otherwise
+            True if the RPC succeeded, False if the controller doesn't support it or retries were exhausted
         """
         for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
             try:
@@ -390,6 +408,53 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 logger.error("Failed to update status: %s", e)
                 return False
 
+    async def _send_release_lease_rpc(self, lease_name: str) -> _ReleaseLeaseResult:
+        """Send ReleaseLease RPC with retry on transient errors.
+
+        Args:
+            lease_name: The name of the lease to release
+
+        Returns:
+            SUCCESS if the lease was released,
+            UNSUPPORTED if the controller doesn't support exporter auth on ReleaseLease,
+            FAILURE if retries were exhausted
+        """
+        for attempt in range(_REPORT_STATUS_MAX_RETRIES + 1):
+            try:
+                async with self._controller_stub() as controller:
+                    await controller.ReleaseLease(jumpstarter_pb2.ReleaseLeaseRequest(name=lease_name))
+                return _ReleaseLeaseResult.SUCCESS
+            except grpc.aio.AioRpcError as e:
+                # Auth rejection codes indicate old controller without exporter auth support
+                if e.code() in (
+                    grpc.StatusCode.PERMISSION_DENIED,
+                    grpc.StatusCode.INVALID_ARGUMENT,
+                    grpc.StatusCode.UNAUTHENTICATED,
+                    grpc.StatusCode.UNIMPLEMENTED,
+                ):
+                    logger.info(
+                        "Controller doesn't support ReleaseLease for exporters (%s), "
+                        "falling back to ReportStatus with release_lease",
+                        e.code().name,
+                    )
+                    return _ReleaseLeaseResult.UNSUPPORTED
+                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _REPORT_STATUS_MAX_RETRIES:
+                    backoff = _REPORT_STATUS_BACKOFF_BASE * (2**attempt)
+                    logger.warning(
+                        "Transient error releasing lease (attempt %d/%d), retrying in %.1fs: %s",
+                        attempt + 1,
+                        _REPORT_STATUS_MAX_RETRIES + 1,
+                        backoff,
+                        e,
+                    )
+                    await anyio.sleep(backoff)
+                    continue
+                logger.error("Failed to release lease: %s", e)
+                return _ReleaseLeaseResult.FAILURE
+            except Exception as e:
+                logger.error("Failed to release lease: %s", e)
+                return _ReleaseLeaseResult.FAILURE
+
     async def _report_status(self, status: ExporterStatus, message: str = ""):
         """Report the exporter status with the controller and session."""
         self._exporter_status = status
@@ -412,20 +477,23 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         ):
             logger.info("Updated status to %s: %s", status, message)
 
-    async def _request_lease_release(self):
+    async def _request_lease_release(self):  # noqa: C901
         """Request the controller to release the current lease.
 
         Called after the afterLease hook completes to ensure the lease is
         released even if the client disconnects unexpectedly. This moves
         the lease release responsibility from the client to the exporter.
+
+        Tries the ReleaseLease RPC first (semantically correct, retry-safe).
+        Falls back to ReportStatus(release_lease=true) for old controllers that
+        don't support exporter auth on ReleaseLease (deprecated path).
         """
         if not self._lease_context or not self._lease_context.lease_name:
             logger.debug("No active lease to release")
             return
 
         # If the lease has already ended (controller sent leased=false, or a previous
-        # call already released it), skip the release RPC. A stale release_lease=true
-        # would release a subsequently-assigned lease on the controller.
+        # call already released it), skip the release RPC.
         if self._lease_context.lease_ended.is_set():
             logger.debug("Lease already ended, skipping release request")
             return
@@ -434,43 +502,60 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             self._lease_context.lease_ended.set()
             return
 
-        # Phase 1: attempt release_lease=true once (non-idempotent, not safe to retry)
-        # If the controller processed the request but response was lost, retrying could
-        # release a newly-assigned lease. The controller has already ended the lease
-        # (it sent leased=false which triggered this hook), so this is a courtesy confirmation.
-        should_retry = False
-        try:
-            async with self._controller_stub() as controller:
-                await controller.ReportStatus(
-                    jumpstarter_pb2.ReportStatusRequest(
-                        status=ExporterStatus.AVAILABLE.to_proto(),
-                        message="Lease released after afterLease hook",
-                        release_lease=True,
-                    )
-                )
-            logger.info("Requested controller to release lease %s", self._lease_context.lease_name)
-        except grpc.aio.AioRpcError as e:
-            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
-                # Legacy support (see _send_report_status_rpc for details): controllers before
-                # Nov 2025 don't support ReportStatus. Safe to remove in future versions.
-                logger.warning("ReportStatus not supported by controller, status updates will be skipped")
-                # Don't retry - controller doesn't support status reporting at all
-            else:
-                # Conservative: retry all other gRPC errors (transient and non-transient).
-                # Phase 2 uses a fresh stub, so temporary connection issues may resolve.
-                # Alternative: restrict to only UNAVAILABLE/DEADLINE_EXCEEDED to avoid
-                # retrying auth failures (PERMISSION_DENIED) that would hit the same barrier.
-                logger.warning("Lease release RPC failed, will retry status update: %s", e)
-                should_retry = True
-        except Exception as e:
-            # Conservative: retry non-gRPC exceptions. In practice, gRPC wraps all network
-            # errors in AioRpcError, so this catches unexpected cases defensively.
-            logger.warning("Lease release RPC failed, will retry status update: %s", e)
-            should_retry = True
+        lease_name = self._lease_context.lease_name
 
-        # Phase 2: retry just the AVAILABLE status if Phase 1 failed (idempotent, safe to retry)
-        if should_retry:
-            await self._report_status(ExporterStatus.AVAILABLE, "Recovery after failed lease release")
+        # Try ReleaseLease RPC unless we've already discovered it's unsupported
+        use_compat_fallback = self._release_lease_unsupported
+
+        if not self._release_lease_unsupported:
+            result = await self._send_release_lease_rpc(lease_name)
+
+            if result == _ReleaseLeaseResult.SUCCESS:
+                logger.info("Released lease %s via ReleaseLease RPC", lease_name)
+                # Make exporter available and signal lease ended
+                await self._report_status(ExporterStatus.AVAILABLE, "Exporter available after lease release")
+                if self._lease_context and not self._lease_context.lease_ended.is_set():
+                    self._lease_context.lease_ended.set()
+                return
+
+            if result == _ReleaseLeaseResult.UNSUPPORTED:
+                # Cache the detection so we skip ReleaseLease on subsequent leases
+                self._release_lease_unsupported = True
+                use_compat_fallback = True
+                logger.info(
+                    "Controller doesn't support exporter auth on ReleaseLease, using fallback for all future releases"
+                )
+                # Fall through to backward-compat path
+
+            # result == FAILURE: couldn't reach controller after retries. Proceed to AVAILABLE
+            # to avoid blocking the exporter indefinitely.
+            if result == _ReleaseLeaseResult.FAILURE:
+                logger.warning("Failed to release lease %s after retries, exporter proceeding to AVAILABLE", lease_name)
+
+        # Backward-compat fallback (DEPRECATED)
+        # When the controller doesn't support exporter auth on ReleaseLease, fall back
+        # to ReportStatus with release_lease=true.
+        # TODO: Remove when all controllers support ReleaseLease for exporters.
+        if use_compat_fallback:
+            # Use current status unless it's AVAILABLE, in which case revert to AFTER_LEASE_HOOK.
+            # Non-AVAILABLE blocks new lease assignment (filterOutNotReadyExporters) until the
+            # final AVAILABLE status below, preventing retry from releasing a newly-assigned lease.
+            release_status = self._exporter_status
+            if release_status == ExporterStatus.AVAILABLE:
+                release_status = ExporterStatus.AFTER_LEASE_HOOK
+
+            # Send release_lease=true with non-AVAILABLE status (retry-safe: blocks lease assignment)
+            if await self._send_report_status_rpc(
+                jumpstarter_pb2.ReportStatusRequest(
+                    status=release_status.to_proto(),
+                    message="Lease released (compat: ReportStatus with release_lease)",
+                    release_lease=True,
+                )
+            ):
+                logger.info("Requested controller to release lease %s (compat path)", lease_name)
+
+        # Make exporter available (both paths converge here)
+        await self._report_status(ExporterStatus.AVAILABLE, "Exporter available after lease release")
 
         # Directly signal lease ended so handle_lease can exit.
         # The controller may not send another leased=False after our release request,

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -487,24 +487,36 @@ class TestBeforeLeaseHookRaceGuard:
         )
 
 
+def _setup_mock_controller_stub(exporter, side_effect=None):
+    """Helper to set up mock controller stub for testing ReportStatus.
+
+    Returns:
+        tuple: (mock_controller, stub_context_manager)
+    """
+    mock_controller = AsyncMock()
+    if side_effect is not None:
+        mock_controller.ReportStatus = AsyncMock(side_effect=side_effect)
+
+    stub_ctx = AsyncMock()
+    stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+    stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_controller, stub_ctx
+
+
 class TestReportStatusGrpcErrorHandling:
     async def test_unimplemented_grpc_error_logs_warning(self, caplog):
         """When ReportStatus returns UNIMPLEMENTED, a warning is logged
         instead of an error."""
         exporter = _make_exporter_for_report_status()
 
-        mock_controller = AsyncMock()
         error = grpc.aio.AioRpcError(
             code=grpc.StatusCode.UNIMPLEMENTED,
             initial_metadata=grpc.aio.Metadata(),
             trailing_metadata=grpc.aio.Metadata(),
             details="Method not implemented",
         )
-        mock_controller.ReportStatus = AsyncMock(side_effect=error)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=error)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             with caplog.at_level(logging.WARNING, logger="jumpstarter.exporter.exporter"):
@@ -525,18 +537,13 @@ class TestReportStatusGrpcErrorHandling:
         it retries and eventually logs at ERROR level."""
         exporter = _make_exporter_for_report_status()
 
-        mock_controller = AsyncMock()
         error = grpc.aio.AioRpcError(
             code=grpc.StatusCode.UNAVAILABLE,
             initial_metadata=grpc.aio.Metadata(),
             trailing_metadata=grpc.aio.Metadata(),
             details="Service unavailable",
         )
-        mock_controller.ReportStatus = AsyncMock(side_effect=error)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=error)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), \
                 patch("anyio.sleep") as mock_sleep:
@@ -551,6 +558,9 @@ class TestReportStatusGrpcErrorHandling:
         # Verify exponential backoff schedule
         backoff_values = [call.args[0] for call in mock_sleep.call_args_list]
         assert backoff_values == [1.0, 2.0, 4.0], f"Expected [1.0, 2.0, 4.0], got: {backoff_values}"
+
+        # 4 total attempts: 1 initial + 3 retries
+        assert mock_controller.ReportStatus.call_count == 4
 
         # Eventually logs ERROR after exhausting retries
         error_msgs = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -585,12 +595,7 @@ class TestReportStatusGrpcErrorHandling:
             # Third attempt succeeds
             delivered_statuses.append(ExporterStatus.from_proto(request.status))
 
-        mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=fail_twice_then_succeed)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=fail_twice_then_succeed)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), \
                 patch("anyio.sleep") as mock_sleep:
@@ -615,13 +620,7 @@ class TestReportStatusGrpcErrorHandling:
             trailing_metadata=grpc.aio.Metadata(),
             details="Permission denied",
         )
-
-        mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=permission_error)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=permission_error)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             await exporter._report_status(ExporterStatus.AVAILABLE, "test")
@@ -634,13 +633,7 @@ class TestReportStatusGrpcErrorHandling:
         exporter = _make_exporter_for_report_status()
 
         connection_error = ConnectionError("Network unreachable")
-
-        mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=connection_error)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=connection_error)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             await exporter._report_status(ExporterStatus.AVAILABLE, "test")
@@ -680,12 +673,7 @@ class TestReportStatusGrpcErrorHandling:
             # Second attempt (fallback via _report_status) succeeds
             delivered.append(request)
 
-        mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=fail_first_then_succeed)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=fail_first_then_succeed)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
             await exporter._request_lease_release()
@@ -695,6 +683,46 @@ class TestReportStatusGrpcErrorHandling:
         assert delivered[0].release_lease is False  # Fallback sends status-only
         assert ExporterStatus.from_proto(delivered[0].status) == ExporterStatus.AVAILABLE
         assert call_count == 2
+
+    async def test_request_lease_release_exhausts_retries(self):
+        """When both Phase 1 and Phase 2 fail completely, lease_ended is still set
+        so handle_lease can exit (prevents being stuck forever)."""
+        exporter = _make_exporter_for_report_status()
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        unavailable_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Service unavailable",
+        )
+
+        call_count = 0
+
+        async def always_fail(request):
+            nonlocal call_count
+            call_count += 1
+            raise unavailable_error
+
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=always_fail)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
+            await exporter._request_lease_release()
+
+        # Phase 1: 1 attempt (release_lease=true fails)
+        # Phase 2: 4 attempts via _send_report_status_rpc (all fail)
+        # Total: 5 calls
+        assert call_count == 5
+
+        # Critical: lease_ended must be set even when everything fails,
+        # otherwise handle_lease never exits
+        assert lease_ctx.lease_ended.is_set()
 
     async def test_request_lease_release_succeeds_on_first_attempt(self):
         """When release_lease=true succeeds immediately, no fallback to _report_status."""
@@ -712,12 +740,7 @@ class TestReportStatusGrpcErrorHandling:
         async def succeed_immediately(request):
             delivered.append(request)
 
-        mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=succeed_immediately)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=succeed_immediately)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             await exporter._request_lease_release()
@@ -745,13 +768,7 @@ class TestReportStatusGrpcErrorHandling:
             trailing_metadata=grpc.aio.Metadata(),
             details="Method not implemented",
         )
-
-        mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=unimplemented_error)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=unimplemented_error)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             await exporter._request_lease_release()

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -649,7 +649,8 @@ class TestReportStatusGrpcErrorHandling:
         assert mock_controller.ReportStatus.call_count == 1
 
     async def test_request_lease_release_retries_on_transient_failure(self):
-        """_request_lease_release also uses retry logic via _send_report_status_rpc."""
+        """When release_lease=true fails, _request_lease_release falls back to
+        retrying just the AVAILABLE status via _report_status."""
         exporter = _make_exporter_for_report_status()
 
         lease_ctx = LeaseContext(
@@ -669,16 +670,18 @@ class TestReportStatusGrpcErrorHandling:
         delivered = []
         call_count = 0
 
-        async def fail_once_then_succeed(request):
+        async def fail_first_then_succeed(request):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
+                # First attempt (release_lease=true) fails
+                assert request.release_lease is True
                 raise unavailable_error
-            # Second attempt succeeds
+            # Second attempt (fallback via _report_status) succeeds
             delivered.append(request)
 
         mock_controller = AsyncMock()
-        mock_controller.ReportStatus = AsyncMock(side_effect=fail_once_then_succeed)
+        mock_controller.ReportStatus = AsyncMock(side_effect=fail_first_then_succeed)
 
         stub_ctx = AsyncMock()
         stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
@@ -687,10 +690,74 @@ class TestReportStatusGrpcErrorHandling:
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
             await exporter._request_lease_release()
 
-        # Status was delivered on the second attempt
+        # First call with release_lease=true failed, second call (via _report_status) succeeded
+        assert len(delivered) == 1
+        assert delivered[0].release_lease is False  # Fallback sends status-only
+        assert ExporterStatus.from_proto(delivered[0].status) == ExporterStatus.AVAILABLE
+        assert call_count == 2
+
+    async def test_request_lease_release_succeeds_on_first_attempt(self):
+        """When release_lease=true succeeds immediately, no fallback to _report_status."""
+        exporter = _make_exporter_for_report_status()
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        delivered = []
+
+        async def succeed_immediately(request):
+            delivered.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=succeed_immediately)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # Only one call made (release_lease=true succeeded)
         assert len(delivered) == 1
         assert delivered[0].release_lease is True
-        assert call_count == 2
+        assert ExporterStatus.from_proto(delivered[0].status) == ExporterStatus.AVAILABLE
+
+    async def test_request_lease_release_unimplemented_no_fallback(self):
+        """When controller returns UNIMPLEMENTED, no fallback to _report_status
+        (controller doesn't support status reporting at all)."""
+        exporter = _make_exporter_for_report_status()
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        unimplemented_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNIMPLEMENTED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Method not implemented",
+        )
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=unimplemented_error)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # Called exactly once (UNIMPLEMENTED means no fallback)
+        assert mock_controller.ReportStatus.call_count == 1
 
 
 class TestHandleLeaseStaleSkip:

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -531,6 +531,8 @@ class TestReportStatusGrpcErrorHandling:
         assert len(error_msgs) == 0, (
             f"No error should be logged for UNIMPLEMENTED, got: {[r.message for r in error_msgs]}"
         )
+        # Ensure no retry - UNIMPLEMENTED should fail fast
+        assert mock_controller.ReportStatus.call_count == 1
 
     async def test_other_grpc_error_logs_error(self, caplog):
         """When ReportStatus returns a gRPC error other than UNIMPLEMENTED,

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -522,7 +522,7 @@ class TestReportStatusGrpcErrorHandling:
 
     async def test_other_grpc_error_logs_error(self, caplog):
         """When ReportStatus returns a gRPC error other than UNIMPLEMENTED,
-        it is logged at ERROR level."""
+        it retries and eventually logs at ERROR level."""
         exporter = _make_exporter_for_report_status()
 
         mock_controller = AsyncMock()
@@ -538,19 +538,159 @@ class TestReportStatusGrpcErrorHandling:
         stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
         stub_ctx.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), \
+                patch("anyio.sleep") as mock_sleep:
             with caplog.at_level(logging.DEBUG, logger="jumpstarter.exporter.exporter"):
                 await exporter._report_status(ExporterStatus.AVAILABLE, "test")
 
+        # Should log retry warnings (3 retries)
+        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        retry_warnings = [r for r in warning_msgs if "Transient error" in r.message]
+        assert len(retry_warnings) == 3, f"Expected 3 retry warnings, got: {len(retry_warnings)}"
+
+        # Verify exponential backoff schedule
+        backoff_values = [call.args[0] for call in mock_sleep.call_args_list]
+        assert backoff_values == [1.0, 2.0, 4.0], f"Expected [1.0, 2.0, 4.0], got: {backoff_values}"
+
+        # Eventually logs ERROR after exhausting retries
         error_msgs = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert any("Failed to update status" in r.message for r in error_msgs), (
             f"Expected error about failed status update, got: {[r.message for r in caplog.records]}"
         )
         # Ensure no WARNING about "not supported" was logged
-        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert not any("ReportStatus not supported" in r.message for r in warning_msgs), (
             "UNAVAILABLE error should not produce 'not supported' warning"
         )
+
+    async def test_report_status_retries_on_transient_failure(self):
+        """Transient gRPC errors (UNAVAILABLE, DEADLINE_EXCEEDED) are retried.
+        If the error resolves before exhausting retries, the status is delivered."""
+        exporter = _make_exporter_for_report_status()
+
+        unavailable_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Service unavailable",
+        )
+
+        delivered_statuses = []
+        call_count = 0
+
+        async def fail_twice_then_succeed(request):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise unavailable_error
+            # Third attempt succeeds
+            delivered_statuses.append(ExporterStatus.from_proto(request.status))
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=fail_twice_then_succeed)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), \
+                patch("anyio.sleep") as mock_sleep:
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Status was delivered on the third attempt
+        assert ExporterStatus.AVAILABLE in delivered_statuses
+        assert call_count == 3
+
+        # Verify exponential backoff for the 2 retries before success
+        backoff_values = [call.args[0] for call in mock_sleep.call_args_list]
+        assert backoff_values == [1.0, 2.0], f"Expected [1.0, 2.0], got: {backoff_values}"
+
+    async def test_report_status_does_not_retry_non_transient_grpc_error(self):
+        """Non-transient gRPC errors (PERMISSION_DENIED, INVALID_ARGUMENT, etc.)
+        are not retried — fail fast."""
+        exporter = _make_exporter_for_report_status()
+
+        permission_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.PERMISSION_DENIED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Permission denied",
+        )
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=permission_error)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Called exactly once (no retry)
+        assert mock_controller.ReportStatus.call_count == 1
+
+    async def test_report_status_does_not_retry_non_grpc_exception(self):
+        """Non-gRPC exceptions (ConnectionError, etc.) are not retried."""
+        exporter = _make_exporter_for_report_status()
+
+        connection_error = ConnectionError("Network unreachable")
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=connection_error)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Called exactly once (no retry)
+        assert mock_controller.ReportStatus.call_count == 1
+
+    async def test_request_lease_release_retries_on_transient_failure(self):
+        """_request_lease_release also uses retry logic via _send_report_status_rpc."""
+        exporter = _make_exporter_for_report_status()
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        unavailable_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Service unavailable",
+        )
+
+        delivered = []
+        call_count = 0
+
+        async def fail_once_then_succeed(request):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise unavailable_error
+            # Second attempt succeeds
+            delivered.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=fail_once_then_succeed)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
+            await exporter._request_lease_release()
+
+        # Status was delivered on the second attempt
+        assert len(delivered) == 1
+        assert delivered[0].release_lease is True
+        assert call_count == 2
 
 
 class TestHandleLeaseStaleSkip:

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -567,7 +567,7 @@ class TestReportStatusGrpcErrorHandling:
 
         # Eventually logs ERROR after exhausting retries
         error_msgs = [r for r in caplog.records if r.levelno == logging.ERROR]
-        assert any("Failed to update status" in r.message for r in error_msgs), (
+        assert any("Failed to report status" in r.message for r in error_msgs), (
             f"Expected error about failed status update, got: {[r.message for r in caplog.records]}"
         )
         # Ensure no WARNING about "not supported" was logged

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -16,6 +16,12 @@ import pytest
 from anyio import Event, create_task_group
 
 from jumpstarter.common import ExporterStatus
+from jumpstarter.exporter.exporter import (
+    _RPC_BACKOFF_BASE,
+    _RPC_BACKOFF_CAP,
+    _RPC_MAX_RETRIES,
+    _RPC_TIMEOUT,
+)
 from jumpstarter.exporter.lease_context import LeaseContext
 
 pytestmark = pytest.mark.anyio
@@ -553,17 +559,20 @@ class TestReportStatusGrpcErrorHandling:
             with caplog.at_level(logging.DEBUG, logger="jumpstarter.exporter.exporter"):
                 await exporter._report_status(ExporterStatus.AVAILABLE, "test")
 
-        # Should log retry warnings (3 retries)
+        # Should log retry warnings (_RPC_MAX_RETRIES)
         warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
         retry_warnings = [r for r in warning_msgs if "Transient error" in r.message]
-        assert len(retry_warnings) == 3, f"Expected 3 retry warnings, got: {len(retry_warnings)}"
+        assert len(retry_warnings) == _RPC_MAX_RETRIES, (
+            f"Expected {_RPC_MAX_RETRIES} retry warnings, got: {len(retry_warnings)}"
+        )
 
-        # Verify exponential backoff schedule
+        # Verify exponential backoff with cap at _RPC_BACKOFF_CAP
         backoff_values = [call.args[0] for call in mock_sleep.call_args_list]
-        assert backoff_values == [1.0, 2.0, 4.0], f"Expected [1.0, 2.0, 4.0], got: {backoff_values}"
+        expected_backoffs = [min(_RPC_BACKOFF_BASE * (2**i), _RPC_BACKOFF_CAP) for i in range(_RPC_MAX_RETRIES)]
+        assert backoff_values == expected_backoffs, f"Expected {expected_backoffs}, got: {backoff_values}"
 
-        # 4 total attempts: 1 initial + 3 retries
-        assert mock_controller.ReportStatus.call_count == 4
+        # _RPC_MAX_RETRIES + 1 total attempts
+        assert mock_controller.ReportStatus.call_count == _RPC_MAX_RETRIES + 1
 
         # Eventually logs ERROR after exhausting retries
         error_msgs = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -575,26 +584,30 @@ class TestReportStatusGrpcErrorHandling:
             "UNAVAILABLE error should not produce 'not supported' warning"
         )
 
-    async def test_report_status_retries_on_transient_failure(self):
+    @pytest.mark.parametrize("error_code", [
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+    ])
+    async def test_report_status_retries_on_transient_failure(self, error_code):
         """Transient gRPC errors (UNAVAILABLE, DEADLINE_EXCEEDED) are retried.
         If the error resolves before exhausting retries, the status is delivered."""
         exporter = _make_exporter_for_report_status()
 
-        unavailable_error = grpc.aio.AioRpcError(
-            code=grpc.StatusCode.UNAVAILABLE,
+        transient_error = grpc.aio.AioRpcError(
+            code=error_code,
             initial_metadata=grpc.aio.Metadata(),
             trailing_metadata=grpc.aio.Metadata(),
-            details="Service unavailable",
+            details=f"{error_code.name} error",
         )
 
         delivered_statuses = []
         call_count = 0
 
-        async def fail_twice_then_succeed(request):
+        async def fail_twice_then_succeed(request, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count <= 2:
-                raise unavailable_error
+                raise transient_error
             # Third attempt succeeds
             delivered_statuses.append(ExporterStatus.from_proto(request.status))
 
@@ -644,6 +657,55 @@ class TestReportStatusGrpcErrorHandling:
         # Called exactly once (no retry)
         assert mock_controller.ReportStatus.call_count == 1
 
+    async def test_rpc_timeout_parameter_passed(self):
+        """Verify that timeout=_RPC_TIMEOUT is passed to gRPC calls."""
+        exporter = _make_exporter_for_report_status()
+
+        captured_calls = []
+
+        async def capture_call(*args, **kwargs):
+            captured_calls.append(kwargs)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_call)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Verify timeout parameter was passed
+        assert len(captured_calls) == 1
+        assert "timeout" in captured_calls[0]
+        assert captured_calls[0]["timeout"] == _RPC_TIMEOUT
+
+    async def test_report_status_non_blocking_during_serve(self):
+        """Verify _report_status returns immediately when drain is active (serve running)."""
+        exporter = _make_exporter_for_report_status()
+
+        # Simulate serve() drain active
+        exporter._status_drain_active = True
+        exporter._status_rpc_event = Event()
+        exporter._pending_status_request = None
+
+        # Call _report_status — should return immediately without awaiting RPC
+        await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Verify it enqueued the request
+        assert exporter._pending_status_request is not None
+        assert exporter._pending_status_request.message == "test"
+        assert exporter._status_rpc_event.is_set()
+
+        # Now verify latest-wins: call again with different status
+        exporter._status_rpc_event = Event()  # Reset
+        await exporter._report_status(ExporterStatus.LEASE_READY, "ready")
+
+        # The pending request should be replaced
+        assert exporter._pending_status_request.message == "ready"
+        assert ExporterStatus.from_proto(exporter._pending_status_request.status) == ExporterStatus.LEASE_READY
+
     async def test_request_lease_release_succeeds_on_first_attempt(self):
         """When ReleaseLease succeeds immediately, send AVAILABLE and exit."""
         exporter = _make_exporter_for_report_status()
@@ -659,10 +721,10 @@ class TestReportStatusGrpcErrorHandling:
         release_calls = []
         report_calls = []
 
-        async def capture_release(request):
+        async def capture_release(request, **kwargs):
             release_calls.append(request)
 
-        async def capture_report(request):
+        async def capture_report(request, **kwargs):
             report_calls.append(request)
 
         mock_controller = AsyncMock()
@@ -711,14 +773,14 @@ class TestReportStatusGrpcErrorHandling:
         report_calls = []
         release_call_count = 0
 
-        async def fail_first_then_succeed(request):
+        async def fail_first_then_succeed(request, **kwargs):
             nonlocal release_call_count
             release_call_count += 1
             if release_call_count == 1:
                 raise unavailable_error
             release_calls.append(request)
 
-        async def capture_report(request):
+        async def capture_report(request, **kwargs):
             report_calls.append(request)
 
         mock_controller = AsyncMock()
@@ -764,12 +826,12 @@ class TestReportStatusGrpcErrorHandling:
         release_call_count = 0
         report_call_count = 0
 
-        async def always_fail_release(request):
+        async def always_fail_release(request, **kwargs):
             nonlocal release_call_count
             release_call_count += 1
             raise unavailable_error
 
-        async def always_fail_report(request):
+        async def always_fail_report(request, **kwargs):
             nonlocal report_call_count
             report_call_count += 1
             raise unavailable_error
@@ -785,11 +847,11 @@ class TestReportStatusGrpcErrorHandling:
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
             await exporter._request_lease_release()
 
-        # ReleaseLease: 4 attempts (all fail)
-        assert release_call_count == 4
+        # ReleaseLease: _RPC_MAX_RETRIES + 1 attempts (all fail)
+        assert release_call_count == _RPC_MAX_RETRIES + 1
 
-        # ReportStatus: 4 attempts via _send_report_status_rpc (all fail)
-        assert report_call_count == 4
+        # ReportStatus: _RPC_MAX_RETRIES + 1 attempts via _send_report_status_rpc (all fail)
+        assert report_call_count == _RPC_MAX_RETRIES + 1
 
         # Critical: lease_ended must be set even when everything fails,
         # otherwise handle_lease never exits
@@ -817,10 +879,10 @@ class TestReportStatusGrpcErrorHandling:
 
         report_calls = []
 
-        async def fail_with_permission(request):
+        async def fail_with_permission(request, **kwargs):
             raise permission_error
 
-        async def capture_report(request):
+        async def capture_report(request, **kwargs):
             report_calls.append(request)
 
         mock_controller = AsyncMock()
@@ -864,7 +926,7 @@ class TestReportStatusGrpcErrorHandling:
 
         report_calls = []
 
-        async def capture_report(request):
+        async def capture_report(request, **kwargs):
             report_calls.append(request)
 
         mock_controller = AsyncMock()
@@ -901,7 +963,7 @@ class TestReportStatusGrpcErrorHandling:
 
         report_calls = []
 
-        async def capture_report(request):
+        async def capture_report(request, **kwargs):
             report_calls.append(request)
 
         mock_controller = AsyncMock()
@@ -944,10 +1006,10 @@ class TestReportStatusGrpcErrorHandling:
 
         report_calls = []
 
-        async def fail_with_unimplemented(request):
+        async def fail_with_unimplemented(request, **kwargs):
             raise unimplemented_error
 
-        async def capture_report(request):
+        async def capture_report(request, **kwargs):
             report_calls.append(request)
 
         mock_controller = AsyncMock()
@@ -1074,6 +1136,9 @@ def _make_serve_exporter(exit_on_lease_end=False):
     exporter.labels = {"jumpstarter.dev/name": "test-exporter"}
     exporter._report_status = AsyncMock()
     exporter._request_lease_release = AsyncMock()
+    exporter._status_drain_active = False
+    exporter._pending_status_request = None
+    exporter._status_rpc_event = Event()
 
     @asynccontextmanager
     async def fake_session():
@@ -1084,11 +1149,16 @@ def _make_serve_exporter(exit_on_lease_end=False):
 
 
 def _wire_status_stream(exporter, statuses):
-    """Replace _retry_stream with a function that feeds statuses into tx."""
+    """Replace _retry_stream with a function that feeds statuses into tx.
+
+    The stream sends the provided statuses then waits indefinitely (until cancelled),
+    matching production behavior where status streams are long-lived.
+    """
     async def fake_retry_stream(name, factory, tx, **kwargs):
         for s in statuses:
             await tx.send(s)
-        await tx.aclose()
+        # Don't close - wait until task group cancels us (matches production)
+        await anyio.sleep_forever()
 
     exporter._retry_stream = fake_retry_stream
 
@@ -1125,9 +1195,14 @@ class TestExitOnLeaseEnd:
             MagicMock(leased=False, lease_name="", client_name=""),
         ])
 
-        await exporter.serve()
-
-        assert exporter._stop_requested is False
+        async with create_task_group() as tg:
+            tg.start_soon(exporter.serve)
+            # Give serve time to process the status
+            await anyio.sleep(0.1)
+            # Check that _stop_requested was NOT set
+            assert exporter._stop_requested is False
+            # Clean exit
+            tg.cancel_scope.cancel()
 
     async def test_serve_continues_when_disabled(self):
         """serve() does NOT set _stop_requested after lease ends when
@@ -1139,9 +1214,14 @@ class TestExitOnLeaseEnd:
         ])
         _wire_handle_lease(exporter)
 
-        await exporter.serve()
-
-        assert exporter._stop_requested is False
+        async with create_task_group() as tg:
+            tg.start_soon(exporter.serve)
+            # Give serve time to process both statuses
+            await anyio.sleep(0.2)
+            # Check that _stop_requested was NOT set (exit_on_lease_end is False)
+            assert exporter._stop_requested is False
+            # Clean exit
+            tg.cancel_scope.cancel()
 
 
 class TestContextPropagation:

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -439,6 +439,7 @@ def _make_exporter_for_report_status():
     exporter._exporter_status = ExporterStatus.AVAILABLE
     exporter._lease_context = None
     exporter._standalone = False
+    exporter._release_lease_unsupported = False
     return exporter
 
 
@@ -643,10 +644,54 @@ class TestReportStatusGrpcErrorHandling:
         # Called exactly once (no retry)
         assert mock_controller.ReportStatus.call_count == 1
 
-    async def test_request_lease_release_retries_on_transient_failure(self):
-        """When release_lease=true fails, _request_lease_release falls back to
-        retrying just the AVAILABLE status via _report_status."""
+    async def test_request_lease_release_succeeds_on_first_attempt(self):
+        """When ReleaseLease succeeds immediately, send AVAILABLE and exit."""
         exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        release_calls = []
+        report_calls = []
+
+        async def capture_release(request):
+            release_calls.append(request)
+
+        async def capture_report(request):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=capture_release)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # ReleaseLease called once with correct lease name
+        assert len(release_calls) == 1
+        assert release_calls[0].name == "test-lease"
+
+        # ReportStatus called once (AVAILABLE only, no release_lease)
+        assert len(report_calls) == 1
+        assert report_calls[0].release_lease is False
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AVAILABLE
+
+        # Lease ended event set
+        assert lease_ctx.lease_ended.is_set()
+
+    async def test_request_lease_release_retries_on_transient_failure(self):
+        """When ReleaseLease fails with UNAVAILABLE on first attempt, retry and succeed."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
 
         lease_ctx = LeaseContext(
             lease_name="test-lease",
@@ -662,34 +707,45 @@ class TestReportStatusGrpcErrorHandling:
             details="Service unavailable",
         )
 
-        delivered = []
-        call_count = 0
+        release_calls = []
+        report_calls = []
+        release_call_count = 0
 
         async def fail_first_then_succeed(request):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                # First attempt (release_lease=true) fails
-                assert request.release_lease is True
+            nonlocal release_call_count
+            release_call_count += 1
+            if release_call_count == 1:
                 raise unavailable_error
-            # Second attempt (fallback via _report_status) succeeds
-            delivered.append(request)
+            release_calls.append(request)
 
-        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=fail_first_then_succeed)
+        async def capture_report(request):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=fail_first_then_succeed)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
             await exporter._request_lease_release()
 
-        # First call with release_lease=true failed, second call (via _report_status) succeeded
-        assert len(delivered) == 1
-        assert delivered[0].release_lease is False  # Fallback sends status-only
-        assert ExporterStatus.from_proto(delivered[0].status) == ExporterStatus.AVAILABLE
-        assert call_count == 2
+        # ReleaseLease called twice (failed once, succeeded on retry)
+        assert release_call_count == 2
+        assert len(release_calls) == 1
+        assert release_calls[0].name == "test-lease"
+
+        # ReportStatus called once (AVAILABLE)
+        assert len(report_calls) == 1
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AVAILABLE
 
     async def test_request_lease_release_exhausts_retries(self):
-        """When both Phase 1 and Phase 2 fail completely, lease_ended is still set
+        """When ReleaseLease and AVAILABLE status both fail, lease_ended is still set
         so handle_lease can exit (prevents being stuck forever)."""
         exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
 
         lease_ctx = LeaseContext(
             lease_name="test-lease",
@@ -705,30 +761,45 @@ class TestReportStatusGrpcErrorHandling:
             details="Service unavailable",
         )
 
-        call_count = 0
+        release_call_count = 0
+        report_call_count = 0
 
-        async def always_fail(request):
-            nonlocal call_count
-            call_count += 1
+        async def always_fail_release(request):
+            nonlocal release_call_count
+            release_call_count += 1
             raise unavailable_error
 
-        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=always_fail)
+        async def always_fail_report(request):
+            nonlocal report_call_count
+            report_call_count += 1
+            raise unavailable_error
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=always_fail_release)
+        mock_controller.ReportStatus = AsyncMock(side_effect=always_fail_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
             await exporter._request_lease_release()
 
-        # Phase 1: 1 attempt (release_lease=true fails)
-        # Phase 2: 4 attempts via _send_report_status_rpc (all fail)
-        # Total: 5 calls
-        assert call_count == 5
+        # ReleaseLease: 4 attempts (all fail)
+        assert release_call_count == 4
+
+        # ReportStatus: 4 attempts via _send_report_status_rpc (all fail)
+        assert report_call_count == 4
 
         # Critical: lease_ended must be set even when everything fails,
         # otherwise handle_lease never exits
         assert lease_ctx.lease_ended.is_set()
 
-    async def test_request_lease_release_succeeds_on_first_attempt(self):
-        """When release_lease=true succeeds immediately, no fallback to _report_status."""
+    async def test_request_lease_release_falls_back_on_unsupported(self):
+        """When ReleaseLease fails with PERMISSION_DENIED, fall back to compat path."""
         exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+        exporter._exporter_status = ExporterStatus.AVAILABLE
 
         lease_ctx = LeaseContext(
             lease_name="test-lease",
@@ -737,25 +808,125 @@ class TestReportStatusGrpcErrorHandling:
         )
         exporter._lease_context = lease_ctx
 
-        delivered = []
+        permission_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.PERMISSION_DENIED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Exporter auth not supported",
+        )
 
-        async def succeed_immediately(request):
-            delivered.append(request)
+        report_calls = []
 
-        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=succeed_immediately)
+        async def fail_with_permission(request):
+            raise permission_error
+
+        async def capture_report(request):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=fail_with_permission)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             await exporter._request_lease_release()
 
-        # Only one call made (release_lease=true succeeded)
-        assert len(delivered) == 1
-        assert delivered[0].release_lease is True
-        assert ExporterStatus.from_proto(delivered[0].status) == ExporterStatus.AVAILABLE
+        # ReleaseLease called once, failed with PERMISSION_DENIED
+        assert mock_controller.ReleaseLease.call_count == 1
 
-    async def test_request_lease_release_unimplemented_no_fallback(self):
-        """When controller returns UNIMPLEMENTED, no fallback to _report_status
-        (controller doesn't support status reporting at all)."""
+        # Fallback: ReportStatus called twice
+        # First call: release_lease=true with AFTER_LEASE_HOOK (AVAILABLE reverted)
+        # Second call: AVAILABLE
+        assert len(report_calls) == 2
+        assert report_calls[0].release_lease is True
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AFTER_LEASE_HOOK
+        assert report_calls[1].release_lease is False
+        assert ExporterStatus.from_proto(report_calls[1].status) == ExporterStatus.AVAILABLE
+
+        # _release_lease_unsupported should be cached
+        assert exporter._release_lease_unsupported is True
+
+    async def test_request_lease_release_skips_release_lease_when_cached_unsupported(self):
+        """When _release_lease_unsupported is True, skip ReleaseLease entirely."""
         exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = True  # Cached from prior attempt
+        exporter._exporter_status = ExporterStatus.AVAILABLE
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        report_calls = []
+
+        async def capture_report(request):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock()  # Should never be called
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # ReleaseLease NOT called (cached as unsupported)
+        assert mock_controller.ReleaseLease.call_count == 0
+
+        # Went straight to fallback path
+        assert len(report_calls) == 2
+        assert report_calls[0].release_lease is True
+        assert report_calls[1].release_lease is False
+
+    async def test_request_lease_release_preserves_failure_status_in_fallback(self):
+        """When falling back with a failure status, preserve it (don't revert to AFTER_LEASE_HOOK)."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = True
+        exporter._exporter_status = ExporterStatus.AFTER_LEASE_HOOK_FAILED  # Failure status
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        report_calls = []
+
+        async def capture_report(request):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # First call: release_lease=true with AFTER_LEASE_HOOK_FAILED (preserved, not reverted)
+        assert report_calls[0].release_lease is True
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AFTER_LEASE_HOOK_FAILED
+
+        # Second call: AVAILABLE
+        assert report_calls[1].release_lease is False
+        assert ExporterStatus.from_proto(report_calls[1].status) == ExporterStatus.AVAILABLE
+
+    async def test_request_lease_release_unimplemented(self):
+        """When ReleaseLease returns UNIMPLEMENTED, treat as unsupported and fall back."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+        exporter._exporter_status = ExporterStatus.AVAILABLE
 
         lease_ctx = LeaseContext(
             lease_name="test-lease",
@@ -770,13 +941,35 @@ class TestReportStatusGrpcErrorHandling:
             trailing_metadata=grpc.aio.Metadata(),
             details="Method not implemented",
         )
-        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=unimplemented_error)
+
+        report_calls = []
+
+        async def fail_with_unimplemented(request):
+            raise unimplemented_error
+
+        async def capture_report(request):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=fail_with_unimplemented)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             await exporter._request_lease_release()
 
-        # Called exactly once (UNIMPLEMENTED means no fallback)
-        assert mock_controller.ReportStatus.call_count == 1
+        # ReleaseLease called once (UNIMPLEMENTED)
+        assert mock_controller.ReleaseLease.call_count == 1
+
+        # Falls back to compat path
+        assert len(report_calls) == 2
+        assert report_calls[0].release_lease is True
+
+        # Cached as unsupported
+        assert exporter._release_lease_unsupported is True
 
 
 class TestHandleLeaseStaleSkip:


### PR DESCRIPTION
## Summary

Fixes #890, closes #912.

Adds retry logic with exponential backoff for transient gRPC failures in exporter status reporting and lease release, with per-RPC deadlines to prevent hanging. Ensures exporters recover from controller outages instead of becoming permanently stuck.

## Problem

When the afterLease hook completes, the exporter calls `_report_status(AVAILABLE)` to tell the controller it's ready for new leases. If that gRPC call fails transiently (network blip, controller momentarily unreachable), the error is silently swallowed. The controller permanently sees `AFTER_LEASE_HOOK`, and the exporter is never assigned new leases — even though it locally believes it's `AVAILABLE`. Only a pod restart recovers.

Additionally, `_request_lease_release` had no retry logic and no per-RPC deadline, so a single transient failure or TCP hang could permanently block lease cleanup.

## Solution

### Shared retry helper (`_retry_rpc`)

Extracted a reusable retry helper used by both `ReportStatus` and `ReleaseLease` RPCs:

- **Max retries:** 20 (~18 min worst case: 21 attempts × 30s timeout + backoff sum ~8 min)
- **Backoff:** Exponential with cap — 1s, 2s, 4s, ..., 30s, 30s, ...
- **Per-RPC timeout:** 30s deadline on each gRPC call (prevents hanging on TCP/keepalive timeout)
- **Retryable:** `UNAVAILABLE`, `DEADLINE_EXCEEDED`
- **Non-retryable:** Configurable per call site (e.g., `UNIMPLEMENTED` for ReportStatus)

The extended retry window is safe because the exporter has nothing useful to do while the controller is unreachable — even a restart just fails at `_register_with_controller` (no retry there).

### Non-blocking status reports during `serve()`

`_report_status` was fire-and-forget before this PR. Adding retry made it blocking, which could stall critical paths like LEASE_READY updates that gate client connections. Fixed with a background drain task using "latest wins" semantics: `_report_status` enqueues the update and returns immediately; the drain task sends the most recent status with full retry.

### ReleaseLease RPC with exporter auth

Added exporter authentication support to the `ReleaseLease` RPC (Go controller), using metadata-based routing (`jumpstarter-kind: Exporter`) instead of try-both-auth. The Python exporter uses `ReleaseLease` with backward-compat fallback to `ReportStatus(release_lease=true)` for older controllers.

Controller-side error codes use `FailedPrecondition`/`NotFound`/`Internal` (not `PermissionDenied`, which would wrongly trigger the UNSUPPORTED fallback path).

## Testing

- 13 new Python tests covering retry, timeout, backoff cap, non-blocking drain, lease release (success, retry, exhaustion, fallback, compat)
- 7 new Go integration tests for `handleExporterLeaseRelease` and `releaseLeaseAsExporter`
- Go auth package at 100% coverage
- All 637 Python tests pass, all Go tests pass
- No lint or type errors

## Test plan

- [x] Unit tests pass (`make -C python pkg-test-jumpstarter`)
- [x] Go tests pass (`make -C controller test`)
- [x] Lint clean (`make -C python lint-fix`)
- [x] Type check clean (`make -C python pkg-ty-jumpstarter`)