### PR TITLE
feat: exporterSet implement core scaling engine (JEP-0014)

### DIFF
--- a/controller/cmd/exporter-set-controller/main.go
+++ b/controller/cmd/exporter-set-controller/main.go
@@ -20,8 +20,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -109,10 +111,11 @@ func main() {
 	}
 
 	if err = (&exporterset.ExporterSetReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor("exporter-set-controller"),
-		Provisioner: prov,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		Recorder:            mgr.GetEventRecorderFor("exporter-set-controller"),
+		Provisioner:         prov,
+		LastScaleDownAction: make(map[types.NamespacedName]time.Time),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ExporterSet")
 		os.Exit(1)

--- a/controller/internal/exporterset/exporterset_controller_test.go
+++ b/controller/internal/exporterset/exporterset_controller_test.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2026 The Jumpstarter Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exporterset
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
+	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter/controller/internal/exporterset/provisioners/qemu"
+)
+
+var _ = Describe("ExporterSet Controller", func() {
+	const (
+		timeout  = 10 * time.Second
+		interval = 250 * time.Millisecond
+	)
+
+	var (
+		reconciler *ExporterSetReconciler
+		vtc        *virtualtargetv1alpha1.VirtualTargetClass
+		ns         string
+	)
+
+	BeforeEach(func() {
+		ns = "default"
+
+		reconciler = &ExporterSetReconciler{
+			Client:      envTestClient,
+			Scheme:      envTestClient.Scheme(),
+			Provisioner: qemu.New(),
+		}
+
+		vtc = &virtualtargetv1alpha1.VirtualTargetClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "qemu-class",
+				Namespace: ns,
+			},
+			Spec: virtualtargetv1alpha1.VirtualTargetClassSpec{
+				Provisioner: qemu.ProvisionerName,
+			},
+		}
+		Expect(envTestClient.Create(envTestCtx, vtc)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(envTestClient.Delete(envTestCtx, vtc)).To(Succeed())
+	})
+
+	Context("When creating an ExporterSet with minReplicas", func() {
+		It("should create the correct number of Exporters and Pods", func() {
+			es := &virtualtargetv1alpha1.ExporterSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scale-up",
+					Namespace: ns,
+				},
+				Spec: virtualtargetv1alpha1.ExporterSetSpec{
+					MinReplicas:            2,
+					MaxReplicas:            5,
+					MinAvailableReplicas:   1,
+					VirtualTargetClassName: "qemu-class",
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"exporterset": "test-scale-up"},
+					},
+					Template: virtualtargetv1alpha1.ExporterSetTemplate{
+						Metadata: virtualtargetv1alpha1.EmbeddedObjectMeta{
+							Labels: map[string]string{"exporterset": "test-scale-up"},
+						},
+					},
+				},
+			}
+			Expect(envTestClient.Create(envTestCtx, es)).To(Succeed())
+
+			defer func() {
+				Expect(envTestClient.Delete(envTestCtx, es)).To(Succeed())
+			}()
+
+			By("Reconciling the ExporterSet — one Exporter per reconcile, minReplicas=2 needs two calls")
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: es.Name, Namespace: ns}}
+			for range 2 {
+				_, err := reconciler.Reconcile(envTestCtx, req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Verifying Exporters were created")
+			var exporterList jumpstarterdevv1alpha1.ExporterList
+			Eventually(func() int {
+				err := envTestClient.List(envTestCtx, &exporterList,
+					client.InNamespace(ns),
+					client.MatchingLabels{"exporterset": "test-scale-up"},
+				)
+				if err != nil {
+					return 0
+				}
+				return len(exporterList.Items)
+			}, timeout, interval).Should(Equal(2))
+
+			By("Verifying ownership chain: Exporter owned by ExporterSet")
+			for _, exp := range exporterList.Items {
+				ownerFound := false
+				for _, ref := range exp.OwnerReferences {
+					if ref.Kind == "ExporterSet" && ref.Name == es.Name &&
+						ref.Controller != nil && *ref.Controller {
+						ownerFound = true
+					}
+				}
+				Expect(ownerFound).To(BeTrue(),
+					"Exporter %s should be controller-owned by ExporterSet", exp.Name)
+			}
+
+			By("Verifying Pods were created with correct ownership")
+			var podList corev1.PodList
+			Eventually(func() int {
+				err := envTestClient.List(envTestCtx, &podList,
+					client.InNamespace(ns),
+					client.MatchingLabels{labelExporterSetName: "test-scale-up"},
+				)
+				if err != nil {
+					return 0
+				}
+				return len(podList.Items)
+			}, timeout, interval).Should(Equal(2))
+
+			By("Verifying ownership chain: Pod owned by Exporter (not ExporterSet)")
+			exporterUIDs := make(map[types.UID]bool)
+			for _, exp := range exporterList.Items {
+				exporterUIDs[exp.UID] = true
+			}
+
+			for _, pod := range podList.Items {
+				ownedByExporter := false
+				ownedByES := false
+				for _, ref := range pod.OwnerReferences {
+					if ref.Kind == "Exporter" && ref.Controller != nil && *ref.Controller {
+						Expect(exporterUIDs).To(HaveKey(ref.UID))
+						ownedByExporter = true
+					}
+					if ref.Kind == "ExporterSet" {
+						ownedByES = true
+					}
+				}
+				Expect(ownedByExporter).To(BeTrue(),
+					"Pod %s should be controller-owned by an Exporter", pod.Name)
+				Expect(ownedByES).To(BeFalse(),
+					"Pod %s should NOT be directly owned by ExporterSet", pod.Name)
+			}
+
+			By("Verifying Pod labels include ExporterSet name for watch mapping")
+			for _, pod := range podList.Items {
+				Expect(pod.Labels[labelExporterSetName]).To(Equal("test-scale-up"))
+			}
+		})
+	})
+
+	Context("When an ExporterSet has excess idle replicas", func() {
+		It("should disable one exporter after cooldown and delete it on next reconcile", func() {
+			cooldown := 1 * time.Second
+			es := &virtualtargetv1alpha1.ExporterSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scale-down",
+					Namespace: ns,
+				},
+				Spec: virtualtargetv1alpha1.ExporterSetSpec{
+					MinReplicas:            1,
+					MaxReplicas:            10,
+					MinAvailableReplicas:   1,
+					ScaleDownCooldown:      &metav1.Duration{Duration: cooldown},
+					VirtualTargetClassName: "qemu-class",
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"exporterset": "test-scale-down"},
+					},
+					Template: virtualtargetv1alpha1.ExporterSetTemplate{
+						Metadata: virtualtargetv1alpha1.EmbeddedObjectMeta{
+							Labels: map[string]string{"exporterset": "test-scale-down"},
+						},
+					},
+				},
+			}
+			Expect(envTestClient.Create(envTestCtx, es)).To(Succeed())
+
+			defer func() {
+				_ = envTestClient.Delete(envTestCtx, es)
+			}()
+
+			By("Creating 3 exporters (surplus of 1 over minAvailableReplicas)")
+			for _, name := range []string{"sd-1", "sd-2", "sd-3"} {
+				exp := &jumpstarterdevv1alpha1.Exporter{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: ns,
+						Labels:    map[string]string{"exporterset": "test-scale-down"},
+					},
+					Spec: jumpstarterdevv1alpha1.ExporterSpec{
+						Enabled: boolPtr(true),
+					},
+				}
+				Expect(envTestClient.Create(envTestCtx, exp)).To(Succeed())
+
+				// Set ownership to ExporterSet
+				exp.OwnerReferences = []metav1.OwnerReference{{
+					APIVersion: "virtualtarget.jumpstarter.dev/v1alpha1",
+					Kind:       "ExporterSet",
+					Name:       es.Name,
+					UID:        es.UID,
+					Controller: boolPtr(true),
+				}}
+				Expect(envTestClient.Update(envTestCtx, exp)).To(Succeed())
+
+				// Set Online condition
+				exp.Status.Conditions = []metav1.Condition{{
+					Type:               string(jumpstarterdevv1alpha1.ExporterConditionTypeOnline),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Online",
+				}}
+				Expect(envTestClient.Status().Update(envTestCtx, exp)).To(Succeed())
+			}
+
+			By("First reconcile: sets surplus annotation and requeues")
+			result, err := reconciler.Reconcile(envTestCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: es.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			By("Waiting for cooldown to elapse")
+			time.Sleep(cooldown + 500*time.Millisecond)
+
+			By("Second reconcile: disables one exporter")
+			result, err = reconciler.Reconcile(envTestCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: es.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// Controller disables one exporter and returns RequeueAfter: cooldown.
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			By("Verifying one exporter is disabled")
+			var exporterList jumpstarterdevv1alpha1.ExporterList
+			Expect(envTestClient.List(envTestCtx, &exporterList,
+				client.InNamespace(ns),
+				client.MatchingLabels{"exporterset": "test-scale-down"},
+			)).To(Succeed())
+
+			disabledCount := 0
+			for _, exp := range exporterList.Items {
+				if !exp.IsEnabled() {
+					disabledCount++
+				}
+			}
+			Expect(disabledCount).To(Equal(1))
+
+			By("Third reconcile: deletes the disabled, unleased exporter")
+			result, err = reconciler.Reconcile(envTestCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: es.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(envTestClient.List(envTestCtx, &exporterList,
+				client.InNamespace(ns),
+				client.MatchingLabels{"exporterset": "test-scale-down"},
+			)).To(Succeed())
+			Expect(exporterList.Items).To(HaveLen(2))
+
+			for _, exp := range exporterList.Items {
+				Expect(exp.IsEnabled()).To(BeTrue(),
+					"remaining exporters should all be enabled")
+			}
+		})
+	})
+
+	Context("When reconciling is idempotent", func() {
+		It("should not create extra resources on repeated reconciles", func() {
+			es := &virtualtargetv1alpha1.ExporterSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-idempotent",
+					Namespace: ns,
+				},
+				Spec: virtualtargetv1alpha1.ExporterSetSpec{
+					MinReplicas:            2,
+					MaxReplicas:            5,
+					MinAvailableReplicas:   1,
+					VirtualTargetClassName: "qemu-class",
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"exporterset": "test-idempotent"},
+					},
+					Template: virtualtargetv1alpha1.ExporterSetTemplate{
+						Metadata: virtualtargetv1alpha1.EmbeddedObjectMeta{
+							Labels: map[string]string{"exporterset": "test-idempotent"},
+						},
+					},
+				},
+			}
+			Expect(envTestClient.Create(envTestCtx, es)).To(Succeed())
+
+			defer func() {
+				Expect(envTestClient.Delete(envTestCtx, es)).To(Succeed())
+			}()
+
+			By("First two reconciles: each creates 1 Exporter (one-per-reconcile policy)")
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: es.Name, Namespace: ns}}
+			for range 2 {
+				_, err := reconciler.Reconcile(envTestCtx, req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			var exporterList jumpstarterdevv1alpha1.ExporterList
+			Expect(envTestClient.List(envTestCtx, &exporterList,
+				client.InNamespace(ns),
+				client.MatchingLabels{"exporterset": "test-idempotent"},
+			)).To(Succeed())
+			firstCount := len(exporterList.Items)
+			Expect(firstCount).To(Equal(2))
+
+			By("Simulating exporters coming online")
+			for i := range exporterList.Items {
+				exp := &exporterList.Items[i]
+				exp.Status.Conditions = []metav1.Condition{{
+					Type:               string(jumpstarterdevv1alpha1.ExporterConditionTypeOnline),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Online",
+				}}
+				Expect(envTestClient.Status().Update(envTestCtx, exp)).To(Succeed())
+			}
+
+			By("Third reconcile: no additional resources")
+			_, err := reconciler.Reconcile(envTestCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: es.Name, Namespace: ns},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(envTestClient.List(envTestCtx, &exporterList,
+				client.InNamespace(ns),
+				client.MatchingLabels{"exporterset": "test-idempotent"},
+			)).To(Succeed())
+			Expect(exporterList.Items).To(HaveLen(firstCount))
+		})
+	})
+})

--- a/controller/internal/exporterset/reconciler.go
+++ b/controller/internal/exporterset/reconciler.go
@@ -40,13 +40,13 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -126,10 +126,22 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			logger.Info("VirtualTargetClass not found",
 				"virtualTargetClassName", exporterSet.Spec.VirtualTargetClassName)
 
-			prevAvailable := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionAvailable))
-			prevDegraded := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionDegraded))
-			prevProgressing := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionProgressing))
-			prevScalingLimited := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited))
+			prevAvailable := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+			)
+			prevDegraded := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
+			)
+			prevProgressing := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
+			)
+			prevScalingLimited := meta.IsStatusConditionTrue(
+				exporterSet.Status.Conditions,
+				string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
+			)
 
 			if countErr := r.reconcileStatusCounts(ctx, &exporterSet); countErr != nil {
 				return ctrl.Result{}, countErr
@@ -166,10 +178,22 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	)
 
 	// Snapshot condition state before changes (for event emission).
-	prevAvailable := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionAvailable))
-	prevDegraded := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionDegraded))
-	prevProgressing := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionProgressing))
-	prevScalingLimited := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited))
+	prevAvailable := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+	)
+	prevDegraded := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
+	)
+	prevProgressing := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
+	)
+	prevScalingLimited := meta.IsStatusConditionTrue(
+		exporterSet.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
+	)
 
 	ownedExporters, err := r.listOwnedExporters(ctx, &exporterSet)
 	if err != nil {
@@ -204,45 +228,15 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Scale-up logic. Uses potentiallyAvailable (replicas - leased) to avoid
 	// cache-race over-creation. One exporter per reconcile; Owns watch
 	// triggers subsequent cycles.
-	potentiallyAvailable := state.replicas - state.leased
-	if state.replicas < exporterSet.Spec.MinReplicas && potentiallyAvailable < exporterSet.Spec.MinReplicas {
-		if room := maxScaleUp(&exporterSet, state.replicas); room > 0 {
-			if err := r.scaleUp(ctx, &exporterSet, &vtc, mergedParameters, 1); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-	} else if state.available < exporterSet.Spec.MinAvailableReplicas &&
-		potentiallyAvailable < exporterSet.Spec.MinAvailableReplicas &&
-		!atMaxReplicas(&exporterSet, state.replicas) {
-		if room := maxScaleUp(&exporterSet, state.replicas); room > 0 {
-			if err := r.scaleUp(ctx, &exporterSet, &vtc, mergedParameters, 1); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-	} else if !atMaxReplicas(&exporterSet, state.replicas) {
-		// Demand-driven scale-up for pending leases with no available capacity.
-		pendingLeases, err := r.countPendingLeases(ctx, &exporterSet)
-		if err != nil {
-			logger.Error(err, "failed to count pending leases")
-		} else if pendingLeases > 0 && state.available == 0 {
-			if room := maxScaleUp(&exporterSet, state.replicas); room > 0 {
-				if err := r.scaleUp(ctx, &exporterSet, &vtc, mergedParameters, 1); err != nil {
-					return ctrl.Result{}, err
-				}
-			}
-		} else {
-			scaleDownResult, err := r.reconcileScaleDown(ctx, &exporterSet, ownedExporters, state)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			result = scaleDownResult
-		}
-	} else {
-		scaleDownResult, err := r.reconcileScaleDown(ctx, &exporterSet, ownedExporters, state)
+	scaled, err := r.reconcileScaleUp(ctx, &exporterSet, &vtc, mergedParameters, state)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !scaled {
+		result, err = r.reconcileScaleDown(ctx, &exporterSet, ownedExporters, state)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		result = scaleDownResult
 	}
 
 	// Update status counts, conditions, and emit events.
@@ -340,7 +334,9 @@ func (r *ExporterSetReconciler) scaleUp(
 		}
 
 		if err := r.Create(ctx, pod); err != nil {
-			_ = r.Delete(ctx, exporter) // roll back headless exporter
+			if delErr := r.Delete(ctx, exporter); delErr != nil {
+				logger.Error(delErr, "failed to roll back Exporter after Pod creation failure", "exporter", exporter.Name)
+			}
 			return fmt.Errorf("unable to create Pod for Exporter %s: %w", exporter.Name, err)
 		}
 
@@ -389,6 +385,52 @@ func (r *ExporterSetReconciler) cleanupDisabledExporters(
 	}
 
 	return deleted, nil
+}
+
+// reconcileScaleUp evaluates the three scale-up rules in priority order and
+// creates one Exporter if any rule fires. Returns true if a scale-up was
+// attempted (caller should skip scale-down for this cycle).
+func (r *ExporterSetReconciler) reconcileScaleUp(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+	vtc *virtualtargetv1alpha1.VirtualTargetClass,
+	params map[string]interface{},
+	state poolState,
+) (scaled bool, err error) {
+	logger := log.FromContext(ctx)
+	potentiallyAvailable := state.replicas - state.leased
+
+	// 1. Floor: never drop below minReplicas.
+	if state.replicas < es.Spec.MinReplicas && potentiallyAvailable < es.Spec.MinReplicas {
+		if maxScaleUp(es, state.replicas) > 0 {
+			return true, r.scaleUp(ctx, es, vtc, params, 1)
+		}
+		return false, nil
+	}
+
+	// 2. Warm buffer: keep minAvailableReplicas ready-and-unleased instances.
+	if state.available < es.Spec.MinAvailableReplicas &&
+		potentiallyAvailable < es.Spec.MinAvailableReplicas &&
+		!atMaxReplicas(es, state.replicas) {
+		if maxScaleUp(es, state.replicas) > 0 {
+			return true, r.scaleUp(ctx, es, vtc, params, 1)
+		}
+		return false, nil
+	}
+
+	// 3. Demand: pending Leases exist and no capacity is available.
+	if !atMaxReplicas(es, state.replicas) {
+		pending, err := r.countPendingLeases(ctx, es)
+		if err != nil {
+			logger.Error(err, "failed to count pending leases")
+			return false, nil
+		}
+		if pending > 0 && state.available == 0 && maxScaleUp(es, state.replicas) > 0 {
+			return true, r.scaleUp(ctx, es, vtc, params, 1)
+		}
+	}
+
+	return false, nil
 }
 
 // reconcileScaleDown disables one idle exporter per cooldown period.
@@ -784,10 +826,22 @@ func (r *ExporterSetReconciler) emitConditionEvents(
 		return
 	}
 
-	nowAvailable := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionAvailable))
-	nowProgressing := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionProgressing))
-	nowDegraded := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionDegraded))
-	nowScalingLimited := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited))
+	nowAvailable := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
+	)
+	nowProgressing := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
+	)
+	nowDegraded := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
+	)
+	nowScalingLimited := meta.IsStatusConditionTrue(
+		es.Status.Conditions,
+		string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
+	)
 
 	if !prevAvailable && nowAvailable {
 		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ExporterSetAvailable",

--- a/controller/internal/exporterset/reconciler.go
+++ b/controller/internal/exporterset/reconciler.go
@@ -14,18 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package exporterset implements the ExporterSet controller — the scaling
+// engine for virtual exporter pools (JEP-0014).
+//
+// Scaling rules, evaluated in priority order each reconcile:
+//  1. Floor: replicas < minReplicas → scale up
+//  2. Warm buffer: available < minAvailableReplicas → scale up
+//  3. Demand: pending Leases match our labels, no capacity → scale up
+//  4. Excess: available > min for longer than cooldown → disable one
+//
+// Creates at most 1 exporter per reconcile to avoid cache-race duplicates.
+// Graceful scale-down: disable → drain leases → delete on next cycle.
+//
+// Why not HPA/KEDA: scaling depends on Exporter CRD fields (leaseRef,
+// enabled, online) and Lease state (pending condition) — not expressible
+// as standard metrics. The disable-drain-delete protocol has no HPA analog.
 package exporterset
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
+	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +56,15 @@ import (
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
+)
+
+const (
+	annotationSurplusSince = "exporterset.jumpstarter.dev/surplus-since"
+
+	// Bridges the grandparent lookup (ExporterSet -> Exporter -> Pod).
+	labelExporterSetName = "exporterset.jumpstarter.dev/name"
+
+	defaultScaleDownCooldown = 5 * time.Minute
 )
 
 // ExporterSetReconciler reconciles an ExporterSet object.
@@ -47,6 +77,11 @@ type ExporterSetReconciler struct {
 	Scheme      *runtime.Scheme
 	Recorder    record.EventRecorder
 	Provisioner Provisioner
+
+	lastScaleDownMu sync.Mutex
+	// Guards against disabling multiple exporters within the same cooldown
+	// when the informer cache is stale.
+	LastScaleDownAction map[types.NamespacedName]time.Time
 }
 
 // +kubebuilder:rbac:groups=virtualtarget.jumpstarter.dev,resources=exportersets,verbs=get;list;watch;create;update;patch;delete
@@ -69,12 +104,18 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	var exporterSet virtualtargetv1alpha1.ExporterSet
 	if err := r.Get(ctx, req.NamespacedName, &exporterSet); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(
-			fmt.Errorf("Reconcile: unable to get ExporterSet: %w", err),
-		)
+		if client.IgnoreNotFound(err) == nil {
+			// ExporterSet deleted — clean up in-memory state.
+			r.lastScaleDownMu.Lock()
+			if r.LastScaleDownAction != nil {
+				delete(r.LastScaleDownAction, req.NamespacedName)
+			}
+			r.lastScaleDownMu.Unlock()
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("Reconcile: unable to get ExporterSet: %w", err)
 	}
 
-	// Resolve the VirtualTargetClass
 	var vtc virtualtargetv1alpha1.VirtualTargetClass
 	vtcKey := client.ObjectKey{
 		Namespace: exporterSet.Namespace,
@@ -85,37 +126,22 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			logger.Info("VirtualTargetClass not found",
 				"virtualTargetClassName", exporterSet.Spec.VirtualTargetClassName)
 
-			prevAvailable := meta.IsStatusConditionTrue(
-				exporterSet.Status.Conditions,
-				string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
-			)
-			prevDegraded := meta.IsStatusConditionTrue(
-				exporterSet.Status.Conditions,
-				string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
-			)
-			prevProgressing := meta.IsStatusConditionTrue(
-				exporterSet.Status.Conditions,
-				string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
-			)
-			prevScalingLimited := meta.IsStatusConditionTrue(
-				exporterSet.Status.Conditions,
-				string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
-			)
+			prevAvailable := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionAvailable))
+			prevDegraded := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionDegraded))
+			prevProgressing := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionProgressing))
+			prevScalingLimited := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited))
 
 			if countErr := r.reconcileStatusCounts(ctx, &exporterSet); countErr != nil {
 				return ctrl.Result{}, countErr
 			}
 			r.reconcileConditions(&exporterSet)
-
 			meta.SetStatusCondition(&exporterSet.Status.Conditions, metav1.Condition{
 				Type:               string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
 				Status:             metav1.ConditionFalse,
 				ObservedGeneration: exporterSet.Generation,
 				Reason:             "VirtualTargetClassNotFound",
-				Message: fmt.Sprintf("VirtualTargetClass %q not found",
-					exporterSet.Spec.VirtualTargetClassName),
+				Message:            fmt.Sprintf("VirtualTargetClass %q not found", exporterSet.Spec.VirtualTargetClassName),
 			})
-
 			if updateErr := r.Status().Update(ctx, &exporterSet); updateErr != nil {
 				return requeueConflict(logger, updateErr)
 			}
@@ -139,36 +165,374 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		"minAvailableReplicas", exporterSet.Spec.MinAvailableReplicas,
 	)
 
-	prevAvailable := meta.IsStatusConditionTrue(
-		exporterSet.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
-	)
-	prevDegraded := meta.IsStatusConditionTrue(
-		exporterSet.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
-	)
-	prevProgressing := meta.IsStatusConditionTrue(
-		exporterSet.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
-	)
-	prevScalingLimited := meta.IsStatusConditionTrue(
-		exporterSet.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
-	)
+	// Snapshot condition state before changes (for event emission).
+	prevAvailable := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionAvailable))
+	prevDegraded := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionDegraded))
+	prevProgressing := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionProgressing))
+	prevScalingLimited := meta.IsStatusConditionTrue(exporterSet.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited))
 
-	if err := r.reconcileStatusCounts(ctx, &exporterSet); err != nil {
+	ownedExporters, err := r.listOwnedExporters(ctx, &exporterSet)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	r.reconcileConditions(&exporterSet)
+	// Clean up drained (disabled+unleased) exporters before computing state.
+	if deleted, err := r.cleanupDisabledExporters(ctx, &exporterSet, ownedExporters); err != nil {
+		return ctrl.Result{}, err
+	} else if deleted {
+		// Update status and return; the next scale-down step fires on RequeueAfter.
+		if err := r.reconcileStatusCounts(ctx, &exporterSet); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.reconcileConditions(&exporterSet)
+		if err := r.Status().Update(ctx, &exporterSet); err != nil {
+			return requeueConflict(logger, err)
+		}
+		r.emitConditionEvents(&exporterSet, prevAvailable, prevProgressing, prevDegraded, prevScalingLimited)
+		return ctrl.Result{}, nil
+	}
 
+	state := computePoolState(ownedExporters)
+
+	mergedParameters, err := deepMergeParameters(vtc.Spec.Parameters, exporterSet.Spec.Parameters)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to merge parameters: %w", err)
+	}
+
+	var result ctrl.Result
+
+	// Scale-up logic. Uses potentiallyAvailable (replicas - leased) to avoid
+	// cache-race over-creation. One exporter per reconcile; Owns watch
+	// triggers subsequent cycles.
+	potentiallyAvailable := state.replicas - state.leased
+	if state.replicas < exporterSet.Spec.MinReplicas && potentiallyAvailable < exporterSet.Spec.MinReplicas {
+		if room := maxScaleUp(&exporterSet, state.replicas); room > 0 {
+			if err := r.scaleUp(ctx, &exporterSet, &vtc, mergedParameters, 1); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if state.available < exporterSet.Spec.MinAvailableReplicas &&
+		potentiallyAvailable < exporterSet.Spec.MinAvailableReplicas &&
+		!atMaxReplicas(&exporterSet, state.replicas) {
+		if room := maxScaleUp(&exporterSet, state.replicas); room > 0 {
+			if err := r.scaleUp(ctx, &exporterSet, &vtc, mergedParameters, 1); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if !atMaxReplicas(&exporterSet, state.replicas) {
+		// Demand-driven scale-up for pending leases with no available capacity.
+		pendingLeases, err := r.countPendingLeases(ctx, &exporterSet)
+		if err != nil {
+			logger.Error(err, "failed to count pending leases")
+		} else if pendingLeases > 0 && state.available == 0 {
+			if room := maxScaleUp(&exporterSet, state.replicas); room > 0 {
+				if err := r.scaleUp(ctx, &exporterSet, &vtc, mergedParameters, 1); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+		} else {
+			scaleDownResult, err := r.reconcileScaleDown(ctx, &exporterSet, ownedExporters, state)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			result = scaleDownResult
+		}
+	} else {
+		scaleDownResult, err := r.reconcileScaleDown(ctx, &exporterSet, ownedExporters, state)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		result = scaleDownResult
+	}
+
+	// Update status counts, conditions, and emit events.
+	if err := r.reconcileStatusCounts(ctx, &exporterSet); err != nil {
+		return ctrl.Result{}, err
+	}
+	r.reconcileConditions(&exporterSet)
 	if err := r.Status().Update(ctx, &exporterSet); err != nil {
 		return requeueConflict(logger, err)
 	}
-
 	r.emitConditionEvents(&exporterSet, prevAvailable, prevProgressing, prevDegraded, prevScalingLimited)
 
+	return result, nil
+}
+
+type poolState struct {
+	replicas  int32
+	ready     int32
+	available int32
+	leased    int32
+}
+
+func computePoolState(exporters []jumpstarterdevv1alpha1.Exporter) poolState {
+	var s poolState
+	for i := range exporters {
+		exp := &exporters[i]
+		s.replicas++
+
+		isOnline := meta.IsStatusConditionTrue(
+			exp.Status.Conditions,
+			string(jumpstarterdevv1alpha1.ExporterConditionTypeOnline),
+		)
+		isEnabled := exp.IsEnabled()
+		isLeased := exp.Status.LeaseRef != nil
+
+		if isOnline {
+			s.ready++
+		}
+		if isLeased {
+			s.leased++
+		}
+		if isOnline && isEnabled && !isLeased {
+			s.available++
+		}
+	}
+	return s
+}
+
+// scaleUp creates Exporter + Pod pairs (ExporterSet → Exporter → Pod).
+func (r *ExporterSetReconciler) scaleUp(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+	vtc *virtualtargetv1alpha1.VirtualTargetClass,
+	mergedParameters map[string]interface{},
+	count int32,
+) error {
+	logger := log.FromContext(ctx)
+
+	for i := int32(0); i < count; i++ {
+		exporter := &jumpstarterdevv1alpha1.Exporter{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: es.Name + "-",
+				Namespace:    es.Namespace,
+				Labels:       maps.Clone(es.Spec.Template.Metadata.Labels),
+				Annotations:  maps.Clone(es.Spec.Template.Metadata.Annotations),
+			},
+			Spec: jumpstarterdevv1alpha1.ExporterSpec{
+				Enabled: boolPtr(true),
+			},
+		}
+
+		if err := ctrl.SetControllerReference(es, exporter, r.Scheme); err != nil {
+			return fmt.Errorf("unable to set owner reference on Exporter: %w", err)
+		}
+
+		if err := r.Create(ctx, exporter); err != nil {
+			return fmt.Errorf("unable to create Exporter: %w", err)
+		}
+
+		logger.Info("created Exporter", "exporter", exporter.Name)
+
+		pod, err := r.Provisioner.RenderPod(ctx, es, vtc, mergedParameters)
+		if err != nil {
+			return fmt.Errorf("unable to render Pod for Exporter %s: %w", exporter.Name, err)
+		}
+
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		pod.Labels[labelExporterSetName] = es.Name
+
+		// Exporter owns Pod; the label bridges the grandparent lookup.
+		if err := ctrl.SetControllerReference(exporter, pod, r.Scheme); err != nil {
+			return fmt.Errorf("unable to set owner reference on Pod: %w", err)
+		}
+
+		if err := r.Create(ctx, pod); err != nil {
+			_ = r.Delete(ctx, exporter) // roll back headless exporter
+			return fmt.Errorf("unable to create Pod for Exporter %s: %w", exporter.Name, err)
+		}
+
+		logger.Info("created Pod for Exporter", "exporter", exporter.Name, "pod", pod.Name)
+
+		if r.Recorder != nil {
+			r.Recorder.Eventf(es, corev1.EventTypeNormal, "ScaleUp",
+				"Created Exporter %s with Pod %s", exporter.Name, pod.Name)
+		}
+	}
+
+	return nil
+}
+
+// cleanupDisabledExporters deletes disabled, unleased exporters. Returns true if any were deleted.
+func (r *ExporterSetReconciler) cleanupDisabledExporters(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+	exporters []jumpstarterdevv1alpha1.Exporter,
+) (bool, error) {
+	logger := log.FromContext(ctx)
+	deleted := false
+
+	for i := range exporters {
+		exp := &exporters[i]
+
+		if exp.IsEnabled() || exp.Status.LeaseRef != nil {
+			continue
+		}
+
+		if err := r.Provisioner.Cleanup(ctx, es, exp); err != nil {
+			return deleted, fmt.Errorf("unable to cleanup Exporter %s: %w", exp.Name, err)
+		}
+
+		if err := r.Delete(ctx, exp); err != nil && !apierrors.IsNotFound(err) {
+			return deleted, fmt.Errorf("unable to delete Exporter %s: %w", exp.Name, err)
+		}
+
+		logger.Info("deleted disabled Exporter", "exporter", exp.Name)
+
+		if r.Recorder != nil {
+			r.Recorder.Eventf(es, corev1.EventTypeNormal, "ScaleDown",
+				"Deleted Exporter %s", exp.Name)
+		}
+		deleted = true
+	}
+
+	return deleted, nil
+}
+
+// reconcileScaleDown disables one idle exporter per cooldown period.
+func (r *ExporterSetReconciler) reconcileScaleDown(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+	ownedExporters []jumpstarterdevv1alpha1.Exporter,
+	state poolState,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Scale down when available > minAvailableReplicas AND replicas > minReplicas.
+	surplus := state.available - es.Spec.MinAvailableReplicas
+	excessOverMin := state.replicas - es.Spec.MinReplicas
+
+	if excessOverMin <= 0 || surplus <= 0 {
+		r.clearSurplusAnnotation(ctx, es)
+		return ctrl.Result{}, nil
+	}
+
+	cooldown := defaultScaleDownCooldown
+	if es.Spec.ScaleDownCooldown != nil {
+		cooldown = es.Spec.ScaleDownCooldown.Duration
+	}
+
+	// In-memory guard against stale-cache double-disables.
+	key := types.NamespacedName{Name: es.Name, Namespace: es.Namespace}
+	r.lastScaleDownMu.Lock()
+	if r.LastScaleDownAction == nil {
+		r.LastScaleDownAction = make(map[types.NamespacedName]time.Time)
+	}
+	lastAction := r.LastScaleDownAction[key]
+	r.lastScaleDownMu.Unlock()
+	if !lastAction.IsZero() {
+		if remaining := cooldown - time.Since(lastAction); remaining > 0 {
+			return ctrl.Result{RequeueAfter: remaining}, nil
+		}
+	}
+
+	surplusSince, hasAnnotation := es.Annotations[annotationSurplusSince]
+	if !hasAnnotation {
+		r.setSurplusAnnotation(ctx, es)
+		return ctrl.Result{RequeueAfter: cooldown}, nil
+	}
+
+	surplusTime, err := time.Parse(time.RFC3339, surplusSince)
+	if err != nil {
+		r.setSurplusAnnotation(ctx, es)
+		return ctrl.Result{RequeueAfter: cooldown}, nil
+	}
+
+	elapsed := time.Since(surplusTime)
+	if elapsed < cooldown {
+		return ctrl.Result{RequeueAfter: cooldown - elapsed}, nil
+	}
+
+	// Cooldown elapsed — pick one exporter to disable (prefer online first).
+	for _, wantOnline := range []bool{true, false} {
+		for i := range ownedExporters {
+			exp := &ownedExporters[i]
+
+			if !exp.IsEnabled() || exp.Status.LeaseRef != nil {
+				continue
+			}
+
+			isOnline := meta.IsStatusConditionTrue(
+				exp.Status.Conditions,
+				string(jumpstarterdevv1alpha1.ExporterConditionTypeOnline),
+			)
+			if isOnline != wantOnline {
+				continue
+			}
+
+			exp.Spec.Enabled = boolPtr(false)
+			if err := r.Update(ctx, exp); err != nil {
+				return ctrl.Result{}, fmt.Errorf("unable to disable Exporter %s: %w", exp.Name, err)
+			}
+
+			logger.Info("disabled Exporter for scale-down", "exporter", exp.Name)
+
+			if r.Recorder != nil {
+				r.Recorder.Eventf(es, corev1.EventTypeNormal, "ScaleDown",
+					"Disabled Exporter %s for removal", exp.Name)
+			}
+
+			r.lastScaleDownMu.Lock()
+			if r.LastScaleDownAction == nil {
+				r.LastScaleDownAction = make(map[types.NamespacedName]time.Time)
+			}
+			r.LastScaleDownAction[key] = time.Now()
+			r.lastScaleDownMu.Unlock()
+
+			r.setSurplusAnnotation(ctx, es)
+			return ctrl.Result{RequeueAfter: cooldown}, nil
+		}
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func (r *ExporterSetReconciler) setSurplusAnnotation(ctx context.Context, es *virtualtargetv1alpha1.ExporterSet) {
+	if es.Annotations == nil {
+		es.Annotations = make(map[string]string)
+	}
+	es.Annotations[annotationSurplusSince] = time.Now().UTC().Format(time.RFC3339)
+	if err := r.Update(ctx, es); err != nil && !apierrors.IsConflict(err) {
+		log.FromContext(ctx).Error(err, "failed to set surplus-since annotation")
+	}
+}
+
+func (r *ExporterSetReconciler) clearSurplusAnnotation(ctx context.Context, es *virtualtargetv1alpha1.ExporterSet) {
+	if _, ok := es.Annotations[annotationSurplusSince]; !ok {
+		return
+	}
+	delete(es.Annotations, annotationSurplusSince)
+	if err := r.Update(ctx, es); err != nil && !apierrors.IsConflict(err) {
+		log.FromContext(ctx).Error(err, "failed to clear surplus-since annotation")
+	}
+}
+
+func (r *ExporterSetReconciler) listOwnedExporters(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+) ([]jumpstarterdevv1alpha1.Exporter, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&es.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid label selector: %w", err)
+	}
+
+	var exporterList jumpstarterdevv1alpha1.ExporterList
+	if err := r.List(ctx, &exporterList,
+		client.InNamespace(es.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return nil, fmt.Errorf("unable to list Exporters: %w", err)
+	}
+
+	owned := make([]jumpstarterdevv1alpha1.Exporter, 0, len(exporterList.Items))
+	for i := range exporterList.Items {
+		if isOwnedBy(&exporterList.Items[i], es.UID) {
+			owned = append(owned, exporterList.Items[i])
+		}
+	}
+	return owned, nil
 }
 
 func (r *ExporterSetReconciler) reconcileStatusCounts(
@@ -420,22 +784,10 @@ func (r *ExporterSetReconciler) emitConditionEvents(
 		return
 	}
 
-	nowAvailable := meta.IsStatusConditionTrue(
-		es.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionAvailable),
-	)
-	nowProgressing := meta.IsStatusConditionTrue(
-		es.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionProgressing),
-	)
-	nowDegraded := meta.IsStatusConditionTrue(
-		es.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionDegraded),
-	)
-	nowScalingLimited := meta.IsStatusConditionTrue(
-		es.Status.Conditions,
-		string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited),
-	)
+	nowAvailable := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionAvailable))
+	nowProgressing := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionProgressing))
+	nowDegraded := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionDegraded))
+	nowScalingLimited := meta.IsStatusConditionTrue(es.Status.Conditions, string(virtualtargetv1alpha1.ExporterSetConditionScalingLimited))
 
 	if !prevAvailable && nowAvailable {
 		r.Recorder.Eventf(es, corev1.EventTypeNormal, "ExporterSetAvailable",
@@ -488,34 +840,48 @@ func filterOwnedExporters(
 	return owned
 }
 
-func isOwnedBy(obj client.Object, ownerUID types.UID) bool {
-	for _, ref := range obj.GetOwnerReferences() {
-		if ref.UID == ownerUID && ref.Controller != nil && *ref.Controller {
-			return true
-		}
-	}
-	return false
-}
-
-func requeueConflict(logger interface{ Info(string, ...interface{}) }, err error) (ctrl.Result, error) {
-	if apierrors.IsConflict(err) {
-		logger.Info("conflict on status update, will retry")
-	}
-	return ctrl.Result{}, err
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *ExporterSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&virtualtargetv1alpha1.ExporterSet{}).
 		Owns(&jumpstarterdevv1alpha1.Exporter{}).
-		Owns(&corev1.Pod{}).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.findExporterSetForPod),
+		).
 		Watches(
 			&virtualtargetv1alpha1.VirtualTargetClass{},
 			handler.EnqueueRequestsFromMapFunc(r.findExporterSetsForVTC),
 		).
+		Watches(
+			&jumpstarterdevv1alpha1.Lease{},
+			handler.EnqueueRequestsFromMapFunc(r.findExporterSetsForLease),
+		).
 		Named("exporterset").
 		Complete(r)
+}
+
+// findExporterSetForPod bridges the ExporterSet→Exporter→Pod grandchild gap via label.
+func (r *ExporterSetReconciler) findExporterSetForPod(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	esName, ok := pod.Labels[labelExporterSetName]
+	if !ok {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      esName,
+			Namespace: pod.Namespace,
+		},
+	}}
 }
 
 func (r *ExporterSetReconciler) findExporterSetsForVTC(
@@ -548,4 +914,154 @@ func (r *ExporterSetReconciler) findExporterSetsForVTC(
 	}
 
 	return requests
+}
+
+// findExporterSetsForLease enqueues ExporterSets whose template labels match the Lease's selector.
+func (r *ExporterSetReconciler) findExporterSetsForLease(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	lease, ok := obj.(*jumpstarterdevv1alpha1.Lease)
+	if !ok {
+		return nil
+	}
+
+	if lease.Status.Ended {
+		return nil
+	}
+
+	leaseSelector, err := metav1.LabelSelectorAsSelector(&lease.Spec.Selector)
+	if err != nil {
+		return nil
+	}
+
+	var exporterSetList virtualtargetv1alpha1.ExporterSetList
+	if err := r.List(ctx, &exporterSetList, client.InNamespace(lease.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "unable to list ExporterSets for Lease",
+			"namespace", lease.Namespace, "lease", lease.Name)
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, es := range exporterSetList.Items {
+		templateLabels := es.Spec.Template.Metadata.Labels
+		if leaseSelector.Matches(labels.Set(templateLabels)) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      es.Name,
+					Namespace: es.Namespace,
+				},
+			})
+		}
+	}
+	return requests
+}
+
+// countPendingLeases counts unassigned pending Leases that match this pool's template labels.
+func (r *ExporterSetReconciler) countPendingLeases(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+) (int32, error) {
+	var leaseList jumpstarterdevv1alpha1.LeaseList
+	if err := r.List(ctx, &leaseList, client.InNamespace(es.Namespace)); err != nil {
+		return 0, fmt.Errorf("unable to list Leases: %w", err)
+	}
+
+	templateLabels := labels.Set(es.Spec.Template.Metadata.Labels)
+	var count int32
+
+	for i := range leaseList.Items {
+		lease := &leaseList.Items[i]
+
+		if lease.Status.Ended || lease.Status.ExporterRef != nil {
+			continue
+		}
+
+		if !meta.IsStatusConditionTrue(lease.Status.Conditions,
+			string(jumpstarterdevv1alpha1.LeaseConditionTypePending)) {
+			continue
+		}
+
+		sel, err := metav1.LabelSelectorAsSelector(&lease.Spec.Selector)
+		if err != nil {
+			continue
+		}
+		if sel.Matches(templateLabels) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func isOwnedBy(obj client.Object, ownerUID types.UID) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == ownerUID && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func atMaxReplicas(es *virtualtargetv1alpha1.ExporterSet, current int32) bool {
+	return es.Spec.MaxReplicas > 0 && current >= es.Spec.MaxReplicas
+}
+
+func maxScaleUp(es *virtualtargetv1alpha1.ExporterSet, current int32) int32 {
+	if es.Spec.MaxReplicas <= 0 {
+		return int32(1<<31 - 1)
+	}
+	room := es.Spec.MaxReplicas - current
+	if room < 0 {
+		return 0
+	}
+	return room
+}
+
+func requeueConflict(logger interface{ Info(string, ...interface{}) }, err error) (ctrl.Result, error) {
+	if apierrors.IsConflict(err) {
+		logger.Info("conflict on status update, will retry")
+	}
+	return ctrl.Result{}, err
+}
+
+// deepMergeParameters merges VTC + ExporterSet params (maps recursive, scalars replace).
+func deepMergeParameters(
+	classParams *apiextensionsv1.JSON,
+	setParams *apiextensionsv1.JSON,
+) (map[string]interface{}, error) {
+	base := make(map[string]interface{})
+	override := make(map[string]interface{})
+
+	if classParams != nil && classParams.Raw != nil {
+		if err := json.Unmarshal(classParams.Raw, &base); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal class parameters: %w", err)
+		}
+	}
+
+	if setParams != nil && setParams.Raw != nil {
+		if err := json.Unmarshal(setParams.Raw, &override); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal set parameters: %w", err)
+		}
+	}
+
+	return deepMerge(base, override), nil
+}
+
+func deepMerge(base, override map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(base)+len(override))
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range override {
+		if baseMap, ok := result[k].(map[string]interface{}); ok {
+			if overrideMap, ok := v.(map[string]interface{}); ok {
+				result[k] = deepMerge(baseMap, overrideMap)
+				continue
+			}
+		}
+		result[k] = v
+	}
+	return result
 }

--- a/controller/internal/exporterset/reconciler_test.go
+++ b/controller/internal/exporterset/reconciler_test.go
@@ -19,6 +19,7 @@ package exporterset
 import (
 	"context"
 	"testing"
+	"time"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
@@ -31,6 +32,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const testExporterSetUID = types.UID("es-uid-1234")
+
+const (
+	kindExporter    = "Exporter"
+	kindExporterSet = "ExporterSet"
+	nsDefault       = "default"
 )
 
 func newScheme(t *testing.T) *runtime.Scheme {
@@ -48,179 +57,53 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
-func TestReconcile_virtualTargetClassNotFound(t *testing.T) {
-	scheme := newScheme(t)
-	exporterSet := &virtualtargetv1alpha1.ExporterSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "demo-set", Namespace: "default"},
-		Spec: virtualtargetv1alpha1.ExporterSetSpec{
-			VirtualTargetClassName: "missing-class",
-		},
-	}
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(exporterSet).
-		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
-		Build()
-	r := &ExporterSetReconciler{
-		Client:      c,
-		Scheme:      scheme,
-		Provisioner: qemu.New(),
-	}
-
-	result, err := r.Reconcile(context.Background(), reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
-	})
-	if err != nil {
-		t.Fatalf("Reconcile() error = %v, want nil", err)
-	}
-	if result.RequeueAfter != 0 {
-		t.Fatalf("Reconcile() result = %#v, want no requeue", result)
-	}
-
-	var updated virtualtargetv1alpha1.ExporterSet
-	if err := c.Get(context.Background(), types.NamespacedName{Name: "demo-set", Namespace: "default"}, &updated); err != nil {
-		t.Fatalf("Get() error = %v", err)
-	}
-	cond := meta.FindStatusCondition(updated.Status.Conditions, "Available")
-	if cond == nil {
-		t.Fatal("Expected Available condition to be set")
-	}
-	if cond.Status != metav1.ConditionFalse {
-		t.Errorf("Available status = %v, want False", cond.Status)
-	}
-	if cond.Reason != "VirtualTargetClassNotFound" {
-		t.Errorf("Available reason = %q, want VirtualTargetClassNotFound", cond.Reason)
-	}
-}
-
-func TestReconcile_provisionerMismatch(t *testing.T) {
-	scheme := newScheme(t)
-	vtc := &virtualtargetv1alpha1.VirtualTargetClass{
-		ObjectMeta: metav1.ObjectMeta{Name: "other-class", Namespace: "default"},
-		Spec: virtualtargetv1alpha1.VirtualTargetClassSpec{
-			Provisioner: "other.jumpstarter.dev",
-		},
-	}
-	exporterSet := &virtualtargetv1alpha1.ExporterSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "demo-set", Namespace: "default"},
-		Spec: virtualtargetv1alpha1.ExporterSetSpec{
-			VirtualTargetClassName: "other-class",
-		},
-	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vtc, exporterSet).Build()
-	r := &ExporterSetReconciler{
-		Client:      c,
-		Scheme:      scheme,
-		Provisioner: qemu.New(),
-	}
-
-	result, err := r.Reconcile(context.Background(), reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
-	})
-	if err != nil {
-		t.Fatalf("Reconcile() error = %v, want nil", err)
-	}
-	if result.RequeueAfter != 0 {
-		t.Fatalf("Reconcile() result = %#v, want no requeue", result)
-	}
-}
-
-func TestFindExporterSetsForVTC_filtersByClassName(t *testing.T) {
-	scheme := newScheme(t)
-	vtc := &virtualtargetv1alpha1.VirtualTargetClass{
-		ObjectMeta: metav1.ObjectMeta{Name: "qemu-class", Namespace: "default"},
-		Spec: virtualtargetv1alpha1.VirtualTargetClassSpec{
-			Provisioner: qemu.ProvisionerName,
-		},
-	}
-	matching := &virtualtargetv1alpha1.ExporterSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: "default"},
-		Spec: virtualtargetv1alpha1.ExporterSetSpec{
-			VirtualTargetClassName: "qemu-class",
-		},
-	}
-	other := &virtualtargetv1alpha1.ExporterSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
-		Spec: virtualtargetv1alpha1.ExporterSetSpec{
-			VirtualTargetClassName: "other-class",
-		},
-	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vtc, matching, other).Build()
-	r := &ExporterSetReconciler{
-		Client:      c,
-		Scheme:      scheme,
-		Provisioner: qemu.New(),
-	}
-
-	requests := r.findExporterSetsForVTC(context.Background(), vtc)
-	if len(requests) != 1 {
-		t.Fatalf("got %d requests, want 1: %#v", len(requests), requests)
-	}
-	if requests[0].Name != "matching" || requests[0].Namespace != "default" {
-		t.Errorf("request = %#v, want matching/default", requests[0])
-	}
-}
-
-func TestFindExporterSetsForVTC_ignoresNonVTC(t *testing.T) {
-	scheme := newScheme(t)
-	r := &ExporterSetReconciler{
-		Client:      fake.NewClientBuilder().WithScheme(scheme).Build(),
-		Scheme:      scheme,
-		Provisioner: qemu.New(),
-	}
-
-	requests := r.findExporterSetsForVTC(context.Background(), &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"},
-	})
-	if requests != nil {
-		t.Errorf("got %#v, want nil", requests)
-	}
-}
-
-// --- Status reconciliation tests ---
-
-const testExporterSetUID = types.UID("es-uid-1234")
-
-func makeExporterSet() *virtualtargetv1alpha1.ExporterSet {
-	return &virtualtargetv1alpha1.ExporterSet{
+func makeExporterSet(opts ...func(*virtualtargetv1alpha1.ExporterSet)) *virtualtargetv1alpha1.ExporterSet {
+	es := &virtualtargetv1alpha1.ExporterSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "demo-set",
-			Namespace:  "default",
+			Namespace:  nsDefault,
 			UID:        testExporterSetUID,
 			Generation: 1,
 		},
 		Spec: virtualtargetv1alpha1.ExporterSetSpec{
 			MinReplicas:            2,
-			MaxReplicas:            4,
+			MaxReplicas:            10,
 			MinAvailableReplicas:   1,
 			VirtualTargetClassName: "qemu-class",
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"exporterset": "demo-set"},
 			},
+			Template: virtualtargetv1alpha1.ExporterSetTemplate{
+				Metadata: virtualtargetv1alpha1.EmbeddedObjectMeta{
+					Labels: map[string]string{"exporterset": "demo-set"},
+				},
+			},
 		},
 	}
+	for _, opt := range opts {
+		opt(es)
+	}
+	return es
 }
 
 func makeVTC() *virtualtargetv1alpha1.VirtualTargetClass {
 	return &virtualtargetv1alpha1.VirtualTargetClass{
-		ObjectMeta: metav1.ObjectMeta{Name: "qemu-class", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "qemu-class", Namespace: nsDefault},
 		Spec: virtualtargetv1alpha1.VirtualTargetClassSpec{
 			Provisioner: qemu.ProvisionerName,
 		},
 	}
 }
 
-func boolPtr(b bool) *bool { return &b }
-
 func makeExporter(name string, online bool, leased bool, enabled bool) *jumpstarterdevv1alpha1.Exporter {
 	exp := &jumpstarterdevv1alpha1.Exporter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: nsDefault,
 			Labels:    map[string]string{"exporterset": "demo-set"},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: "virtualtarget.jumpstarter.dev/v1alpha1",
-				Kind:       "ExporterSet",
+				Kind:       kindExporterSet,
 				Name:       "demo-set",
 				UID:        testExporterSetUID,
 				Controller: boolPtr(true),
@@ -247,15 +130,77 @@ func makeExporter(name string, online bool, leased bool, enabled bool) *jumpstar
 	return exp
 }
 
+func newReconciler(t *testing.T, objs ...client.Object) (*ExporterSetReconciler, client.Client) {
+	t.Helper()
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		Build()
+	r := &ExporterSetReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		Provisioner: qemu.New(),
+	}
+	return r, c
+}
+
+func reconcileOnce(t *testing.T, r *ExporterSetReconciler) reconcile.Result {
+	t.Helper()
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: nsDefault},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	return result
+}
+
+func getExporterSet(t *testing.T, c client.Client) virtualtargetv1alpha1.ExporterSet {
+	t.Helper()
+	var es virtualtargetv1alpha1.ExporterSet
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "demo-set", Namespace: nsDefault}, &es); err != nil {
+		t.Fatalf("Get ExporterSet error = %v", err)
+	}
+	return es
+}
+
+func listExporters(t *testing.T, c client.Client) []jumpstarterdevv1alpha1.Exporter {
+	t.Helper()
+	var list jumpstarterdevv1alpha1.ExporterList
+	if err := c.List(context.Background(), &list, client.InNamespace(nsDefault)); err != nil {
+		t.Fatalf("List Exporters error = %v", err)
+	}
+	return list.Items
+}
+
+func listPods(t *testing.T, c client.Client) []corev1.Pod {
+	t.Helper()
+	var list corev1.PodList
+	if err := c.List(context.Background(), &list, client.InNamespace(nsDefault)); err != nil {
+		t.Fatalf("List Pods error = %v", err)
+	}
+	return list.Items
+}
+
+func assertInt32(t *testing.T, field string, got, want int32) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %d, want %d", field, got, want)
+	}
+}
+
 func makePod(name string, phase corev1.PodPhase) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "default",
+			Namespace: nsDefault,
 			Labels:    map[string]string{"exporterset": "demo-set"},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: "virtualtarget.jumpstarter.dev/v1alpha1",
-				Kind:       "ExporterSet",
+				Kind:       kindExporterSet,
 				Name:       "demo-set",
 				UID:        testExporterSetUID,
 				Controller: boolPtr(true),
@@ -280,7 +225,7 @@ func reconcileAndGet(t *testing.T, objs ...client.Object) virtualtargetv1alpha1.
 	}
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
+		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: nsDefault},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
@@ -288,11 +233,912 @@ func reconcileAndGet(t *testing.T, objs ...client.Object) virtualtargetv1alpha1.
 
 	var updated virtualtargetv1alpha1.ExporterSet
 	if err := c.Get(context.Background(),
-		types.NamespacedName{Name: "demo-set", Namespace: "default"}, &updated); err != nil {
+		types.NamespacedName{Name: "demo-set", Namespace: nsDefault}, &updated); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
 	return updated
 }
+
+// --- VTC resolution tests ---
+
+func TestReconcile_virtualTargetClassNotFound(t *testing.T) {
+	r, _ := newReconciler(t, makeExporterSet())
+	result := reconcileOnce(t, r)
+	if result.RequeueAfter != 0 {
+		t.Fatalf("Reconcile() result = %#v, want no requeue", result)
+	}
+}
+
+func TestReconcile_provisionerMismatch(t *testing.T) {
+	vtc := &virtualtargetv1alpha1.VirtualTargetClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-class", Namespace: nsDefault},
+		Spec: virtualtargetv1alpha1.VirtualTargetClassSpec{
+			Provisioner: "other.jumpstarter.dev",
+		},
+	}
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.VirtualTargetClassName = "other-class"
+	})
+	r, _ := newReconciler(t, vtc, es)
+	result := reconcileOnce(t, r)
+	if result.RequeueAfter != 0 {
+		t.Fatalf("Reconcile() result = %#v, want no requeue", result)
+	}
+}
+
+// --- Scale-up tests ---
+
+func TestReconcile_scaleUp_noExporters_createsMinReplicas(t *testing.T) {
+	r, c := newReconciler(t, makeExporterSet(), makeVTC())
+
+	// minReplicas=2: one Exporter per reconcile, Owns watch drives the next cycle.
+	for range 2 {
+		reconcileOnce(t, r)
+	}
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 2 {
+		t.Fatalf("expected 2 Exporters (minReplicas), got %d", len(exporters))
+	}
+
+	pods := listPods(t, c)
+	if len(pods) != 2 {
+		t.Fatalf("expected 2 Pods, got %d", len(pods))
+	}
+
+	// Verify Exporter is owned by ExporterSet
+	for _, exp := range exporters {
+		if !isOwnedBy(&exp, testExporterSetUID) {
+			t.Errorf("Exporter %s not owned by ExporterSet", exp.Name)
+		}
+		if !exp.IsEnabled() {
+			t.Errorf("Exporter %s should be enabled", exp.Name)
+		}
+	}
+
+	// Verify Pods are owned by their Exporters (not ExporterSet)
+	for _, pod := range pods {
+		ownedByExporter := false
+		for _, ref := range pod.OwnerReferences {
+			if ref.Kind == kindExporter && ref.Controller != nil && *ref.Controller {
+				ownedByExporter = true
+				break
+			}
+		}
+		if !ownedByExporter {
+			t.Errorf("Pod %s should be owned by an Exporter", pod.Name)
+		}
+
+		ownedByES := false
+		for _, ref := range pod.OwnerReferences {
+			if ref.UID == testExporterSetUID {
+				ownedByES = true
+			}
+		}
+		if ownedByES {
+			t.Errorf("Pod %s should NOT be directly owned by ExporterSet", pod.Name)
+		}
+
+		if pod.Labels[labelExporterSetName] != "demo-set" {
+			t.Errorf("Pod %s missing ExporterSet label", pod.Name)
+		}
+	}
+}
+
+func TestReconcile_scaleUp_warmBuffer(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 3
+	})
+	r, c := newReconciler(t, es, makeVTC())
+
+	// minAvailableReplicas=3: one Exporter per reconcile.
+	for range 3 {
+		reconcileOnce(t, r)
+	}
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 3 {
+		t.Fatalf("expected 3 Exporters (minAvailableReplicas), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_scaleUp_respectsMaxReplicas(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 5
+		es.Spec.MaxReplicas = 3
+	})
+	r, c := newReconciler(t, es, makeVTC())
+
+	// maxReplicas=3: 3 reconciles create 3, the 4th is a no-op (capped).
+	for range 4 {
+		reconcileOnce(t, r)
+	}
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 3 {
+		t.Fatalf("expected 3 Exporters (capped by maxReplicas), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_scaleUp_refillsWarmBuffer(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 2
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, true, true),  // online, leased
+		makeExporter("exp-2", true, false, true), // online, not leased (available=1)
+	)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 3 {
+		t.Fatalf("expected 3 Exporters (refilled warm buffer), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_scaleUp_noOpWhenSufficient(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 2
+		es.Spec.MinAvailableReplicas = 1
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+	)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 2 {
+		t.Fatalf("expected 2 Exporters (no change), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_scaleUp_atMaxReplicas_noOp(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 5
+		es.Spec.MaxReplicas = 2
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, true, true),
+		makeExporter("exp-2", true, true, true),
+	)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 2 {
+		t.Fatalf("expected 2 Exporters (at maxReplicas), got %d", len(exporters))
+	}
+}
+
+// --- Scale-down tests ---
+
+func TestReconcile_scaleDown_setsAnnotationAndRequeues(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 1
+		es.Spec.MinAvailableReplicas = 1
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-3", true, false, true),
+	)
+
+	result := reconcileOnce(t, r)
+
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected RequeueAfter for cooldown, got 0")
+	}
+
+	updated := getExporterSet(t, c)
+	if _, ok := updated.Annotations[annotationSurplusSince]; !ok {
+		t.Fatal("expected surplus-since annotation to be set")
+	}
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 3 {
+		t.Fatalf("expected 3 Exporters (cooldown not elapsed), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_scaleDown_afterCooldown_disablesExporter(t *testing.T) {
+	cooldown := 1 * time.Second
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 1
+		es.Spec.MinAvailableReplicas = 1
+		es.Spec.ScaleDownCooldown = &metav1.Duration{Duration: cooldown}
+		es.Annotations = map[string]string{
+			annotationSurplusSince: time.Now().Add(-2 * cooldown).UTC().Format(time.RFC3339),
+		}
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-3", true, false, true),
+	)
+
+	result := reconcileOnce(t, r)
+
+	// After disabling an exporter the controller resets the annotation and
+	// returns RequeueAfter: cooldown (not an immediate Requeue).
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected RequeueAfter > 0 after disabling exporter")
+	}
+
+	exporters := listExporters(t, c)
+	disabledCount := 0
+	for _, exp := range exporters {
+		if !exp.IsEnabled() {
+			disabledCount++
+		}
+	}
+	if disabledCount != 1 {
+		t.Fatalf("expected 1 disabled Exporter, got %d", disabledCount)
+	}
+}
+
+func TestReconcile_scaleDown_deletesDisabledUnleasedExporter(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 1
+		es.Spec.MinAvailableReplicas = 1
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-disabled", true, false, false), // disabled, unleased -> cleaned up
+	)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 2 {
+		t.Fatalf("expected 2 Exporters after cleanup, got %d", len(exporters))
+	}
+
+	for _, exp := range exporters {
+		if exp.Name == "exp-disabled" {
+			t.Fatal("disabled exporter should have been cleaned up")
+		}
+	}
+}
+
+func TestReconcile_scaleDown_doesNotDeleteLeasedDisabledExporter(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 1
+		es.Spec.MinAvailableReplicas = 1
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-disabled-leased", true, true, false), // disabled but still leased
+	)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 3 {
+		t.Fatalf("expected 3 Exporters (leased disabled not deleted), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_scaleDown_respectsMinReplicas(t *testing.T) {
+	cooldown := 1 * time.Second
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 3
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.ScaleDownCooldown = &metav1.Duration{Duration: cooldown}
+		es.Annotations = map[string]string{
+			annotationSurplusSince: time.Now().Add(-2 * cooldown).UTC().Format(time.RFC3339),
+		}
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+		makeExporter("exp-3", true, false, true),
+	)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 3 {
+		t.Fatalf("expected 3 Exporters (at minReplicas), got %d", len(exporters))
+	}
+}
+
+// --- Ownership chain tests ---
+
+func TestReconcile_ownershipChain_exporterOwnedByExporterSet(t *testing.T) {
+	r, c := newReconciler(t, makeExporterSet(), makeVTC())
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	for _, exp := range exporters {
+		found := false
+		for _, ref := range exp.OwnerReferences {
+			if ref.UID == testExporterSetUID &&
+				ref.Kind == kindExporterSet &&
+				ref.Controller != nil && *ref.Controller {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Exporter %s should be controller-owned by ExporterSet", exp.Name)
+		}
+	}
+}
+
+func TestReconcile_ownershipChain_podOwnedByExporter(t *testing.T) {
+	r, c := newReconciler(t, makeExporterSet(), makeVTC())
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	pods := listPods(t, c)
+
+	exporterUIDs := make(map[types.UID]bool)
+	for _, exp := range exporters {
+		exporterUIDs[exp.UID] = true
+	}
+
+	for _, pod := range pods {
+		ownedByExporter := false
+		for _, ref := range pod.OwnerReferences {
+			if ref.Kind == kindExporter &&
+				ref.Controller != nil && *ref.Controller &&
+				exporterUIDs[ref.UID] {
+				ownedByExporter = true
+			}
+		}
+		if !ownedByExporter {
+			t.Errorf("Pod %s should be controller-owned by an Exporter", pod.Name)
+		}
+
+		ownedByES := false
+		for _, ref := range pod.OwnerReferences {
+			if ref.UID == testExporterSetUID {
+				ownedByES = true
+			}
+		}
+		if ownedByES {
+			t.Errorf("Pod %s should NOT be directly owned by ExporterSet", pod.Name)
+		}
+	}
+}
+
+// --- Pod watch mapping tests ---
+
+func TestFindExporterSetForPod_returnsRequestForLabeledPod(t *testing.T) {
+	r, _ := newReconciler(t)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: nsDefault,
+			Labels:    map[string]string{labelExporterSetName: "my-set"},
+		},
+	}
+
+	requests := r.findExporterSetForPod(context.Background(), pod)
+	if len(requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(requests))
+	}
+	if requests[0].Name != "my-set" || requests[0].Namespace != nsDefault {
+		t.Errorf("request = %#v, want my-set/default", requests[0])
+	}
+}
+
+func TestFindExporterSetForPod_returnsNilForUnlabeledPod(t *testing.T) {
+	r, _ := newReconciler(t)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unrelated-pod",
+			Namespace: nsDefault,
+		},
+	}
+
+	requests := r.findExporterSetForPod(context.Background(), pod)
+	if len(requests) != 0 {
+		t.Errorf("got %d requests, want 0", len(requests))
+	}
+}
+
+func TestFindExporterSetForPod_returnsNilForNonPod(t *testing.T) {
+	r, _ := newReconciler(t)
+	requests := r.findExporterSetForPod(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: nsDefault},
+	})
+	if requests != nil {
+		t.Errorf("got %#v, want nil", requests)
+	}
+}
+
+// --- VTC watch mapping tests ---
+
+func TestFindExporterSetsForVTC_filtersByClassName(t *testing.T) {
+	vtc := makeVTC()
+	matching := &virtualtargetv1alpha1.ExporterSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: nsDefault},
+		Spec: virtualtargetv1alpha1.ExporterSetSpec{
+			VirtualTargetClassName: "qemu-class",
+		},
+	}
+	other := &virtualtargetv1alpha1.ExporterSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: nsDefault},
+		Spec: virtualtargetv1alpha1.ExporterSetSpec{
+			VirtualTargetClassName: "other-class",
+		},
+	}
+	r, _ := newReconciler(t, vtc, matching, other)
+
+	requests := r.findExporterSetsForVTC(context.Background(), vtc)
+	if len(requests) != 1 {
+		t.Fatalf("got %d requests, want 1: %#v", len(requests), requests)
+	}
+	if requests[0].Name != "matching" || requests[0].Namespace != nsDefault {
+		t.Errorf("request = %#v, want matching/default", requests[0])
+	}
+}
+
+func TestFindExporterSetsForVTC_ignoresNonVTC(t *testing.T) {
+	r, _ := newReconciler(t)
+	requests := r.findExporterSetsForVTC(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: nsDefault},
+	})
+	if requests != nil {
+		t.Errorf("got %#v, want nil", requests)
+	}
+}
+
+// --- computePoolState tests ---
+
+func TestComputePoolState(t *testing.T) {
+	exporters := []jumpstarterdevv1alpha1.Exporter{
+		*makeExporter("e1", true, false, true),  // online, unleased, enabled -> available, ready
+		*makeExporter("e2", true, true, true),   // online, leased, enabled -> ready, leased
+		*makeExporter("e3", false, false, true), // offline, unleased, enabled
+		*makeExporter("e4", true, false, false), // online, unleased, disabled -> ready (not available)
+	}
+
+	state := computePoolState(exporters)
+	assertInt32(t, "replicas", state.replicas, 4)
+	assertInt32(t, "ready", state.ready, 3)
+	assertInt32(t, "available", state.available, 1)
+	assertInt32(t, "leased", state.leased, 1)
+}
+
+// --- Deep merge tests ---
+
+func TestDeepMerge_mapsRecursive(t *testing.T) {
+	base := map[string]interface{}{
+		"resources": map[string]interface{}{
+			"cpu":     "4",
+			"memory":  "4Gi",
+			"storage": "16Gi",
+		},
+		"firmware": map[string]interface{}{
+			"url": "registry.example.com/fw:v1",
+		},
+	}
+	override := map[string]interface{}{
+		"resources": map[string]interface{}{
+			"memory": "8Gi",
+		},
+	}
+
+	result := deepMerge(base, override)
+
+	resources := result["resources"].(map[string]interface{})
+	if resources["cpu"] != "4" {
+		t.Errorf("cpu = %v, want 4", resources["cpu"])
+	}
+	if resources["memory"] != "8Gi" {
+		t.Errorf("memory = %v, want 8Gi", resources["memory"])
+	}
+	if resources["storage"] != "16Gi" {
+		t.Errorf("storage = %v, want 16Gi", resources["storage"])
+	}
+
+	firmware := result["firmware"].(map[string]interface{})
+	if firmware["url"] != "registry.example.com/fw:v1" {
+		t.Errorf("firmware.url = %v, want original", firmware["url"])
+	}
+}
+
+func TestDeepMerge_scalarReplace(t *testing.T) {
+	base := map[string]interface{}{"machineType": "virt"}
+	override := map[string]interface{}{"machineType": "q35"}
+
+	result := deepMerge(base, override)
+	if result["machineType"] != "q35" {
+		t.Errorf("machineType = %v, want q35", result["machineType"])
+	}
+}
+
+func TestDeepMerge_listReplace(t *testing.T) {
+	base := map[string]interface{}{"ports": []interface{}{22, 80}}
+	override := map[string]interface{}{"ports": []interface{}{443}}
+
+	result := deepMerge(base, override)
+	ports := result["ports"].([]interface{})
+	if len(ports) != 1 || ports[0] != 443 {
+		t.Errorf("ports = %v, want [443]", ports)
+	}
+}
+
+// --- Status update tests ---
+
+func TestReconcile_statusUpdated(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, true, true),
+		makeExporter("exp-3", false, false, true),
+	)
+
+	reconcileOnce(t, r)
+
+	updated := getExporterSet(t, c)
+	assertInt32(t, "Replicas", updated.Status.Replicas, 3)
+	assertInt32(t, "ReadyReplicas", updated.Status.ReadyReplicas, 2)
+	assertInt32(t, "AvailableReplicas", updated.Status.AvailableReplicas, 1)
+	assertInt32(t, "LeasedReplicas", updated.Status.LeasedReplicas, 1)
+}
+
+// --- Idempotency test ---
+
+func TestReconcile_idempotent(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 2
+		es.Spec.MinAvailableReplicas = 1
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, true, true),
+	)
+
+	reconcileOnce(t, r)
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 2 {
+		t.Fatalf("expected 2 Exporters after idempotent reconcile, got %d", len(exporters))
+	}
+}
+
+// --- In-memory race guard test ---
+
+func TestReconcile_scaleDown_inMemoryGuardPreventsRapidDisables(t *testing.T) {
+	// Long cooldown so only the in-memory guard (not the annotation check)
+	// can block the third reconcile.
+	cooldown := 10 * time.Second
+	pastTimestamp := time.Now().Add(-2 * cooldown).UTC().Format(time.RFC3339)
+
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.ScaleDownCooldown = &metav1.Duration{Duration: cooldown}
+		es.Annotations = map[string]string{
+			annotationSurplusSince: pastTimestamp,
+		}
+	})
+
+	r, c := newReconciler(t,
+		es, makeVTC(),
+		makeExporter("exp-1", true, false, true),
+		makeExporter("exp-2", true, false, true),
+	)
+
+	// Reconcile 1: cooldown elapsed → disables exp-1, records lastScaleDownAction.
+	reconcileOnce(t, r)
+
+	// Reconcile 2: cleanupDisabledExporters deletes exp-1, returns early.
+	// The stale annotation doesn't matter here because cleanup short-circuits.
+	reconcileOnce(t, r)
+
+	// Simulate cache lag before reconcile 3: reset the annotation back to the
+	// stale past timestamp, as if the informer hasn't seen setSurplusAnnotation.
+	var fresh virtualtargetv1alpha1.ExporterSet
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "demo-set", Namespace: nsDefault}, &fresh); err != nil {
+		t.Fatalf("Get ExporterSet: %v", err)
+	}
+	if fresh.Annotations == nil {
+		fresh.Annotations = make(map[string]string)
+	}
+	fresh.Annotations[annotationSurplusSince] = pastTimestamp
+	if err := c.Update(context.Background(), &fresh); err != nil {
+		t.Fatalf("Reset annotation: %v", err)
+	}
+
+	// Reconcile 3: only exp-2 remains. Annotation appears elapsed again, but
+	// the in-memory guard (lastScaleDownAction < cooldown ago) must block it.
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 1 {
+		t.Fatalf("expected 1 exporter remaining, got %d", len(exporters))
+	}
+	if !exporters[0].IsEnabled() {
+		t.Fatal("in-memory guard should have blocked disabling the remaining exporter")
+	}
+}
+
+func TestReconcile_ignoresUnownedExporters(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+	})
+
+	unowned := makeExporter("unowned", true, false, true)
+	unowned.OwnerReferences = nil
+
+	r, c := newReconciler(t, es, makeVTC(), unowned)
+
+	reconcileOnce(t, r)
+
+	updated := getExporterSet(t, c)
+	assertInt32(t, "Replicas", updated.Status.Replicas, 0)
+}
+
+// --- Demand-driven scale-up tests ---
+
+func makePendingLease(name string, selectorLabels map[string]string) *jumpstarterdevv1alpha1.Lease {
+	return &jumpstarterdevv1alpha1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: nsDefault,
+		},
+		Spec: jumpstarterdevv1alpha1.LeaseSpec{
+			ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+			Selector: metav1.LabelSelector{
+				MatchLabels: selectorLabels,
+			},
+		},
+		Status: jumpstarterdevv1alpha1.LeaseStatus{
+			Ended: false,
+			Conditions: []metav1.Condition{{
+				Type:   string(jumpstarterdevv1alpha1.LeaseConditionTypePending),
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+func TestReconcile_demandDriven_scalesUpForPendingLease(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.MaxReplicas = 5
+	})
+
+	// One pending lease matching the ExporterSet's template labels.
+	lease := makePendingLease("pending-1", map[string]string{"exporterset": "demo-set"})
+
+	r, c := newReconciler(t, es, makeVTC(), lease)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 1 {
+		t.Fatalf("expected 1 Exporter (demand-driven scale-up), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_demandDriven_noScaleUpWhenAvailableExists(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.MaxReplicas = 5
+	})
+
+	// A pending lease, but there's already an available exporter.
+	lease := makePendingLease("pending-1", map[string]string{"exporterset": "demo-set"})
+	exp := makeExporter("exp-1", true, false, true) // online, unleased = available
+
+	r, c := newReconciler(t, es, makeVTC(), lease, exp)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 1 {
+		t.Fatalf("expected 1 Exporter (no scale-up, available exists), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_demandDriven_respectsMaxReplicas(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.MaxReplicas = 2
+	})
+
+	// Three pending leases but maxReplicas=2 caps us.
+	lease1 := makePendingLease("pending-1", map[string]string{"exporterset": "demo-set"})
+	lease2 := makePendingLease("pending-2", map[string]string{"exporterset": "demo-set"})
+	lease3 := makePendingLease("pending-3", map[string]string{"exporterset": "demo-set"})
+
+	r, c := newReconciler(t, es, makeVTC(), lease1, lease2, lease3)
+
+	// 3 reconciles: first 2 create, 3rd is capped.
+	for range 3 {
+		reconcileOnce(t, r)
+	}
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 2 {
+		t.Fatalf("expected 2 Exporters (capped by maxReplicas), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_demandDriven_ignoresNonMatchingLeases(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.MaxReplicas = 5
+	})
+
+	// Pending lease with different labels — shouldn't match.
+	lease := makePendingLease("pending-other", map[string]string{"exporterset": "other-pool"})
+
+	r, c := newReconciler(t, es, makeVTC(), lease)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 0 {
+		t.Fatalf("expected 0 Exporters (lease doesn't match), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_demandDriven_ignoresEndedLeases(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.MaxReplicas = 5
+	})
+
+	// Ended lease — shouldn't trigger scale-up.
+	lease := makePendingLease("ended-1", map[string]string{"exporterset": "demo-set"})
+	lease.Status.Ended = true
+
+	r, c := newReconciler(t, es, makeVTC(), lease)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 0 {
+		t.Fatalf("expected 0 Exporters (lease ended), got %d", len(exporters))
+	}
+}
+
+func TestReconcile_demandDriven_ignoresAssignedLeases(t *testing.T) {
+	es := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MinReplicas = 0
+		es.Spec.MinAvailableReplicas = 0
+		es.Spec.MaxReplicas = 5
+	})
+
+	// Already assigned lease — shouldn't trigger scale-up.
+	lease := makePendingLease("assigned-1", map[string]string{"exporterset": "demo-set"})
+	lease.Status.ExporterRef = &corev1.LocalObjectReference{Name: "some-exporter"}
+
+	r, c := newReconciler(t, es, makeVTC(), lease)
+
+	reconcileOnce(t, r)
+
+	exporters := listExporters(t, c)
+	if len(exporters) != 0 {
+		t.Fatalf("expected 0 Exporters (lease already assigned), got %d", len(exporters))
+	}
+}
+
+// --- Lease watch mapping tests ---
+
+func TestFindExporterSetsForLease_matchesTemplateLabels(t *testing.T) {
+	es := makeExporterSet()
+	r, _ := newReconciler(t, es, makeVTC())
+
+	lease := &jumpstarterdevv1alpha1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lease",
+			Namespace: nsDefault,
+		},
+		Spec: jumpstarterdevv1alpha1.LeaseSpec{
+			ClientRef: corev1.LocalObjectReference{Name: "client"},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"exporterset": "demo-set"},
+			},
+		},
+	}
+
+	requests := r.findExporterSetsForLease(context.Background(), lease)
+	if len(requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(requests))
+	}
+	if requests[0].Name != "demo-set" {
+		t.Errorf("request name = %q, want demo-set", requests[0].Name)
+	}
+}
+
+func TestFindExporterSetsForLease_ignoresEndedLease(t *testing.T) {
+	es := makeExporterSet()
+	r, _ := newReconciler(t, es, makeVTC())
+
+	lease := &jumpstarterdevv1alpha1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ended-lease",
+			Namespace: nsDefault,
+		},
+		Spec: jumpstarterdevv1alpha1.LeaseSpec{
+			ClientRef: corev1.LocalObjectReference{Name: "client"},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"exporterset": "demo-set"},
+			},
+		},
+		Status: jumpstarterdevv1alpha1.LeaseStatus{
+			Ended: true,
+		},
+	}
+
+	requests := r.findExporterSetsForLease(context.Background(), lease)
+	if len(requests) != 0 {
+		t.Fatalf("got %d requests for ended lease, want 0", len(requests))
+	}
+}
+
+func TestFindExporterSetsForLease_ignoresNonMatchingSelector(t *testing.T) {
+	es := makeExporterSet()
+	r, _ := newReconciler(t, es, makeVTC())
+
+	lease := &jumpstarterdevv1alpha1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-lease",
+			Namespace: nsDefault,
+		},
+		Spec: jumpstarterdevv1alpha1.LeaseSpec{
+			ClientRef: corev1.LocalObjectReference{Name: "client"},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"exporterset": "other-pool"},
+			},
+		},
+	}
+
+	requests := r.findExporterSetsForLease(context.Background(), lease)
+	if len(requests) != 0 {
+		t.Fatalf("got %d requests for non-matching lease, want 0", len(requests))
+	}
+}
+
+// --- Status condition tests ---
 
 func TestReconcile_statusCounts_allOnlineNotLeased(t *testing.T) {
 	es := reconcileAndGet(t,
@@ -324,7 +1170,7 @@ func TestReconcile_statusCounts_mixedStates(t *testing.T) {
 		makeExporter("exp-1", true, true, true),
 		makeExporter("exp-2", true, false, true),
 		makeExporter("exp-3", false, false, true),
-		makeExporter("exp-4", true, false, false),
+		makeExporter("exp-4", true, true, false), // disabled but leased (draining)
 		makePod("pod-1", corev1.PodRunning),
 		makePod("pod-2", corev1.PodRunning),
 		makePod("pod-3", corev1.PodFailed),
@@ -335,7 +1181,7 @@ func TestReconcile_statusCounts_mixedStates(t *testing.T) {
 	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 3)
 	assertInt32(t, "AvailableReplicas", es.Status.AvailableReplicas, 1)
 	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 1)
-	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 1)
+	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 2)
 	assertInt32(t, "ExportersActive", es.Status.ExportersActive, 1)
 	assertInt32(t, "ExportersIdle", es.Status.ExportersIdle, 1)
 	assertInt32(t, "ExportersDisabled", es.Status.ExportersDisabled, 1)
@@ -464,9 +1310,10 @@ func TestReconcile_conditionDegraded_healthy(t *testing.T) {
 }
 
 func TestReconcile_conditionScalingLimited_atMax(t *testing.T) {
-	esObj := makeExporterSet()
-	esObj.Spec.MaxReplicas = 2
-	esObj.Spec.MinAvailableReplicas = 2
+	esObj := makeExporterSet(func(es *virtualtargetv1alpha1.ExporterSet) {
+		es.Spec.MaxReplicas = 2
+		es.Spec.MinAvailableReplicas = 2
+	})
 
 	es := reconcileAndGet(t,
 		esObj,
@@ -515,19 +1362,6 @@ func TestReconcile_selectorField_populated(t *testing.T) {
 	}
 }
 
-func TestReconcile_ignoresUnownedExporters(t *testing.T) {
-	unowned := makeExporter("unowned", true, false, true)
-	unowned.OwnerReferences = nil
-
-	es := reconcileAndGet(t,
-		makeExporterSet(),
-		makeVTC(),
-		unowned,
-	)
-
-	assertInt32(t, "Replicas", es.Status.Replicas, 0)
-}
-
 func TestReconcile_ignoresUnownedPods(t *testing.T) {
 	unowned := makePod("unowned-pod", corev1.PodRunning)
 	unowned.OwnerReferences = nil
@@ -539,49 +1373,6 @@ func TestReconcile_ignoresUnownedPods(t *testing.T) {
 	)
 
 	assertInt32(t, "PodsRunning", es.Status.PodsRunning, 0)
-}
-
-func TestReconcile_idempotent(t *testing.T) {
-	scheme := newScheme(t)
-	objs := []client.Object{
-		makeExporterSet(),
-		makeVTC(),
-		makeExporter("exp-1", true, false, true),
-		makeExporter("exp-2", true, true, true),
-		makePod("pod-1", corev1.PodRunning),
-		makePod("pod-2", corev1.PodRunning),
-	}
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(objs...).
-		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
-		Build()
-	r := &ExporterSetReconciler{
-		Client:      c,
-		Scheme:      scheme,
-		Provisioner: qemu.New(),
-	}
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
-	}
-
-	if _, err := r.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("first Reconcile() error = %v", err)
-	}
-	if _, err := r.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("second Reconcile() error = %v", err)
-	}
-
-	var es virtualtargetv1alpha1.ExporterSet
-	if err := c.Get(context.Background(),
-		types.NamespacedName{Name: "demo-set", Namespace: "default"}, &es); err != nil {
-		t.Fatalf("Get() error = %v", err)
-	}
-
-	assertInt32(t, "Replicas", es.Status.Replicas, 2)
-	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 2)
-	assertInt32(t, "AvailableReplicas", es.Status.AvailableReplicas, 1)
-	assertInt32(t, "LeasedReplicas", es.Status.LeasedReplicas, 1)
 }
 
 func TestReconcile_offlineLeasedExporter_notCountedAsActive(t *testing.T) {
@@ -606,8 +1397,8 @@ func TestReconcile_disabledExporters_dontInflateUnavailable(t *testing.T) {
 		makeVTC(),
 		makeExporter("exp-1", true, false, true),
 		makeExporter("exp-2", true, false, true),
-		makeExporter("exp-disabled-offline", false, false, false),
-		makeExporter("exp-disabled-online", true, false, false),
+		makeExporter("exp-disabled-offline", false, true, false), // disabled but leased (draining)
+		makeExporter("exp-disabled-online", true, true, false),   // disabled but leased (draining)
 	)
 
 	assertInt32(t, "Replicas", es.Status.Replicas, 4)
@@ -649,7 +1440,7 @@ func TestReconcile_vtcNotFound_updatesAllConditionsAndCounters(t *testing.T) {
 		Provisioner: qemu.New(),
 	}
 	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: "default"},
+		NamespacedName: types.NamespacedName{Name: "demo-set", Namespace: nsDefault},
 	}
 
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
@@ -668,11 +1459,10 @@ func TestReconcile_vtcNotFound_updatesAllConditionsAndCounters(t *testing.T) {
 
 	var es virtualtargetv1alpha1.ExporterSet
 	if err := c.Get(context.Background(),
-		types.NamespacedName{Name: "demo-set", Namespace: "default"}, &es); err != nil {
+		types.NamespacedName{Name: "demo-set", Namespace: nsDefault}, &es); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
 
-	// Available should be False with VTC reason
 	avail := meta.FindStatusCondition(es.Status.Conditions, "Available")
 	if avail == nil {
 		t.Fatal("Expected Available condition")
@@ -684,21 +1474,12 @@ func TestReconcile_vtcNotFound_updatesAllConditionsAndCounters(t *testing.T) {
 		t.Errorf("Available reason = %q, want VirtualTargetClassNotFound", avail.Reason)
 	}
 
-	// Counters should reflect current exporter state, not be stale
 	assertInt32(t, "Replicas", es.Status.Replicas, 2)
 	assertInt32(t, "ReadyReplicas", es.Status.ReadyReplicas, 1)
 	assertInt32(t, "UnavailableReplicas", es.Status.UnavailableReplicas, 1)
 
-	// Degraded should reflect current state
 	degraded := meta.FindStatusCondition(es.Status.Conditions, "Degraded")
 	if degraded == nil {
 		t.Fatal("Expected Degraded condition")
-	}
-}
-
-func assertInt32(t *testing.T, field string, got, want int32) {
-	t.Helper()
-	if got != want {
-		t.Errorf("%s = %d, want %d", field, got, want)
 	}
 }

--- a/controller/internal/exporterset/suite_test.go
+++ b/controller/internal/exporterset/suite_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Jumpstarter Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exporterset
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
+	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
+)
+
+var (
+	envTestCfg    *rest.Config
+	envTestClient client.Client
+	envTestEnv    *envtest.Environment
+	envTestCtx    context.Context
+	envTestCancel context.CancelFunc
+)
+
+func TestExporterSetEnvTest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ExporterSet Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	envTestCtx, envTestCancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	envTestEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "deploy", "operator", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+			fmt.Sprintf("1.30.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	var err error
+	envTestCfg, err = envTestEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(envTestCfg).NotTo(BeNil())
+
+	err = jumpstarterdevv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = virtualtargetv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	envTestClient, err = client.New(envTestCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(envTestClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	envTestCancel()
+	err := envTestEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
This PR implements the ExporterSet scaling engine described in JEP-0014.

At the core is a new reconciler that manages a pool of virtual exporters. On each reconcile it evaluates the scaling rules in priority order:

- Ensures the pool never drops below minReplicas.
- Maintains a warm pool by keeping at least minAvailableReplicas ready and unleased exporters available.
- Scales up on demand when there are pending Leases and no available capacity.
- Scales down gracefully by disabling one idle exporter per cooldown period, waiting for any active lease to drain, and deleting it on a subsequent reconcile.

To avoid duplicate scale-downs caused by stale informer cache state, the reconciler keeps an in-memory guard that prevents the same exporter from being disabled twice.

The reconciler establishes the ownership hierarchy ExporterSet → Exporter → Pod, allowing k8s garbage collection to clean up all resources when an ExporterSet is deleted. If Pod creation fails, the corresponding Exporter is rolled back immediately to avoid leaving orphaned exporters in the pool. VirtualTargetClass and ExporterSet parameters are deep-merged so pool-specific configuration can override class defaults.

The controller watches:

- Exporters as owned children.
- Pods as grandchildren through a label-based mapper.
- VirtualTargetClass resources to reconcile configuration changes.
- Leases so pending requests immediately trigger demand-driven scale-up.

This PR includes the following test coverage:
- Unit tests covering all scale-up and scale-down scenarios.
- Cooldown behavior.
- Ownership and garbage collection behavior.
- Lease-to-ExporterSet mapping.
- Parameter merging and rollback on Pod creation failures.
- Envtest integration tests covering the full reconcile lifecycle against a real API server.