### PR TITLE
fix(cli): suppress noisy warnings and retry transparently on token refresh

### DIFF
--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions.py
@@ -211,13 +211,26 @@ def handle_exceptions(func):
     return wrapped
 
 
+class _ReauthSucceeded(Exception):
+    """Internal signal that re-authentication succeeded and the caller should retry."""
+
+
 def _handle_connection_error_with_reauth(exc, login_func):
-    """Handle ConnectionError with reauthentication logic."""
+    """Handle ConnectionError with reauthentication logic.
+
+    If the error indicates an expired token, triggers re-authentication via
+    ``login_func`` and raises ``_ReauthSucceeded`` so the calling decorator
+    can retry the original operation.  Non-expired connection errors are
+    surfaced as ``ClickExceptionRed`` directly.
+    """
     if "expired" in str(exc).lower():
-        click.echo(click.style("Token is expired, triggering re-authentication", fg="red"))
+        click.echo(click.style("Token is expired, triggering re-authentication", fg="yellow"))
         config = exc.get_config()
-        login_func(config)
-        raise ClickExceptionRed("Please try again now") from None
+        try:
+            login_func(config)
+        except Exception as reauth_exc:
+            raise ClickExceptionRed(f"Re-authentication failed: {reauth_exc}") from None
+        raise _ReauthSucceeded() from None
     else:
         raise ClickExceptionRed(str(exc)) from None
 
@@ -239,26 +252,78 @@ def _handle_exception_group_with_reauth(eg, login_func) -> NoReturn:
     raise eg
 
 
+def _raise_if_mappable(exc: BaseException) -> None:
+    """Raise a user-friendly ClickException if *exc* maps to one, otherwise return."""
+    if cli_exc := _map_cli_exception(exc):
+        raise cli_exc from None
+
+
+def _try_reauth_or_handle(handler, exc, login_func, *, allow_reauth: bool) -> bool:
+    """Attempt re-auth via *handler*; return True if re-auth succeeded.
+
+    When *allow_reauth* is False the handler is called without catching
+    ``_ReauthSucceeded`` — any re-auth signal propagates as a normal error.
+    """
+    if allow_reauth:
+        try:
+            handler(exc, login_func)
+        except _ReauthSucceeded:
+            return True
+    else:
+        handler(exc, login_func)
+    return False
+
+
+def _call_with_exception_handling(func, args, kwargs, login_func, *, allow_reauth: bool):
+    """Call *func* and handle exceptions, optionally allowing re-authentication.
+
+    Returns ``(result, needs_retry)`` where *needs_retry* is ``True`` when
+    re-authentication succeeded and the caller should retry the call.
+    """
+    try:
+        return func(*args, **kwargs), False
+    except _ReauthSucceeded:
+        raise ClickExceptionRed("Unexpected re-auth signal") from None
+    except BaseExceptionGroup as eg:
+        if _try_reauth_or_handle(_handle_exception_group_with_reauth, eg, login_func, allow_reauth=allow_reauth):
+            return None, True
+    except (ConnectionError, JumpstarterException, click.ClickException) as e:
+        if isinstance(e, ConnectionError) and not allow_reauth:
+            raise ClickExceptionRed(str(e)) from None
+        if _try_reauth_or_handle(_handle_single_exception_with_reauth, e, login_func, allow_reauth=allow_reauth):
+            return None, True
+    except Exception as e:
+        _raise_if_mappable(e)
+        raise
+    except KeyboardInterrupt as e:
+        _raise_if_mappable(e)
+        raise
+    return None, False  # pragma: no cover — handlers above always raise or return
+
+
 def handle_exceptions_with_reauthentication(login_func):
-    """Decorator to handle exceptions in blocking functions, including those wrapped in BaseExceptionGroup."""
+    """Decorator to handle exceptions in blocking functions, including those wrapped in BaseExceptionGroup.
+
+    When a ``ConnectionError`` with an expired-token message is caught, the
+    decorator triggers re-authentication via *login_func* and **retries the
+    original call exactly once**.  If the retry also fails, the error is
+    surfaced normally — no infinite loop.
+    """
 
     def decorator(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except BaseExceptionGroup as eg:
-                _handle_exception_group_with_reauth(eg, login_func)
-            except (ConnectionError, JumpstarterException, click.ClickException) as e:
-                _handle_single_exception_with_reauth(e, login_func)
-            except Exception as e:
-                if cli_exc := _map_cli_exception(e):
-                    raise cli_exc from None
-                raise
-            except KeyboardInterrupt as e:
-                if cli_exc := _map_cli_exception(e):
-                    raise cli_exc from None
-                raise
+            result, needs_retry = _call_with_exception_handling(
+                func, args, kwargs, login_func, allow_reauth=True
+            )
+            if not needs_retry:
+                return result
+
+            click.echo(click.style("Re-authenticated, retrying...", fg="yellow"))
+            result, _ = _call_with_exception_handling(
+                func, args, kwargs, login_func, allow_reauth=False
+            )
+            return result
 
         return wrapped
 

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
@@ -1,5 +1,6 @@
 import ssl
 from json import JSONDecodeError
+from unittest.mock import MagicMock
 
 import click
 import pytest
@@ -9,6 +10,8 @@ from jumpstarter_cli_common.exceptions import (
     handle_exceptions,
     handle_exceptions_with_reauthentication,
 )
+
+from jumpstarter.common.exceptions import ConnectionError as JmpConnectionError
 
 
 @pytest.fixture
@@ -183,3 +186,79 @@ def test_handle_exceptions_maps_grpc_failed_precondition_without_details() -> No
 
     with pytest.raises(click.ClickException, match="precondition"):
         grpc_precondition_no_details_fn()
+
+
+# ---------------------------------------------------------------------------
+# Tests for automatic retry after successful re-authentication (NS-REQ-1/3)
+# ---------------------------------------------------------------------------
+
+
+def _make_expired_connection_error():
+    """Create a ConnectionError that looks like an expired-token error."""
+    exc = JmpConnectionError("token expired")
+    config = MagicMock(name="client_config")
+    exc.set_config(config)
+    return exc, config
+
+
+def test_reauth_retries_on_success() -> None:
+    """After successful re-auth the decorator retries and returns the result (TS-NS-1)."""
+    call_count = 0
+
+    def login_func(_config):
+        pass  # success
+
+    @handle_exceptions_with_reauthentication(login_func)
+    def fn():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            exc, _ = _make_expired_connection_error()
+            raise exc
+        return "sentinel"
+
+    result = fn()
+    assert result == "sentinel"
+    assert call_count == 2
+
+
+def test_reauth_failure_raises_click_exception() -> None:
+    """If login_func raises, the decorator surfaces a ClickException (TS-NS-2)."""
+    call_count = 0
+
+    def login_func(_config):
+        raise RuntimeError("IdP unreachable")
+
+    @handle_exceptions_with_reauthentication(login_func)
+    def fn():
+        nonlocal call_count
+        call_count += 1
+        exc, _ = _make_expired_connection_error()
+        raise exc
+
+    with pytest.raises(click.ClickException, match="Re-authentication failed"):
+        fn()
+
+    # The wrapped function should have been called only once (no retry).
+    assert call_count == 1
+
+
+def test_reauth_retry_bounded_to_one_attempt() -> None:
+    """The decorator retries at most once; a second failure surfaces normally (TS-NS-3)."""
+    call_count = 0
+
+    def login_func(_config):
+        pass  # always succeeds
+
+    @handle_exceptions_with_reauthentication(login_func)
+    def fn():
+        nonlocal call_count
+        call_count += 1
+        exc, _ = _make_expired_connection_error()
+        raise exc
+
+    with pytest.raises(click.ClickException):
+        fn()
+
+    # Original call + exactly one retry = 2 total.
+    assert call_count == 2

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/exceptions_test.py
@@ -211,7 +211,7 @@ def test_reauth_retries_on_success() -> None:
     @handle_exceptions_with_reauthentication(login_func)
     def fn():
         nonlocal call_count
-        call_count += 1
+        call_count += 1  # ty: ignore[unresolved-reference]
         if call_count == 1:
             exc, _ = _make_expired_connection_error()
             raise exc
@@ -232,7 +232,7 @@ def test_reauth_failure_raises_click_exception() -> None:
     @handle_exceptions_with_reauthentication(login_func)
     def fn():
         nonlocal call_count
-        call_count += 1
+        call_count += 1  # ty: ignore[unresolved-reference]
         exc, _ = _make_expired_connection_error()
         raise exc
 
@@ -253,7 +253,7 @@ def test_reauth_retry_bounded_to_one_attempt() -> None:
     @handle_exceptions_with_reauthentication(login_func)
     def fn():
         nonlocal call_count
-        call_count += 1
+        call_count += 1  # ty: ignore[unresolved-reference]
         exc, _ = _make_expired_connection_error()
         raise exc
 

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
@@ -2,6 +2,7 @@ import json
 import os
 import ssl
 import time
+import warnings
 from dataclasses import dataclass
 from functools import wraps
 from typing import ClassVar
@@ -12,11 +13,14 @@ import click
 from aiohttp import web
 from anyio import create_memory_object_stream
 from anyio.to_thread import run_sync
-from authlib.integrations.requests_client import OAuth2Session
-from joserfc.jws import extract_compact
-from yarl import URL
 
-from jumpstarter.config.env import JMP_OIDC_CALLBACK_PORT
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"authlib\.")
+
+from authlib.integrations.requests_client import OAuth2Session  # noqa: E402
+from joserfc.jws import extract_compact  # noqa: E402
+from yarl import URL  # noqa: E402
+
+from jumpstarter.config.env import JMP_OIDC_CALLBACK_PORT  # noqa: E402
 
 
 def _get_ssl_context() -> ssl.SSLContext:
@@ -78,7 +82,15 @@ class Config:
 
     def client(self, **kwargs):
         session = OAuth2Session(client_id=self.client_id, scope=self._scopes(), **kwargs)
-        session.verify = False if self.insecure_tls else (os.environ.get("SSL_CERT_FILE") or certifi.where())
+        if self.insecure_tls:
+            session.verify = False
+            # The user has already opted into insecure TLS (via --insecure flag
+            # or config), so urllib3's InsecureRequestWarning is redundant noise.
+            import urllib3
+
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        else:
+            session.verify = os.environ.get("SSL_CERT_FILE") or certifi.where()
         return session
 
     async def token_exchange_grant(self, token: str, **kwargs):

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc_test.py
@@ -1,4 +1,5 @@
 import ssl
+import warnings
 
 from jumpstarter_cli_common.oidc import Config, _get_ssl_context
 
@@ -23,3 +24,40 @@ class TestGetSslContext:
     def test_returns_ssl_context(self) -> None:
         ctx = _get_ssl_context()
         assert isinstance(ctx, ssl.SSLContext)
+
+
+class TestAuthlibDeprecationWarningSuppressed:
+    """Importing oidc must not emit AuthlibDeprecationWarning."""
+
+    def test_no_authlib_deprecation_warning_on_import(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import importlib
+
+            import jumpstarter_cli_common.oidc
+
+            importlib.reload(jumpstarter_cli_common.oidc)
+
+        authlib_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning) and "authlib" in str(w.message).lower()
+        ]
+        assert authlib_warnings == [], f"Unexpected authlib deprecation warnings: {authlib_warnings}"
+
+
+class TestInsecureRequestWarningSuppressed:
+    """Config.client() with insecure_tls=True suppresses InsecureRequestWarning."""
+
+    def test_urllib3_insecure_request_warning_suppressed(self) -> None:
+        import urllib3.exceptions
+
+        config = Config(issuer="https://auth.example.com", client_id="test", insecure_tls=True)
+        config.client()
+
+        matching_filters = [
+            f
+            for f in warnings.filters
+            if len(f) >= 3 and f[0] == "ignore" and f[2] is urllib3.exceptions.InsecureRequestWarning
+        ]
+        assert len(matching_filters) > 0, "InsecureRequestWarning was not suppressed"

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -365,11 +365,27 @@ def _make_expired_jwt() -> str:
     return f"{header}.{payload}.{sig}"
 
 
+def _make_valid_jwt() -> str:
+    """Create a JWT with an exp claim in the future (no signature verification needed)."""
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = b64url(json.dumps({"exp": int(time.time()) + 3600, "iss": "https://example.com"}).encode())
+    sig = b64url(b"fakesig")
+    return f"{header}.{payload}.{sig}"
+
+
 def test_expired_token_triggers_reauth():
     config = _DummyConfig()
     config.token = _make_expired_jwt()
 
-    login_mock = Mock()
+    def _login_side_effect(cfg):
+        # Simulate successful re-authentication by updating the token
+        cfg.token = _make_valid_jwt()
+
+    login_mock = Mock(side_effect=_login_side_effect)
 
     @handle_exceptions_with_reauthentication(login_mock)
     def run_shell():
@@ -385,8 +401,11 @@ def test_expired_token_triggers_reauth():
             None,
         )
 
-    with pytest.raises(click.ClickException, match="Please try again now"):
-        run_shell()
+    with patch(
+        "jumpstarter_cli.shell._run_shell_with_lease_async",
+        new=AsyncMock(return_value=0),
+    ):
+        run_shell()  # Should succeed after retry — no exception raised
 
     login_mock.assert_called_once_with(config)
 


### PR DESCRIPTION
## Summary

Suppress noisy warnings and retry CLI commands transparently after token refresh, improving the `jmp` CLI user experience.

- Suppress `AuthlibDeprecationWarning` emitted unconditionally by authlib's internal import chain
- Suppress `InsecureRequestWarning` from urllib3 when user has already opted into `--insecure` TLS
- Auto-retry the original CLI command after successful re-authentication instead of showing "Error: Please try again now"

Closes https://github.com/mickume/jumpstarter/issues/17

## Changes

| File | Change |
|------|--------|
| `jumpstarter_cli_common/oidc.py` | Add `warnings.filterwarnings` for authlib deprecation + urllib3 InsecureRequestWarning suppression |
| `jumpstarter_cli_common/exceptions.py` | Refactor `handle_exceptions_with_reauthentication` to retry the original call after successful re-auth |
| `jumpstarter_cli_common/exceptions_test.py` | Add tests for retry-on-success, failure propagation, and bounded retry |
| `jumpstarter_cli_common/oidc_test.py` | Add tests for warning suppression |
| `jumpstarter_cli/shell_test.py` | Update `test_expired_token_triggers_reauth` to match new retry behavior |

## Tests

- All 32 `jumpstarter-cli-common` tests pass
- `ty` type checker passes ("All checks passed!")
- `ruff` linter passes

## Test plan

- [ ] Verify `jmp get exporters` with an expired token no longer shows `AuthlibDeprecationWarning`
- [ ] Verify no `InsecureRequestWarning` when using `--insecure` TLS
- [ ] Verify expired token triggers re-auth and retries the command automatically
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
