### PR TITLE
feat: ExporterSet Pod provisioning with credential and config injection (JEP-0014)

### DIFF
--- a/controller/api/virtualtarget/v1alpha1/exporterset_types.go
+++ b/controller/api/virtualtarget/v1alpha1/exporterset_types.go
@@ -33,6 +33,11 @@ const (
 
 // DriverConfig defines a single driver entry in an exporter template.
 type DriverConfig struct {
+	// Name is the key used in the exporter config's export map (e.g. "power", "serial").
+	// If omitted the controller derives a name from the last segment of Type.
+	// +optional
+	Name string `json:"name,omitempty"`
+
 	// Type is the fully qualified Python driver class name.
 	Type string `json:"type"`
 

--- a/controller/cmd/exporter-set-controller/main.go
+++ b/controller/cmd/exporter-set-controller/main.go
@@ -101,6 +101,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// GRPC_ENDPOINT is the controller's gRPC address injected into each exporter
+	// sidecar config so it can connect back to the controller on startup.
+	// Example: "jumpstarter.my-lab.svc.cluster.local:8082"
+	// Defaults to "localhost:8082" when unset (useful for local development).
+	if ep := os.Getenv("GRPC_ENDPOINT"); ep == "" {
+		setupLog.Info("GRPC_ENDPOINT not set; exporter sidecars will connect to localhost:8082")
+	}
+
 	// Select the provisioner implementation based on the flag
 	prov, err := selectProvisioner(provisioner)
 	if err != nil {

--- a/controller/deploy/operator/config/crd/bases/virtualtarget.jumpstarter.dev_exportersets.yaml
+++ b/controller/deploy/operator/config/crd/bases/virtualtarget.jumpstarter.dev_exportersets.yaml
@@ -176,6 +176,11 @@ spec:
                             config:
                               description: Config holds driver-specific configuration.
                               x-kubernetes-preserve-unknown-fields: true
+                            name:
+                              description: Name is the key used in the exporter config's
+                                export map (e.g. "power", "serial"). If omitted the
+                                controller derives a name from the last segment of Type.
+                              type: string
                             type:
                               description: Type is the fully qualified Python driver
                                 class name.

--- a/controller/internal/exporterset/config.go
+++ b/controller/internal/exporterset/config.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Jumpstarter Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exporterset
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
+	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+const (
+	configVolumeName      = "exporter-config"
+	configMountPath       = "/etc/jumpstarter/exporters" // exporter reads <name>.yaml from here
+	exporterContainerName = "exporter"                   // init-container name in the sidecar Pod
+)
+
+// exporterConfigMeta mirrors the metadata block of ExporterConfig YAML.
+type exporterConfigMeta struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// exporterConfigTLS mirrors the tls block of ExporterConfig YAML.
+type exporterConfigTLS struct {
+	CA       string `json:"ca,omitempty"`
+	Insecure bool   `json:"insecure,omitempty"`
+}
+
+// exporterConfigDriver mirrors a single entry in the export map.
+type exporterConfigDriver struct {
+	Type   string      `json:"type"`
+	Config interface{} `json:"config,omitempty"`
+}
+
+// exporterConfigYAML is the in-memory form of the ExporterConfig document.
+// Fields use json tags because sigs.k8s.io/yaml marshals through JSON.
+type exporterConfigYAML struct {
+	APIVersion string                          `json:"apiVersion"`
+	Kind       string                          `json:"kind"`
+	Metadata   exporterConfigMeta              `json:"metadata"`
+	Endpoint   string                          `json:"endpoint"`
+	Token      string                          `json:"token"`
+	TLS        *exporterConfigTLS              `json:"tls,omitempty"`
+	Export     map[string]exporterConfigDriver `json:"export,omitempty"`
+}
+
+// controllerEndpoint reads GRPC_ENDPOINT or falls back to localhost:8082.
+func controllerEndpoint() string {
+	if ep := os.Getenv("GRPC_ENDPOINT"); ep != "" {
+		return ep
+	}
+	return "localhost:8082"
+}
+
+// driverKey returns the export-map key for a DriverConfig: d.Name if set,
+// otherwise the last dot-segment of d.Type lowercased
+// (e.g. "jumpstarter_driver_power.driver.QemuPower" → "qemupower").
+func driverKey(d virtualtargetv1alpha1.DriverConfig, idx int) string {
+	if d.Name != "" {
+		return d.Name
+	}
+	parts := strings.Split(d.Type, ".")
+	if last := strings.ToLower(parts[len(parts)-1]); last != "" {
+		return last
+	}
+	return fmt.Sprintf("driver%d", idx)
+}
+
+// renderExporterConfigYAML builds the ExporterConfig YAML for the given exporter,
+// including its JWT token, optional CA bundle, and driver list.
+func renderExporterConfigYAML(
+	exporter *jumpstarterdevv1alpha1.Exporter,
+	token string,
+	caBundle string,
+	drivers []virtualtargetv1alpha1.DriverConfig,
+) (string, error) {
+	cfg := exporterConfigYAML{
+		APIVersion: "jumpstarter.dev/v1alpha1",
+		Kind:       "ExporterConfig",
+		Metadata: exporterConfigMeta{
+			Namespace: exporter.Namespace,
+			Name:      exporter.Name,
+		},
+		Endpoint: controllerEndpoint(),
+		Token:    token,
+	}
+
+	if caBundle != "" {
+		cfg.TLS = &exporterConfigTLS{CA: caBundle}
+	}
+
+	if len(drivers) > 0 {
+		cfg.Export = make(map[string]exporterConfigDriver, len(drivers))
+		for i, d := range drivers {
+			key := driverKey(d, i)
+			if _, exists := cfg.Export[key]; exists {
+				return "", fmt.Errorf("duplicate driver key %q in ExporterSet drivers", key)
+			}
+			entry := exporterConfigDriver{Type: d.Type}
+			if d.Config != nil {
+				var parsed interface{}
+				if err := json.Unmarshal(d.Config.Raw, &parsed); err != nil {
+					return "", fmt.Errorf("unmarshal config for driver %q: %w", key, err)
+				}
+				entry.Config = parsed
+			}
+			cfg.Export[key] = entry
+		}
+	}
+
+	out, err := sigsyaml.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("marshal ExporterConfig for %s/%s: %w",
+			exporter.Namespace, exporter.Name, err)
+	}
+	return string(out), nil
+}

--- a/controller/internal/exporterset/config_test.go
+++ b/controller/internal/exporterset/config_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The Jumpstarter Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exporterset
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
+	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRenderExporterConfigYAML_minimal(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-exporter",
+			Namespace: nsDefault,
+		},
+	}
+
+	got, err := renderExporterConfigYAML(exp, "tok123", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, got, "apiVersion: jumpstarter.dev/v1alpha1")
+	assertContains(t, got, "kind: ExporterConfig")
+	assertContains(t, got, "name: my-exporter")
+	assertContains(t, got, "namespace: default")
+	assertContains(t, got, "token: tok123")
+	assertNotContains(t, got, "tls:")
+	assertNotContains(t, got, "export:")
+}
+
+func TestRenderExporterConfigYAML_withCABundle(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{Name: "exp", Namespace: nsDefault},
+	}
+
+	got, err := renderExporterConfigYAML(exp, "tok", "-----BEGIN CERTIFICATE-----\nABC\n", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, got, "tls:")
+	assertContains(t, got, "ca:")
+	assertContains(t, got, "BEGIN CERTIFICATE")
+}
+
+func TestRenderExporterConfigYAML_withDrivers_namedExplicit(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{Name: "exp", Namespace: nsDefault},
+	}
+
+	drivers := []virtualtargetv1alpha1.DriverConfig{
+		{Name: "power", Type: "jumpstarter_driver_power.driver.QemuPower"},
+		{Name: "serial", Type: "jumpstarter_driver_serial.driver.QemuSerial"},
+	}
+
+	got, err := renderExporterConfigYAML(exp, "tok", "", drivers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, got, "export:")
+	assertContains(t, got, "power:")
+	assertContains(t, got, "serial:")
+	assertContains(t, got, "QemuPower")
+	assertContains(t, got, "QemuSerial")
+}
+
+func TestRenderExporterConfigYAML_withDrivers_derivedName(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{Name: "exp", Namespace: nsDefault},
+	}
+
+	drivers := []virtualtargetv1alpha1.DriverConfig{
+		{Type: "jumpstarter_driver_power.driver.QemuPower"},
+	}
+
+	got, err := renderExporterConfigYAML(exp, "tok", "", drivers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Name derived: lower-case last segment = "qemupower"
+	assertContains(t, got, "qemupower:")
+}
+
+func TestRenderExporterConfigYAML_withDriverConfig(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{Name: "exp", Namespace: nsDefault},
+	}
+
+	raw, _ := json.Marshal(map[string]interface{}{"port": 22, "host": "192.168.1.1"})
+	drivers := []virtualtargetv1alpha1.DriverConfig{
+		{
+			Name:   "network",
+			Type:   "jumpstarter_driver_network.driver.TcpNetwork",
+			Config: &apiextensionsv1.JSON{Raw: raw},
+		},
+	}
+
+	got, err := renderExporterConfigYAML(exp, "tok", "", drivers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, got, "network:")
+	assertContains(t, got, "TcpNetwork")
+	assertContains(t, got, "port:")
+	assertContains(t, got, "host:")
+}
+
+func TestDriverKey_explicit(t *testing.T) {
+	d := virtualtargetv1alpha1.DriverConfig{Name: "power", Type: "some.Type"}
+	if got := driverKey(d, 0); got != "power" {
+		t.Errorf("got %q, want %q", got, "power")
+	}
+}
+
+func TestDriverKey_derived(t *testing.T) {
+	d := virtualtargetv1alpha1.DriverConfig{Type: "a.b.c.MyDriver"}
+	if got := driverKey(d, 0); got != "mydriver" {
+		t.Errorf("got %q, want %q", got, "mydriver")
+	}
+}
+
+func TestDriverKey_fallback(t *testing.T) {
+	d := virtualtargetv1alpha1.DriverConfig{Type: ""}
+	if got := driverKey(d, 3); got != "driver3" {
+		t.Errorf("got %q, want %q", got, "driver3")
+	}
+}
+
+func TestInjectConfigVolume_mountsExporterContainer(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "exporter"}},
+		},
+	}
+
+	ok := injectConfigVolume(pod, "my-exp")
+	if !ok {
+		t.Fatal("expected injectConfigVolume to return true")
+	}
+	if len(pod.Spec.Volumes) == 0 {
+		t.Fatal("expected volume to be added")
+	}
+	if len(pod.Spec.InitContainers[0].VolumeMounts) == 0 {
+		t.Fatal("expected volume mount to be added to exporter container")
+	}
+	if pod.Spec.InitContainers[0].VolumeMounts[0].MountPath != configMountPath {
+		t.Errorf("unexpected mount path: %s", pod.Spec.InitContainers[0].VolumeMounts[0].MountPath)
+	}
+}
+
+func TestInjectConfigVolume_returnsFalseWhenContainerMissing(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "not-exporter"}},
+		},
+	}
+
+	ok := injectConfigVolume(pod, "my-exp")
+	if ok {
+		t.Error("expected injectConfigVolume to return false when exporter container absent")
+	}
+	// Volume is still added even when mount can't be set.
+	if len(pod.Spec.Volumes) == 0 {
+		t.Error("expected volume to be added even when mount fails")
+	}
+}
+
+func assertContains(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Errorf("expected output to contain %q\ngot:\n%s", sub, s)
+	}
+}
+
+func assertNotContains(t *testing.T, s, sub string) {
+	t.Helper()
+	if strings.Contains(s, sub) {
+		t.Errorf("expected output NOT to contain %q\ngot:\n%s", sub, s)
+	}
+}
+
+func TestRenderExporterConfigYAML_duplicateDriverKey_returnsError(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{Name: "exp-1", Namespace: "default"},
+	}
+	drivers := []virtualtargetv1alpha1.DriverConfig{
+		{Name: "power", Type: "jumpstarter_driver_power.driver.QemuPower"},
+		{Name: "power", Type: "jumpstarter_driver_power.driver.QemuPower2"},
+	}
+	_, err := renderExporterConfigYAML(exp, "tok", "", drivers)
+	if err == nil {
+		t.Fatal("expected error for duplicate driver key, got nil")
+	}
+}
+
+func TestRenderExporterConfigYAML_derivedDuplicateKey_returnsError(t *testing.T) {
+	exp := &jumpstarterdevv1alpha1.Exporter{
+		ObjectMeta: metav1.ObjectMeta{Name: "exp-1", Namespace: "default"},
+	}
+	// Both types end in ".Serial" — derived key "serial" would collide.
+	drivers := []virtualtargetv1alpha1.DriverConfig{
+		{Type: "vendor_a.driver.Serial"},
+		{Type: "vendor_b.driver.Serial"},
+	}
+	_, err := renderExporterConfigYAML(exp, "tok", "", drivers)
+	if err == nil {
+		t.Fatal("expected error for derived duplicate key, got nil")
+	}
+}

--- a/controller/internal/exporterset/exporterset_controller_test.go
+++ b/controller/internal/exporterset/exporterset_controller_test.go
@@ -131,6 +131,25 @@ var _ = Describe("ExporterSet Controller", func() {
 					"Exporter %s should be controller-owned by ExporterSet", exp.Name)
 			}
 
+			By("Simulating ExporterReconciler issuing credentials for each Exporter")
+			for i := range exporterList.Items {
+				exp := &exporterList.Items[i]
+				credSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      exp.Name + "-exporter",
+						Namespace: ns,
+					},
+					Data: map[string][]byte{"token": []byte("test-token")},
+				}
+				Expect(envTestClient.Create(envTestCtx, credSecret)).To(Succeed())
+				exp.Status.Credential = &corev1.LocalObjectReference{Name: credSecret.Name}
+				Expect(envTestClient.Status().Update(envTestCtx, exp)).To(Succeed())
+			}
+
+			By("Reconciling once more to trigger Pod creation")
+			_, err := reconciler.Reconcile(envTestCtx, req)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("Verifying Pods were created with correct ownership")
 			var podList corev1.PodList
 			Eventually(func() int {

--- a/controller/internal/exporterset/reconciler.go
+++ b/controller/internal/exporterset/reconciler.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -65,6 +66,9 @@ const (
 	labelExporterSetName = "exporterset.jumpstarter.dev/name"
 
 	defaultScaleDownCooldown = 5 * time.Minute
+
+	// kindExporter is the Kind string used in OwnerReference lookups.
+	kindExporter = "Exporter"
 )
 
 // ExporterSetReconciler reconciles an ExporterSet object.
@@ -93,7 +97,7 @@ type ExporterSetReconciler struct {
 // +kubebuilder:rbac:groups=jumpstarter.dev,resources=leases,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // Reconcile is the main reconciliation loop for ExporterSet resources.
@@ -239,6 +243,17 @@ func (r *ExporterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	// Create config Secrets + Pods for Exporters that now have credentials.
+	// Returns true when some Exporters are still waiting; we requeue to retry
+	// rather than relying solely on the Owns(&Exporter{}) watch event.
+	waiting, err := r.ensureExporterPods(ctx, &exporterSet, &vtc, mergedParameters, ownedExporters)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if waiting && result.RequeueAfter == 0 {
+		result.RequeueAfter = 5 * time.Second
+	}
+
 	// Update status counts, conditions, and emit events.
 	if err := r.reconcileStatusCounts(ctx, &exporterSet); err != nil {
 		return ctrl.Result{}, err
@@ -285,12 +300,14 @@ func computePoolState(exporters []jumpstarterdevv1alpha1.Exporter) poolState {
 	return s
 }
 
-// scaleUp creates Exporter + Pod pairs (ExporterSet → Exporter → Pod).
+// scaleUp creates Exporter CRs (ExporterSet → Exporter).
+// Pod creation is handled separately by ensureExporterPods once the
+// ExporterReconciler has issued credentials for the new Exporters.
 func (r *ExporterSetReconciler) scaleUp(
 	ctx context.Context,
 	es *virtualtargetv1alpha1.ExporterSet,
-	vtc *virtualtargetv1alpha1.VirtualTargetClass,
-	mergedParameters map[string]interface{},
+	_ *virtualtargetv1alpha1.VirtualTargetClass,
+	_ map[string]interface{},
 	count int32,
 ) error {
 	logger := log.FromContext(ctx)
@@ -318,37 +335,290 @@ func (r *ExporterSetReconciler) scaleUp(
 
 		logger.Info("created Exporter", "exporter", exporter.Name)
 
-		pod, err := r.Provisioner.RenderPod(ctx, es, vtc, mergedParameters)
-		if err != nil {
-			return fmt.Errorf("unable to render Pod for Exporter %s: %w", exporter.Name, err)
-		}
-
-		if pod.Labels == nil {
-			pod.Labels = make(map[string]string)
-		}
-		pod.Labels[labelExporterSetName] = es.Name
-
-		// Exporter owns Pod; the label bridges the grandparent lookup.
-		if err := ctrl.SetControllerReference(exporter, pod, r.Scheme); err != nil {
-			return fmt.Errorf("unable to set owner reference on Pod: %w", err)
-		}
-
-		if err := r.Create(ctx, pod); err != nil {
-			if delErr := r.Delete(ctx, exporter); delErr != nil {
-				logger.Error(delErr, "failed to roll back Exporter after Pod creation failure", "exporter", exporter.Name)
-			}
-			return fmt.Errorf("unable to create Pod for Exporter %s: %w", exporter.Name, err)
-		}
-
-		logger.Info("created Pod for Exporter", "exporter", exporter.Name, "pod", pod.Name)
-
 		if r.Recorder != nil {
 			r.Recorder.Eventf(es, corev1.EventTypeNormal, "ScaleUp",
-				"Created Exporter %s with Pod %s", exporter.Name, pod.Name)
+				"Created Exporter %s", exporter.Name)
 		}
 	}
 
 	return nil
+}
+
+// ensureExporterPods creates a config Secret and Pod for each Exporter that
+// has credentials but no Pod yet. Config Secrets are always synced so token
+// rotation takes effect without a Pod restart (Kubernetes refreshes Secret-backed
+// volume mounts automatically).
+// Returns true if any Exporter is still waiting for its credential Secret.
+func (r *ExporterSetReconciler) ensureExporterPods(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+	vtc *virtualtargetv1alpha1.VirtualTargetClass,
+	mergedParameters map[string]interface{},
+	ownedExporters []jumpstarterdevv1alpha1.Exporter,
+) (waiting bool, err error) {
+	logger := log.FromContext(ctx)
+
+	// Build a set of Exporter names that already have a Pod.
+	podsByExporter, err := r.listPodsByExporter(ctx, es)
+	if err != nil {
+		return false, err
+	}
+
+	// CA bundle is shared across all Exporters; read once per reconcile.
+	caBundle, err := r.readCABundle(ctx, vtc)
+	if err != nil {
+		return false, err
+	}
+
+	for i := range ownedExporters {
+		exp := &ownedExporters[i]
+
+		// Skip exporters that are being scaled down.
+		if !exp.IsEnabled() {
+			continue
+		}
+
+		// Wait for the ExporterReconciler to issue credentials.
+		if exp.Status.Credential == nil {
+			logger.V(1).Info("waiting for credential", "exporter", exp.Name)
+			waiting = true
+			continue
+		}
+
+		// Sync config Secret on every reconcile so token rotation takes effect.
+		// Secret-backed volume mounts update automatically; no Pod restart needed.
+		if err := r.syncConfigSecret(ctx, exp, caBundle, es.Spec.Template.Spec.Drivers); err != nil {
+			return waiting, err
+		}
+
+		// Pod already exists — nothing further to do.
+		if _, hasPod := podsByExporter[exp.Name]; hasPod {
+			continue
+		}
+
+		if err := r.createExporterPod(ctx, es, vtc, mergedParameters, exp); err != nil {
+			return waiting, err
+		}
+	}
+
+	return waiting, nil
+}
+
+// syncConfigSecret creates or updates the per-exporter config Secret so the
+// exporter sidecar always has a fresh token and correct configuration.
+func (r *ExporterSetReconciler) syncConfigSecret(
+	ctx context.Context,
+	exp *jumpstarterdevv1alpha1.Exporter,
+	caBundle string,
+	drivers []virtualtargetv1alpha1.DriverConfig,
+) error {
+	token, err := r.readCredentialToken(ctx, exp)
+	if err != nil {
+		return fmt.Errorf("read credential for %s: %w", exp.Name, err)
+	}
+
+	configYAML, err := renderExporterConfigYAML(exp, token, caBundle, drivers)
+	if err != nil {
+		return fmt.Errorf("render config for %s: %w", exp.Name, err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      exp.Name + "-config",
+			Namespace: exp.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		// Set inside the mutation so it's applied on both create and update.
+		if err := ctrl.SetControllerReference(exp, secret, r.Scheme); err != nil {
+			return fmt.Errorf("set owner on config Secret for %s: %w", exp.Name, err)
+		}
+		secret.Data = map[string][]byte{
+			exp.Name + ".yaml": []byte(configYAML),
+		}
+		return nil
+	})
+	return err
+}
+
+// createExporterPod issues a Pod for a single Exporter that has credentials
+// but no Pod yet. The config Secret must already exist (syncConfigSecret).
+func (r *ExporterSetReconciler) createExporterPod(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+	vtc *virtualtargetv1alpha1.VirtualTargetClass,
+	mergedParameters map[string]interface{},
+	exp *jumpstarterdevv1alpha1.Exporter,
+) error {
+	logger := log.FromContext(ctx)
+
+	// Render base Pod from the provisioner and inject config + credentials.
+	pod, err := r.Provisioner.RenderPod(ctx, es, vtc, mergedParameters)
+	if err != nil {
+		return fmt.Errorf("render Pod for %s: %w", exp.Name, err)
+	}
+
+	if !injectConfigVolume(pod, exp.Name) {
+		logger.Info("exporter container not found in pod spec; config volume not mounted",
+			"exporter", exp.Name, "expectedContainer", exporterContainerName)
+	}
+
+	injectCredentialsSecretRef(pod, vtc)
+
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	pod.Labels[labelExporterSetName] = es.Name
+
+	// Exporter owns Pod; the label bridges the grandparent lookup.
+	if err := ctrl.SetControllerReference(exp, pod, r.Scheme); err != nil {
+		return fmt.Errorf("set owner on Pod for %s: %w", exp.Name, err)
+	}
+
+	if err := r.Create(ctx, pod); err != nil {
+		return fmt.Errorf("create Pod for %s: %w", exp.Name, err)
+	}
+
+	logger.Info("created Pod for Exporter", "exporter", exp.Name, "pod", pod.Name)
+
+	if r.Recorder != nil {
+		r.Recorder.Eventf(es, corev1.EventTypeNormal, "PodCreated",
+			"Created Pod %s for Exporter %s", pod.Name, exp.Name)
+	}
+
+	return nil
+}
+
+// readCredentialToken reads the JWT from the Exporter's credential Secret.
+func (r *ExporterSetReconciler) readCredentialToken(
+	ctx context.Context,
+	exp *jumpstarterdevv1alpha1.Exporter,
+) (string, error) {
+	var secret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      exp.Status.Credential.Name,
+		Namespace: exp.Namespace,
+	}, &secret); err != nil {
+		return "", fmt.Errorf("get credential Secret %q: %w", exp.Status.Credential.Name, err)
+	}
+
+	token, ok := secret.Data["token"]
+	if !ok {
+		return "", fmt.Errorf("credential Secret %q missing 'token' key", exp.Status.Credential.Name)
+	}
+
+	return string(token), nil
+}
+
+// readCABundle fetches PEM CA data from VTC.spec.caBundleConfigMapRef.
+// Returns an empty string when the field is not set.
+func (r *ExporterSetReconciler) readCABundle(
+	ctx context.Context,
+	vtc *virtualtargetv1alpha1.VirtualTargetClass,
+) (string, error) {
+	if vtc.Spec.CABundleConfigMapRef == nil {
+		return "", nil
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      vtc.Spec.CABundleConfigMapRef.Name,
+		Namespace: vtc.Namespace,
+	}, &cm); err != nil {
+		return "", fmt.Errorf("get CA bundle ConfigMap %q: %w",
+			vtc.Spec.CABundleConfigMapRef.Name, err)
+	}
+
+	key := vtc.Spec.CABundleConfigMapRef.Key
+	if key == "" {
+		key = "ca-bundle.crt"
+	}
+
+	ca, ok := cm.Data[key]
+	if !ok {
+		return "", fmt.Errorf("CA bundle ConfigMap %q missing key %q",
+			vtc.Spec.CABundleConfigMapRef.Name, key)
+	}
+
+	return ca, nil
+}
+
+// listPodsByExporter returns a set of Exporter names that already have a Pod.
+func (r *ExporterSetReconciler) listPodsByExporter(
+	ctx context.Context,
+	es *virtualtargetv1alpha1.ExporterSet,
+) (map[string]struct{}, error) {
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList,
+		client.InNamespace(es.Namespace),
+		client.MatchingLabels{labelExporterSetName: es.Name},
+	); err != nil {
+		return nil, fmt.Errorf("list Pods for ExporterSet %s: %w", es.Name, err)
+	}
+
+	byExporter := make(map[string]struct{}, len(podList.Items))
+	for i := range podList.Items {
+		for _, ref := range podList.Items[i].OwnerReferences {
+			if ref.Kind == kindExporter && ref.Controller != nil && *ref.Controller {
+				byExporter[ref.Name] = struct{}{}
+			}
+		}
+	}
+
+	return byExporter, nil
+}
+
+// injectConfigVolume adds the config Secret as a volume and mounts it in the
+// "exporter" init-container. Returns false if that container isn't found.
+func injectConfigVolume(pod *corev1.Pod, exporterName string) bool {
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: configVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: exporterName + "-config",
+			},
+		},
+	})
+
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == exporterContainerName {
+			pod.Spec.InitContainers[i].VolumeMounts = append(
+				pod.Spec.InitContainers[i].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      configVolumeName,
+					MountPath: configMountPath,
+					ReadOnly:  true,
+				},
+			)
+			return true
+		}
+	}
+
+	return false
+}
+
+// injectCredentialsSecretRef mounts VTC.credentialsSecretRef as env vars in
+// the runtime container. Used by API-backed provisioners; QEMU ignores it.
+func injectCredentialsSecretRef(pod *corev1.Pod, vtc *virtualtargetv1alpha1.VirtualTargetClass) {
+	if vtc.Spec.CredentialsSecretRef == nil {
+		return
+	}
+
+	envFrom := corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: vtc.Spec.CredentialsSecretRef.Name,
+			},
+		},
+	}
+
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].EnvFrom = append(
+			pod.Spec.Containers[i].EnvFrom,
+			envFrom,
+		)
+	}
 }
 
 // cleanupDisabledExporters deletes disabled, unleased exporters. Returns true if any were deleted.
@@ -654,7 +924,10 @@ func (r *ExporterSetReconciler) reconcileStatusCounts(
 	var pending, running, failed, unknown int32
 
 	for i := range podList.Items {
-		if !isOwnedBy(&podList.Items[i], es.UID) {
+		// Pods are owned by Exporters (not ExporterSets directly); skip any
+		// that lack a controller owner of Kind=Exporter to avoid counting
+		// stray pods that happen to share the selector labels.
+		if !isOwnedByKind(&podList.Items[i], kindExporter) {
 			continue
 		}
 		switch podList.Items[i].Status.Phase {
@@ -1050,6 +1323,17 @@ func (r *ExporterSetReconciler) countPendingLeases(
 func isOwnedBy(obj client.Object, ownerUID types.UID) bool {
 	for _, ref := range obj.GetOwnerReferences() {
 		if ref.UID == ownerUID && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
+// isOwnedByKind reports whether the object's controller owner has the given Kind.
+// Used for grandchild resources like Pods (owned by Exporter, not ExporterSet).
+func isOwnedByKind(obj client.Object, kind string) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind == kind && ref.Controller != nil && *ref.Controller {
 			return true
 		}
 	}

--- a/controller/internal/exporterset/reconciler_test.go
+++ b/controller/internal/exporterset/reconciler_test.go
@@ -18,6 +18,7 @@ package exporterset
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,7 +38,6 @@ import (
 const testExporterSetUID = types.UID("es-uid-1234")
 
 const (
-	kindExporter    = "Exporter"
 	kindExporterSet = "ExporterSet"
 	nsDefault       = "default"
 )
@@ -136,7 +136,7 @@ func newReconciler(t *testing.T, objs ...client.Object) (*ExporterSetReconciler,
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
-		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}, &jumpstarterdevv1alpha1.Exporter{}).
 		Build()
 	r := &ExporterSetReconciler{
 		Client:      c,
@@ -198,11 +198,12 @@ func makePod(name string, phase corev1.PodPhase) *corev1.Pod {
 			Name:      name,
 			Namespace: nsDefault,
 			Labels:    map[string]string{"exporterset": "demo-set"},
+			// Pods are owned by Exporters, not ExporterSets directly.
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "virtualtarget.jumpstarter.dev/v1alpha1",
-				Kind:       kindExporterSet,
-				Name:       "demo-set",
-				UID:        testExporterSetUID,
+				APIVersion: "jumpstarter.dev/v1alpha1",
+				Kind:       kindExporter,
+				Name:       name,
+				UID:        types.UID(name + "-uid"),
 				Controller: boolPtr(true),
 			}},
 		},
@@ -216,7 +217,7 @@ func reconcileAndGet(t *testing.T, objs ...client.Object) virtualtargetv1alpha1.
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
-		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}, &jumpstarterdevv1alpha1.Exporter{}).
 		Build()
 	r := &ExporterSetReconciler{
 		Client:      c,
@@ -281,9 +282,25 @@ func TestReconcile_scaleUp_noExporters_createsMinReplicas(t *testing.T) {
 		t.Fatalf("expected 2 Exporters (minReplicas), got %d", len(exporters))
 	}
 
+	// Phase 2: simulate ExporterReconciler issuing credentials for each Exporter.
+	for i := range exporters {
+		credSecret := makeCredentialSecret(exporters[i].Name)
+		if err := c.Create(context.Background(), credSecret); err != nil {
+			t.Fatalf("create credential secret: %v", err)
+		}
+		exporters[i].Status.Credential = &corev1.LocalObjectReference{
+			Name: exporters[i].Name + "-exporter",
+		}
+		if err := c.Status().Update(context.Background(), &exporters[i]); err != nil {
+			t.Fatalf("update exporter credential status: %v", err)
+		}
+	}
+
+	reconcileOnce(t, r)
+
 	pods := listPods(t, c)
 	if len(pods) != 2 {
-		t.Fatalf("expected 2 Pods, got %d", len(pods))
+		t.Fatalf("expected 2 Pods after credential issuance, got %d", len(pods))
 	}
 
 	// Verify Exporter is owned by ExporterSet
@@ -1432,7 +1449,7 @@ func TestReconcile_vtcNotFound_updatesAllConditionsAndCounters(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(esObj, makeVTC(), exp1, exp2).
-		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}).
+		WithStatusSubresource(&virtualtargetv1alpha1.ExporterSet{}, &jumpstarterdevv1alpha1.Exporter{}).
 		Build()
 	r := &ExporterSetReconciler{
 		Client:      c,
@@ -1481,5 +1498,205 @@ func TestReconcile_vtcNotFound_updatesAllConditionsAndCounters(t *testing.T) {
 	degraded := meta.FindStatusCondition(es.Status.Conditions, "Degraded")
 	if degraded == nil {
 		t.Fatal("Expected Degraded condition")
+	}
+}
+
+// makeExporterWithCredential returns a credentialed "exp-1" exporter
+// (as if ExporterReconciler ran first).
+func makeExporterWithCredential() *jumpstarterdevv1alpha1.Exporter {
+	exp := makeExporter("exp-1", false, false, true)
+	exp.Status.Credential = &corev1.LocalObjectReference{Name: "exp-1-exporter"}
+	return exp
+}
+
+// makeCredentialSecret returns the Secret that ExporterReconciler would create.
+func makeCredentialSecret(exporterName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      exporterName + "-exporter",
+			Namespace: nsDefault,
+		},
+		Data: map[string][]byte{"token": []byte("test-token-" + exporterName)},
+	}
+}
+
+func TestEnsureExporterPods_waitingWithoutCredential(t *testing.T) {
+	es := makeExporterSet()
+	r, _ := newReconciler(t, es, makeVTC(),
+		makeExporter("exp-1", false, false, true), // no credential yet
+	)
+
+	reconcileOnce(t, r)
+
+	// No Pods should be created since the exporter has no credential.
+	pods := listPods(t, r.Client)
+	if len(pods) != 0 {
+		t.Errorf("got %d pods, want 0 (credential not yet issued)", len(pods))
+	}
+}
+
+func TestEnsureExporterPods_createsPodWhenCredentialReady(t *testing.T) {
+	es := makeExporterSet()
+	exp := makeExporterWithCredential()
+	credSecret := makeCredentialSecret("exp-1")
+
+	r, _ := newReconciler(t, es, makeVTC(), exp, credSecret)
+
+	reconcileOnce(t, r)
+
+	// A config Secret should have been created.
+	var secrets corev1.SecretList
+	if err := r.List(context.Background(), &secrets,
+		client.InNamespace(nsDefault)); err != nil {
+		t.Fatal(err)
+	}
+	configFound := false
+	for _, s := range secrets.Items {
+		if s.Name == "exp-1-config" {
+			configFound = true
+			if _, ok := s.Data["exp-1.yaml"]; !ok {
+				t.Error("config Secret missing 'exp-1.yaml' key")
+			}
+		}
+	}
+	if !configFound {
+		t.Error("expected config Secret 'exp-1-config' not found")
+	}
+
+	// A Pod should have been created.
+	pods := listPods(t, r.Client)
+	if len(pods) == 0 {
+		t.Error("expected a Pod to be created, got none")
+	}
+}
+
+func TestEnsureExporterPods_idempotent(t *testing.T) {
+	es := makeExporterSet()
+	exp := makeExporterWithCredential()
+	credSecret := makeCredentialSecret("exp-1")
+
+	r, _ := newReconciler(t, es, makeVTC(), exp, credSecret)
+
+	reconcileOnce(t, r)
+	reconcileOnce(t, r) // second reconcile should not create another Pod
+
+	pods := listPods(t, r.Client)
+	if len(pods) != 1 {
+		t.Errorf("got %d pods after 2 reconciles, want 1 (idempotent)", len(pods))
+	}
+}
+
+func TestEnsureExporterPods_configSecretHasEndpointAndToken(t *testing.T) {
+	es := makeExporterSet()
+	exp := makeExporterWithCredential()
+	credSecret := makeCredentialSecret("exp-1")
+
+	r, _ := newReconciler(t, es, makeVTC(), exp, credSecret)
+	reconcileOnce(t, r)
+
+	var secret corev1.Secret
+	if err := r.Get(context.Background(),
+		types.NamespacedName{Name: "exp-1-config", Namespace: nsDefault},
+		&secret); err != nil {
+		t.Fatalf("config Secret not found: %v", err)
+	}
+
+	configYAML, ok := secret.Data["exp-1.yaml"]
+	if !ok {
+		t.Fatal("missing 'exp-1.yaml' key in config Secret")
+	}
+
+	content := string(configYAML)
+	for _, want := range []string{
+		"apiVersion: jumpstarter.dev/v1alpha1",
+		"kind: ExporterConfig",
+		"token: test-token-exp-1",
+		"endpoint:",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("config YAML missing %q\ngot:\n%s", want, content)
+		}
+	}
+}
+
+func TestEnsureExporterPods_driversAppearedInConfig(t *testing.T) {
+	es := makeExporterSet(func(e *virtualtargetv1alpha1.ExporterSet) {
+		e.Spec.Template.Spec.Drivers = []virtualtargetv1alpha1.DriverConfig{
+			{Name: "power", Type: "jumpstarter_driver_power.driver.QemuPower"},
+		}
+	})
+	exp := makeExporterWithCredential()
+	credSecret := makeCredentialSecret("exp-1")
+
+	r, _ := newReconciler(t, es, makeVTC(), exp, credSecret)
+	reconcileOnce(t, r)
+
+	var secret corev1.Secret
+	if err := r.Get(context.Background(),
+		types.NamespacedName{Name: "exp-1-config", Namespace: nsDefault},
+		&secret); err != nil {
+		t.Fatalf("config Secret not found: %v", err)
+	}
+
+	content := string(secret.Data["exp-1.yaml"])
+	if !strings.Contains(content, "power:") {
+		t.Errorf("expected 'power:' in config YAML, got:\n%s", content)
+	}
+	if !strings.Contains(content, "QemuPower") {
+		t.Errorf("expected 'QemuPower' in config YAML, got:\n%s", content)
+	}
+}
+
+func TestEnsureExporterPods_skipsDisabledExporters(t *testing.T) {
+	es := makeExporterSet()
+	// Disabled exporter with credential — should NOT get a Pod.
+	exp := makeExporterWithCredential()
+	exp.Spec.Enabled = boolPtr(false)
+	credSecret := makeCredentialSecret("exp-1")
+
+	r, _ := newReconciler(t, es, makeVTC(), exp, credSecret)
+	reconcileOnce(t, r)
+
+	pods := listPods(t, r.Client)
+	if len(pods) != 0 {
+		t.Errorf("got %d pods for disabled exporter, want 0", len(pods))
+	}
+}
+
+func TestEnsureExporterPods_tokenRotationUpdatesConfigSecret(t *testing.T) {
+	es := makeExporterSet()
+	exp := makeExporterWithCredential()
+	credSecret := makeCredentialSecret("exp-1") // initial token = "test-token-exp-1"
+
+	r, c := newReconciler(t, es, makeVTC(), exp, credSecret)
+	reconcileOnce(t, r) // creates config Secret + Pod
+
+	// Simulate token rotation: update the credential Secret with a new token.
+	var latestCred corev1.Secret
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "exp-1-exporter", Namespace: nsDefault},
+		&latestCred); err != nil {
+		t.Fatalf("get credential Secret: %v", err)
+	}
+	latestCred.Data["token"] = []byte("rotated-token-xyz")
+	if err := c.Update(context.Background(), &latestCred); err != nil {
+		t.Fatalf("update credential Secret: %v", err)
+	}
+
+	reconcileOnce(t, r) // should update the config Secret
+
+	var configSecret corev1.Secret
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "exp-1-config", Namespace: nsDefault},
+		&configSecret); err != nil {
+		t.Fatalf("config Secret not found: %v", err)
+	}
+
+	content := string(configSecret.Data["exp-1.yaml"])
+	if !strings.Contains(content, "rotated-token-xyz") {
+		t.Errorf("config Secret should contain rotated token\ngot:\n%s", content)
+	}
+	if strings.Contains(content, "test-token-exp-1") {
+		t.Errorf("config Secret still contains stale token\ngot:\n%s", content)
 	}
 }


### PR DESCRIPTION
Implements the Pod provisioning stage of JEP-0014. Once the main controller issues a credential secret for an exporter, the ExporterSet controller creates the config secret and pod.

**This PR includes the following:**
two phase pod creation, Exporter CRs are created first (existing scaling logic). Pods are created only after status.credential is set by the ExporterReconciler, avoiding races with credential issuance.

Config Secret (<name>-config), ExporterConfig YAML written per Exporter, mounted into the sidecar at /etc/jumpstarter/exporters/<name>.yaml. Includes endpoint, JWT token, optional TLS CA from VTC, and the driver map from spec.template.spec.drivers.

Token rotation and config secrets are synced on every reconcile via CreateOrUpdate. Kubernetes auto-refreshes secret backed volume mounts so no pod restart is needed.

Credential injection: VTC.credentialsSecretRef is injected as env vars into the runtime container for API-backed provisioners (e.g. Corellium). QEMU ignores it.

Ownership chain — ExporterSet → Exporter → Pod via ownerReferences. An ExporterSet label on pods bridges the grandparent watch for event-driven reconciliation.

Bug fix — Pod phase counts in ExporterSet.status was always 0 because the filter checked for direct ExporterSet ownership. Pods are owned by Exporters, so the check now uses isOwnedByKind("Exporter").

**Testing**
Unit tests: TestEnsureExporterPods_*, TestRenderExporterConfigYAML_*, TestDriverKey_*, TestInjectConfigVolume_*, token rotation
E2e (envtest): two-phase creation flow, full ownership chain, Pod labels
Manual on CRC cluster: config Secrets appear with correct YAML structure, token rotation confirmed with rotated token.