### PR TITLE
refactor: split task group into data-plane and control-plane

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -999,7 +999,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         lease_scope.after_lease_hook_done.set()
         return True
 
-    async def handle_lease(self, lease_name: str, tg: TaskGroup, lease_scope: LeaseContext) -> None:
+    async def handle_lease(self, lease_name: str, conns_tg: TaskGroup, lease_scope: LeaseContext) -> None:
         """Handle all incoming client connections for a lease.
 
         This method orchestrates the complete lifecycle of managing connections during
@@ -1015,7 +1015,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
         Args:
             lease_name: Name of the lease to handle connections for
-            tg: TaskGroup for spawning concurrent connection handler tasks
+            conns_tg: Data-plane TaskGroup for spawning connection handler tasks
             lease_scope: LeaseScope with before_lease_hook event (session/socket set here)
 
         Note:
@@ -1075,7 +1075,8 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 # session creation (e.g., BEFORE_LEASE_HOOK when hooks are configured).
 
                 # Start task to handle EndSession requests (runs afterLease hook when client signals done)
-                tg.start_soon(self._handle_end_session, lease_scope)
+                # Runs on control-plane group so it's cancelled with Status/Listen, not data-plane
+                self._tg.start_soon(self._handle_end_session, lease_scope)
 
                 # Process client connections until lease ends
                 # The lease can end via:
@@ -1113,7 +1114,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                                     lease_name,
                                     request.router_endpoint,
                                 )
-                                tg.start_soon(
+                                conns_tg.start_soon(
                                     self._handle_client_conn,
                                     lease_scope.socket_path,
                                     request.router_endpoint,
@@ -1163,21 +1164,23 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             pass
         status_tx, status_rx = create_memory_object_stream[jumpstarter_pb2.StatusResponse](max_buffer_size=5)
         try:
-            await self._run_control_plane(status_tx, status_rx)
-            if self._fatal_stream_error:
-                name, err = self._fatal_stream_error
-                logger.warning(
-                    "Control plane down (%s: %s)",
-                    name,
-                    err,
-                )
+            async with create_task_group() as conns_tg:
+                await self._run_control_plane(status_tx, status_rx, conns_tg)
+                if self._fatal_stream_error:
+                    name, err = self._fatal_stream_error
+                    logger.warning(
+                        "Control plane down (%s: %s), cancelling active connections",
+                        name,
+                        err,
+                    )
+                conns_tg.cancel_scope.cancel()
         finally:
             self._tg = None
             self._fatal_stream_error = None
             self._status_drain_active = False
             clear_log_context()
 
-    async def _run_control_plane(self, status_tx, status_rx):
+    async def _run_control_plane(self, status_tx, status_rx, conns_tg: TaskGroup):
         """Start control-plane streams and process status updates."""
         async with create_task_group() as tg:
             self._tg = tg
@@ -1192,13 +1195,14 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 status_tx,
             )
             async for status in status_rx:
-                if await self._apply_status(status, tg):
+                if await self._apply_status(status, tg, conns_tg):
                     break
 
     async def _apply_status(
         self,
         status: jumpstarter_pb2.StatusResponse,
         tg: TaskGroup,
+        conns_tg: TaskGroup,
     ) -> bool:
         """Process a single status update. Returns True to stop the status loop."""
         previous_state = self._lease_state
@@ -1206,7 +1210,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
         if current_leased:
             if previous_state == LeaseState.IDLE and status.lease_name != "":
-                self._on_lease_acquired(status, tg)
+                self._on_lease_acquired(status, tg, conns_tg)
             elif (
                 previous_state == LeaseState.LEASED
                 and self._lease_context
@@ -1229,6 +1233,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         self,
         status: jumpstarter_pb2.StatusResponse,
         tg: TaskGroup,
+        conns_tg: TaskGroup,
     ) -> None:
         """Handle new lease assignment: create context and spawn lease handler."""
         self._started = True
@@ -1250,7 +1255,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 self.stop,
                 self._request_lease_release,
             )
-        tg.start_soon(self.handle_lease, status.lease_name, tg, lease_scope)
+        conns_tg.start_soon(self.handle_lease, status.lease_name, conns_tg, lease_scope)
 
     def _on_lease_update(self, status: jumpstarter_pb2.StatusResponse) -> None:
         """Update client info on every leased status tick."""

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -1332,3 +1332,55 @@ class TestContextPropagation:
 
         assert calls == [{"client": "ci-bot"}]
         clear_log_context()
+
+
+class TestTaskGroupIsolation:
+    """Verify that control-plane failure does not cancel data-plane connections.
+
+    The split: inner tg (control-plane: Status/Listen streams) and outer
+    conns_tg (data-plane: handle_lease, _handle_client_conn).  When
+    _cancel_with_fatal_error cancels tg, connections on conns_tg must
+    remain alive until serve() explicitly cancels conns_tg.
+    """
+
+    @pytest.mark.anyio
+    async def test_conn_alive_after_control_plane_cancel(self):
+        """Between _cancel_with_fatal_error and serve() cancelling conns_tg,
+        connection tasks on conns_tg are still running."""
+        exporter = _make_serve_exporter()
+        conn_alive_after_cp_cancel = False
+        conn_started = Event()
+        cp_cancelled = Event()
+
+        async def fake_conn():
+            nonlocal conn_alive_after_cp_cancel
+            conn_started.set()
+            await cp_cancelled.wait()
+            conn_alive_after_cp_cancel = True
+
+        async def fake_retry_stream(name, factory, tx, **kwargs):
+            if name == "Status":
+                await tx.send(
+                    MagicMock(leased=True, lease_name="test-lease", client_name="c", context={})
+                )
+                await conn_started.wait()
+                exporter._cancel_with_fatal_error("Status", Exception("controller gone"))
+                cp_cancelled.set()
+            else:
+                await anyio.sleep_forever()
+
+        exporter._retry_stream = fake_retry_stream
+
+        async def fake_handle_lease(lease_name, conns_tg, lease_ctx):
+            conns_tg.start_soon(fake_conn)
+            await lease_ctx.lease_ended.wait()
+            lease_ctx.after_lease_hook_done.set()
+
+        exporter.handle_lease = fake_handle_lease
+
+        await exporter.serve()
+
+        assert conn_alive_after_cp_cancel, (
+            "Connection task was killed before serve() cancelled conns_tg — "
+            "control-plane cancellation leaked into data-plane"
+        )


### PR DESCRIPTION
## Summary
- Split single task group into outer `conns_tg` (data-plane: client connections) and inner `_tg` (control-plane: Status/Listen streams)
- Stream failure cancels inner group only, preserving active tunnels
- `_cancel_with_fatal_error` cancels control-plane; `serve()` then cancels data-plane after control plane returns

## Stack
Part 4 of 6 — depends on #945.

## Test plan
- [x] All 653 jumpstarter tests pass
- [x] `TestTaskGroupIsolation` proves live connections survive Status stream terminal failure
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)