### PR TITLE
Disable fail-fast strategy in build-images workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -27,6 +27,7 @@ jobs:
       attestations: write
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Controller images


### PR DESCRIPTION
One failed image building should not cancel the other images being built. This happens sometimes due to infra issues or other reasons, but we always want as many images as possible.