### PR TITLE
fix: per-connection Dial retry with dual timeout budget

### DIFF
--- a/e2e/test/hooks_test.go
+++ b/e2e/test/hooks_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 				"--retry-timeout", "0",
 				"--selector", "example.com/board=hooks", "j", "power", "on")
 			Expect(err).To(HaveOccurred())
-			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Exporter shutting down|Connection to exporter lost)`))
+			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Exporter shutting down|Connection to exporter lost|unreachable after)`))
 
 			WaitForExporter("test-exporter-hooks")
 		})
@@ -159,7 +159,7 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 				"--retry-timeout", "0",
 				"--selector", "example.com/board=hooks", "j", "power", "on")
 			Expect(err).To(HaveOccurred())
-			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Connection to exporter lost)`))
+			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Connection to exporter lost|unreachable after)`))
 
 			// The exporter should release the lease and return to Available
 			WaitForExporter("test-exporter-hooks")
@@ -170,7 +170,7 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 				"--retry-timeout", "0",
 				"--selector", "example.com/board=hooks", "j", "power", "on")
 			Expect(err2).To(HaveOccurred())
-			Expect(out2).To(MatchRegexp(`(beforeLease hook fail|Connection to exporter lost)`))
+			Expect(out2).To(MatchRegexp(`(beforeLease hook fail|Connection to exporter lost|unreachable after)`))
 
 			// Exporter should recover again
 			WaitForExporter("test-exporter-hooks")
@@ -196,7 +196,7 @@ var _ = Describe("Hooks E2E Tests", Label("hooks"), Ordered, func() {
 				"--retry-timeout", "0",
 				"--selector", "example.com/board=hooks", "j", "power", "on")
 			Expect(err).To(HaveOccurred())
-			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Exporter shutting down|Connection to exporter lost)`))
+			Expect(out).To(MatchRegexp(`(beforeLease hook fail|Exporter shutting down|Connection to exporter lost|unreachable after)`))
 
 			// Exporter process should have exited (allow extra time on slower runners like ARM)
 			Eventually(func() bool {

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -12,7 +12,7 @@ import anyio.to_thread
 import click
 import grpc
 import grpc.aio
-from anyio import create_task_group, get_cancelled_exc_class
+from anyio import CancelScope, create_task_group, get_cancelled_exc_class
 from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.exceptions import find_exception_in_group, handle_exceptions_with_reauthentication
 from jumpstarter_cli_common.oidc import (
@@ -236,40 +236,43 @@ async def _monitor_token_expiry(config, lease, cancel_scope, token_state=None) -
     2. Updates the lease's gRPC channel with new credentials
     3. If refresh fails, periodically checks the config on disk for a token
        refreshed externally (e.g. via 'jmp login' from within the shell)
-    4. Never cancels the scope - the shell stays alive regardless
+    4. Never cancels the shell scope - the shell stays alive regardless.
+       The monitor must still enter *its own* cancel_scope so cancel()
+       aborts an in-progress sleep (otherwise retries pile up monitors).
     """
     token = getattr(config, "token", None)
     if not token:
         return
 
     warn_state = {"expiry": False, "refresh_failed": False, "token_expired": False}
-    while not cancel_scope.cancel_called:
-        try:
-            # Re-read config.token each iteration since it may have been refreshed
-            remaining = get_token_remaining_seconds(config.token)
-            if remaining is None:
-                return
+    with cancel_scope:
+        while not cancel_scope.cancel_called:
+            try:
+                # Re-read config.token each iteration since it may have been refreshed
+                remaining = get_token_remaining_seconds(config.token)
+                if remaining is None:
+                    return
 
-            if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
-                await _handle_token_refresh(config, lease, remaining, warn_state, token_state)
-            elif remaining <= TOKEN_EXPIRY_WARNING_SECONDS and not warn_state["expiry"]:
-                duration = format_duration(remaining)
-                click.echo(
-                    click.style(
-                        f"\nToken expires in {duration}. Will attempt auto-refresh.",
-                        fg="yellow",
-                        bold=True,
+                if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
+                    await _handle_token_refresh(config, lease, remaining, warn_state, token_state)
+                elif remaining <= TOKEN_EXPIRY_WARNING_SECONDS and not warn_state["expiry"]:
+                    duration = format_duration(remaining)
+                    click.echo(
+                        click.style(
+                            f"\nToken expires in {duration}. Will attempt auto-refresh.",
+                            fg="yellow",
+                            bold=True,
+                        )
                     )
-                )
-                warn_state["expiry"] = True
+                    warn_state["expiry"] = True
 
-            # Check more frequently as we approach expiry
-            if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
-                await anyio.sleep(5)
-            else:
-                await anyio.sleep(30)
-        except Exception:
-            return
+                # Check more frequently as we approach expiry
+                if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
+                    await anyio.sleep(5)
+                else:
+                    await anyio.sleep(30)
+            except Exception:
+                return
 
 
 async def _cancel_if_connection_lost(monitor, coro):
@@ -504,6 +507,7 @@ async def _shell_with_signal_handling(  # noqa: C901
             try:
                 async with anyio.from_thread.BlockingPortal() as portal:
                     connect_deadline = None
+                    connect_start = None
                     while True:
                         async with config.lease_async(
                             selector, exporter_name, lease_name, duration, portal, acquisition_timeout,
@@ -511,8 +515,10 @@ async def _shell_with_signal_handling(  # noqa: C901
                         ) as lease:
                             lease_used = lease
 
-                            # Start token monitoring only once we're in the shell
-                            tg.start_soon(_monitor_token_expiry, config, lease, tg.cancel_scope, token_state)
+                            monitor_scope = CancelScope()
+                            tg.start_soon(
+                                _monitor_token_expiry, config, lease, monitor_scope, token_state
+                            )
 
                             unreachable = None
                             try:
@@ -525,6 +531,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                                     raise
                             except ExporterUnreachableError as exc:
                                 unreachable = exc
+                            finally:
+                                monitor_scope.cancel()
                             if unreachable is not None:
                                 if lease.lease_ended:
                                     break  # lease expired naturally — exit cleanly
@@ -534,11 +542,13 @@ async def _shell_with_signal_handling(  # noqa: C901
                                         "Session is no longer valid."
                                     ) from unreachable
                                 if connect_deadline is None:
-                                    connect_deadline = time.monotonic() + lease.retry_timeout
+                                    connect_start = time.monotonic()
+                                    connect_deadline = connect_start + lease.retry_timeout
                                 if time.monotonic() >= connect_deadline:
+                                    elapsed = time.monotonic() - connect_start
                                     raise ExporterUnreachableError(
                                         f"Exporter {lease.exporter_name} unreachable after "
-                                        f"{lease.retry_timeout:.0f}s of retrying"
+                                        f"{elapsed:.0f}s of retrying: {unreachable}"
                                     ) from unreachable
                                 logger.warning(
                                     "Exporter %s is unreachable, releasing lease and retrying...",
@@ -546,6 +556,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                                 )
                                 logger.debug("Unreachable cause: %s", unreachable)
                                 continue  # lease released by __aexit__, loop re-acquires
+                            connect_deadline = None
+                            connect_start = None
                             if lease.release and lease.name and token_state["expired_unrecovered"]:
                                 _warn_about_expired_token(lease.name, selector)
                             break

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -12,7 +12,7 @@ import anyio.to_thread
 import click
 import grpc
 import grpc.aio
-from anyio import create_task_group, get_cancelled_exc_class
+from anyio import CancelScope, create_task_group, get_cancelled_exc_class
 from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.exceptions import find_exception_in_group, handle_exceptions_with_reauthentication
 from jumpstarter_cli_common.oidc import (
@@ -237,40 +237,43 @@ async def _monitor_token_expiry(config, lease, cancel_scope, token_state=None) -
     2. Updates the lease's gRPC channel with new credentials
     3. If refresh fails, periodically checks the config on disk for a token
        refreshed externally (e.g. via 'jmp login' from within the shell)
-    4. Never cancels the scope - the shell stays alive regardless
+    4. Never cancels the shell scope - the shell stays alive regardless.
+       The monitor must still enter *its own* cancel_scope so cancel()
+       aborts an in-progress sleep (otherwise retries pile up monitors).
     """
     token = getattr(config, "token", None)
     if not token:
         return
 
     warn_state = {"expiry": False, "refresh_failed": False, "token_expired": False}
-    while not cancel_scope.cancel_called:
-        try:
-            # Re-read config.token each iteration since it may have been refreshed
-            remaining = get_token_remaining_seconds(config.token)
-            if remaining is None:
-                return
+    with cancel_scope:
+        while not cancel_scope.cancel_called:
+            try:
+                # Re-read config.token each iteration since it may have been refreshed
+                remaining = get_token_remaining_seconds(config.token)
+                if remaining is None:
+                    return
 
-            if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
-                await _handle_token_refresh(config, lease, remaining, warn_state, token_state)
-            elif remaining <= TOKEN_EXPIRY_WARNING_SECONDS and not warn_state["expiry"]:
-                duration = format_duration(remaining)
-                click.echo(
-                    click.style(
-                        f"\nToken expires in {duration}. Will attempt auto-refresh.",
-                        fg="yellow",
-                        bold=True,
+                if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
+                    await _handle_token_refresh(config, lease, remaining, warn_state, token_state)
+                elif remaining <= TOKEN_EXPIRY_WARNING_SECONDS and not warn_state["expiry"]:
+                    duration = format_duration(remaining)
+                    click.echo(
+                        click.style(
+                            f"\nToken expires in {duration}. Will attempt auto-refresh.",
+                            fg="yellow",
+                            bold=True,
+                        )
                     )
-                )
-                warn_state["expiry"] = True
+                    warn_state["expiry"] = True
 
-            # Check more frequently as we approach expiry
-            if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
-                await anyio.sleep(5)
-            else:
-                await anyio.sleep(30)
-        except Exception:
-            return
+                # Check more frequently as we approach expiry
+                if remaining <= _TOKEN_REFRESH_THRESHOLD_SECONDS:
+                    await anyio.sleep(5)
+                else:
+                    await anyio.sleep(30)
+            except Exception:
+                return
 
 
 async def _cancel_if_connection_lost(monitor, coro):
@@ -505,6 +508,7 @@ async def _shell_with_signal_handling(  # noqa: C901
             try:
                 async with anyio.from_thread.BlockingPortal() as portal:
                     connect_deadline = None
+                    connect_start = None
                     while True:
                         async with config.lease_async(
                             selector, exporter_name, lease_name, duration, portal, acquisition_timeout,
@@ -513,8 +517,10 @@ async def _shell_with_signal_handling(  # noqa: C901
                         ) as lease:
                             lease_used = lease
 
-                            # Start token monitoring only once we're in the shell
-                            tg.start_soon(_monitor_token_expiry, config, lease, tg.cancel_scope, token_state)
+                            monitor_scope = CancelScope()
+                            tg.start_soon(
+                                _monitor_token_expiry, config, lease, monitor_scope, token_state
+                            )
 
                             unreachable = None
                             try:
@@ -527,6 +533,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                                     raise
                             except ExporterUnreachableError as exc:
                                 unreachable = exc
+                            finally:
+                                monitor_scope.cancel()
                             if unreachable is not None:
                                 if lease.lease_ended:
                                     break  # lease expired naturally — exit cleanly
@@ -536,11 +544,13 @@ async def _shell_with_signal_handling(  # noqa: C901
                                         "Session is no longer valid."
                                     ) from unreachable
                                 if connect_deadline is None:
-                                    connect_deadline = time.monotonic() + lease.retry_timeout
+                                    connect_start = time.monotonic()
+                                    connect_deadline = connect_start + lease.retry_timeout
                                 if time.monotonic() >= connect_deadline:
+                                    elapsed = time.monotonic() - connect_start
                                     raise ExporterUnreachableError(
                                         f"Exporter {lease.exporter_name} unreachable after "
-                                        f"{lease.retry_timeout:.0f}s of retrying"
+                                        f"{elapsed:.0f}s of retrying: {unreachable}"
                                     ) from unreachable
                                 logger.warning(
                                     "Exporter %s is unreachable, releasing lease and retrying...",
@@ -548,6 +558,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                                 )
                                 logger.debug("Unreachable cause: %s", unreachable)
                                 continue  # lease released by __aexit__, loop re-acquires
+                            connect_deadline = None
+                            connect_start = None
                             if lease.release and lease.name and token_state["expired_unrecovered"]:
                                 _warn_about_expired_token(lease.name, selector)
                             break

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -12,7 +12,7 @@ import anyio.to_thread
 import click
 import grpc
 import grpc.aio
-from anyio import create_task_group, get_cancelled_exc_class
+from anyio import CancelScope, create_task_group, get_cancelled_exc_class
 from jumpstarter_cli_common.config import opt_config
 from jumpstarter_cli_common.exceptions import find_exception_in_group, handle_exceptions_with_reauthentication
 from jumpstarter_cli_common.oidc import (
@@ -504,6 +504,7 @@ async def _shell_with_signal_handling(  # noqa: C901
             try:
                 async with anyio.from_thread.BlockingPortal() as portal:
                     connect_deadline = None
+                    connect_start = None
                     while True:
                         async with config.lease_async(
                             selector, exporter_name, lease_name, duration, portal, acquisition_timeout,
@@ -511,8 +512,10 @@ async def _shell_with_signal_handling(  # noqa: C901
                         ) as lease:
                             lease_used = lease
 
-                            # Start token monitoring only once we're in the shell
-                            tg.start_soon(_monitor_token_expiry, config, lease, tg.cancel_scope, token_state)
+                            monitor_scope = CancelScope()
+                            tg.start_soon(
+                                _monitor_token_expiry, config, lease, monitor_scope, token_state
+                            )
 
                             unreachable = None
                             try:
@@ -525,6 +528,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                                     raise
                             except ExporterUnreachableError as exc:
                                 unreachable = exc
+                            finally:
+                                monitor_scope.cancel()
                             if unreachable is not None:
                                 if lease.lease_ended:
                                     break  # lease expired naturally — exit cleanly
@@ -534,11 +539,13 @@ async def _shell_with_signal_handling(  # noqa: C901
                                         "Session is no longer valid."
                                     ) from unreachable
                                 if connect_deadline is None:
-                                    connect_deadline = time.monotonic() + lease.retry_timeout
+                                    connect_start = time.monotonic()
+                                    connect_deadline = connect_start + lease.retry_timeout
                                 if time.monotonic() >= connect_deadline:
+                                    elapsed = time.monotonic() - connect_start
                                     raise ExporterUnreachableError(
                                         f"Exporter {lease.exporter_name} unreachable after "
-                                        f"{lease.retry_timeout:.0f}s of retrying"
+                                        f"{elapsed:.0f}s of retrying: {unreachable}"
                                     ) from unreachable
                                 logger.warning(
                                     "Exporter %s is unreachable, releasing lease and retrying...",
@@ -546,6 +553,8 @@ async def _shell_with_signal_handling(  # noqa: C901
                                 )
                                 logger.debug("Unreachable cause: %s", unreachable)
                                 continue  # lease released by __aexit__, loop re-acquires
+                            connect_deadline = None
+                            connect_start = None
                             if lease.release and lease.name and token_state["expired_unrecovered"]:
                                 _warn_about_expired_token(lease.name, selector)
                             break

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -434,6 +434,15 @@ def _make_mock_lease():
     return lease
 
 
+def _fake_cancel_scope(*, cancel_called=False):
+    """Stand-in for anyio.CancelScope that monitor tests can drive."""
+    scope = Mock()
+    scope.cancel_called = cancel_called
+    scope.__enter__ = Mock(return_value=scope)
+    scope.__exit__ = Mock(return_value=False)
+    return scope
+
+
 class TestUpdateLeaseChannel:
     async def test_updates_channel_on_lease(self):
         config = _make_config()
@@ -666,7 +675,7 @@ class TestWarnRefreshFailed:
 class TestMonitorTokenExpiry:
     async def test_returns_immediately_when_no_token(self):
         config = Mock(spec=[])  # no token attribute
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, None, cancel_scope)
         # Should return without error
@@ -675,7 +684,7 @@ class TestMonitorTokenExpiry:
     @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=None)
     async def test_returns_when_remaining_is_none(self, _mock_remaining, _mock_sleep):
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, None, cancel_scope)
 
@@ -688,7 +697,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = "Token refreshed automatically."
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -704,7 +713,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = None  # all recovery failed
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -723,7 +732,7 @@ class TestMonitorTokenExpiry:
             Exception("done"),
         ]
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -736,17 +745,22 @@ class TestMonitorTokenExpiry:
     @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=500)
     async def test_sleeps_30s_when_above_threshold(self, _mock_remaining, mock_sleep):
         # Exit after one loop via cancel_called
-        call_count = 0
-
-        def check_cancelled():
-            nonlocal call_count
-            call_count += 1  # ty: ignore[unresolved-reference]
-            return call_count > 1
-
         config = _make_config()
 
-        class _CancelScope(Mock):
-            cancel_called = property(lambda self: check_cancelled())
+        class _CancelScope:
+            def __init__(self):
+                self._n = 0
+
+            @property
+            def cancel_called(self):
+                self._n += 1
+                return self._n > 1
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
 
         cancel_scope = _CancelScope()
 
@@ -762,7 +776,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = None
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -777,7 +791,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = None
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -795,7 +809,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, -5, Exception("done")]
         mock_recovery.return_value = None  # all recovery fails
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
         token_state = {"expired_unrecovered": False}
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope, token_state)
@@ -809,6 +823,18 @@ class TestMonitorTokenExpiry:
         assert len(yellow_calls) >= 1, "Expected yellow warning for near-expiry"
         assert len(red_calls) >= 1, "Expected red warning for actual expiry"
         assert token_state["expired_unrecovered"] is True
+
+    async def test_cancel_interrupts_sleep(self):
+        """monitor_scope.cancel() must abort the in-progress sleep so a
+        replacement monitor can start without piling up."""
+        config = _make_config()
+        with patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=500):
+            with anyio.fail_after(2):
+                async with anyio.create_task_group() as tg:
+                    scope = anyio.CancelScope()
+                    tg.start_soon(_monitor_token_expiry, config, _make_mock_lease(), scope)
+                    await anyio.sleep(0.05)
+                    scope.cancel()
 
 
 class _FakeStatusMonitor:
@@ -1169,7 +1195,8 @@ class TestRetryLoopTimeout:
 
             exc = find_exception_in_group(exc, ExporterUnreachableError)
             assert exc is not None
-        assert "after 0s of retrying" in str(exc)
+        assert "test-exporter" in str(exc)
+        assert "unreachable" in str(exc).lower()
         assert state["call_count"] >= 1
 
     async def test_retries_when_wrapped_in_exception_group(self):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -441,6 +441,15 @@ def _make_mock_lease():
     return lease
 
 
+def _fake_cancel_scope(*, cancel_called=False):
+    """Stand-in for anyio.CancelScope that monitor tests can drive."""
+    scope = Mock()
+    scope.cancel_called = cancel_called
+    scope.__enter__ = Mock(return_value=scope)
+    scope.__exit__ = Mock(return_value=False)
+    return scope
+
+
 class TestUpdateLeaseChannel:
     async def test_updates_channel_on_lease(self):
         config = _make_config()
@@ -673,7 +682,7 @@ class TestWarnRefreshFailed:
 class TestMonitorTokenExpiry:
     async def test_returns_immediately_when_no_token(self):
         config = Mock(spec=[])  # no token attribute
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, None, cancel_scope)
         # Should return without error
@@ -682,7 +691,7 @@ class TestMonitorTokenExpiry:
     @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=None)
     async def test_returns_when_remaining_is_none(self, _mock_remaining, _mock_sleep):
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, None, cancel_scope)
 
@@ -695,7 +704,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = "Token refreshed automatically."
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -711,7 +720,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = None  # all recovery failed
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -730,7 +739,7 @@ class TestMonitorTokenExpiry:
             Exception("done"),
         ]
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -743,17 +752,22 @@ class TestMonitorTokenExpiry:
     @patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=500)
     async def test_sleeps_30s_when_above_threshold(self, _mock_remaining, mock_sleep):
         # Exit after one loop via cancel_called
-        call_count = 0
-
-        def check_cancelled():
-            nonlocal call_count
-            call_count += 1  # ty: ignore[unresolved-reference]
-            return call_count > 1
-
         config = _make_config()
 
-        class _CancelScope(Mock):
-            cancel_called = property(lambda self: check_cancelled())
+        class _CancelScope:
+            def __init__(self):
+                self._n = 0
+
+            @property
+            def cancel_called(self):
+                self._n += 1
+                return self._n > 1
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
 
         cancel_scope = _CancelScope()
 
@@ -769,7 +783,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = None
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -784,7 +798,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, Exception("done")]
         mock_recovery.return_value = None
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope)
 
@@ -802,7 +816,7 @@ class TestMonitorTokenExpiry:
         mock_remaining.side_effect = [60, -5, Exception("done")]
         mock_recovery.return_value = None  # all recovery fails
         config = _make_config()
-        cancel_scope = Mock(cancel_called=False)
+        cancel_scope = _fake_cancel_scope()
         token_state = {"expired_unrecovered": False}
 
         await _monitor_token_expiry(config, _make_mock_lease(), cancel_scope, token_state)
@@ -816,6 +830,18 @@ class TestMonitorTokenExpiry:
         assert len(yellow_calls) >= 1, "Expected yellow warning for near-expiry"
         assert len(red_calls) >= 1, "Expected red warning for actual expiry"
         assert token_state["expired_unrecovered"] is True
+
+    async def test_cancel_interrupts_sleep(self):
+        """monitor_scope.cancel() must abort the in-progress sleep so a
+        replacement monitor can start without piling up."""
+        config = _make_config()
+        with patch("jumpstarter_cli.shell.get_token_remaining_seconds", return_value=500):
+            with anyio.fail_after(2):
+                async with anyio.create_task_group() as tg:
+                    scope = anyio.CancelScope()
+                    tg.start_soon(_monitor_token_expiry, config, _make_mock_lease(), scope)
+                    await anyio.sleep(0.05)
+                    scope.cancel()
 
 
 class _FakeStatusMonitor:
@@ -1176,7 +1202,8 @@ class TestRetryLoopTimeout:
 
             exc = find_exception_in_group(exc, ExporterUnreachableError)
             assert exc is not None
-        assert "after 0s of retrying" in str(exc)
+        assert "test-exporter" in str(exc)
+        assert "unreachable" in str(exc).lower()
         assert state["call_count"] >= 1
 
     async def test_retries_when_wrapped_in_exception_group(self):

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -1169,7 +1169,8 @@ class TestRetryLoopTimeout:
 
             exc = find_exception_in_group(exc, ExporterUnreachableError)
             assert exc is not None
-        assert "after 0s of retrying" in str(exc)
+        assert "test-exporter" in str(exc)
+        assert "unreachable" in str(exc).lower()
         assert state["call_count"] >= 1
 
     async def test_retries_when_wrapped_in_exception_group(self):

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Self
 
+import anyio
 import grpc
 from anyio import (
     AsyncContextManagerMixin,
@@ -74,6 +75,14 @@ class DirectLease(ContextManagerMixin, AsyncContextManagerMixin):
         yield
 
 
+# Per-attempt Dial RPC timeout in handle_async's retry loop. Deliberately much
+# shorter than dial_timeout/retry_timeout (the overall retry budgets): a single
+# attempt allowed to run for the full budget can silently consume most of it
+# before the caller sees any sign of trouble, turning a transient blip into
+# what looks like an indefinite hang.
+_DIAL_ATTEMPT_TIMEOUT = 10.0
+
+
 @dataclass(kw_only=True)
 class Lease(ContextManagerMixin, AsyncContextManagerMixin):
     channel: Channel
@@ -102,6 +111,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
     )  # Called when lease is ending
     lease_ended: bool = field(default=False, init=False)  # Set when lease expires naturally
     lease_transferred: bool = field(default=False, init=False)  # Set when lease is transferred to another client
+    _connected: bool = field(default=False, init=False)  # True after first successful Dial
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -331,104 +341,127 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         with self.portal.wrap_async_context_manager(self) as value:
             yield value
 
-    async def _dial_with_retry(self):
-        """Dial the controller with exponential backoff, waiting for the exporter to be ready.
-
-        Returns DialResponse on success.
-        Raises ExporterUnreachableError on timeout or unrecoverable error.
-        """
-        logger.debug("Dialing controller for lease %s", self.name)
+    async def handle_async(self, stream: "anyio.abc.SocketStream") -> None:  # noqa: C901
+        logger.debug("Connecting to Lease with name %s", self.name)
+        started = time.monotonic()
         base_delay = 0.3
         max_delay = 2.0
-        deadline = time.monotonic() + self.dial_timeout
+        dial_deadline = started + self.dial_timeout
+        unavail_budget = self.retry_timeout if self._connected else self.dial_timeout
+        unavailable_deadline = started + unavail_budget if unavail_budget > 0 else None
         attempt = 0
-        while True:
-            try:
-                return await self.controller.Dial(jumpstarter_pb2.DialRequest(lease_name=self.name))
-            except AioRpcError as e:
-                if e.code() == grpc.StatusCode.FAILED_PRECONDITION and "not ready" in str(e.details()):
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
+        warned_unavailable = False
+        try:
+            while True:
+                try:
+                    # Cap each RPC by _DIAL_ATTEMPT_TIMEOUT (not the overall
+                    # dial_timeout/retry_timeout budget) so one hung Dial can't
+                    # silently consume most of the retry window before the
+                    # loop gets a chance to retry. Also cap by remaining loop
+                    # time so we do not wait past the deadline.
+                    now = time.monotonic()
+                    loop_deadline = (
+                        unavailable_deadline if unavailable_deadline is not None else dial_deadline
+                    )
+                    dial_remaining = max(min(_DIAL_ATTEMPT_TIMEOUT, loop_deadline - now), 0.1)
+                    response = await self.controller.Dial(
+                        jumpstarter_pb2.DialRequest(lease_name=self.name),
+                        timeout=dial_remaining,
+                    )
+                    break
+                except AioRpcError as e:
+                    details_lower = str(e.details()).lower()
+                    if e.code() == grpc.StatusCode.FAILED_PRECONDITION and "hook failed" not in details_lower:
+                        remaining = dial_deadline - time.monotonic()
+                        if remaining <= 0:
+                            elapsed = time.monotonic() - started
+                            logger.debug(
+                                "Exporter %s not ready and dial timeout (%.1fs) exceeded after %d attempts",
+                                self.exporter_name,
+                                self.dial_timeout,
+                                attempt + 1,
+                            )
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} not ready after {elapsed:.0f}s: {e.details()}"
+                            ) from e
+                        delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
                         logger.debug(
-                            "Exporter not ready and dial timeout (%.1fs) exceeded after %d attempts",
-                            self.dial_timeout,
+                            "Exporter not ready (%s), retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
+                            e.details(),
+                            delay,
                             attempt + 1,
+                            remaining,
                         )
-                        raise ExporterUnreachableError(
-                            f"Exporter {self.exporter_name} not ready after {self.dial_timeout:.0f}s"
-                        ) from e
-                    delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
-                    logger.debug(
-                        "Exporter not ready, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
-                        delay,
-                        attempt + 1,
-                        remaining,
-                    )
-                    await sleep(delay)
-                    attempt += 1
-                    continue
-                if e.code() == grpc.StatusCode.UNAVAILABLE:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        logger.warning(
-                            "Exporter unavailable and dial timeout (%.1fs) exceeded after %d attempts",
-                            self.dial_timeout,
+                        await sleep(delay)
+                        attempt += 1
+                        continue
+                    if e.code() in (grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED):
+                        if unavailable_deadline is None:
+                            logger.warning("Exporter %s unavailable and retry disabled", self.exporter_name)
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} unavailable (retry disabled): {e.details()}"
+                            ) from e
+                        remaining = unavailable_deadline - time.monotonic()
+                        if remaining <= 0:
+                            elapsed = time.monotonic() - started
+                            logger.warning(
+                                "Exporter %s unavailable, retry budget (%.1fs) exceeded after %d attempts",
+                                self.exporter_name,
+                                unavail_budget,
+                                attempt + 1,
+                            )
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} permanently unavailable after "
+                                f"{elapsed:.0f}s of retrying: {e.details()}"
+                            ) from e
+                        if not warned_unavailable:
+                            warned_unavailable = True
+                            logger.warning(
+                                "Controller/exporter %s unavailable, retrying for %.0fs...",
+                                self.exporter_name,
+                                unavail_budget,
+                            )
+                        delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
+                        logger.info(
+                            "Exporter unavailable, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
+                            delay,
                             attempt + 1,
+                            remaining,
                         )
+                        await sleep(delay)
+                        attempt += 1
+                        continue
+                    if (
+                        e.code() == grpc.StatusCode.PERMISSION_DENIED
+                        or "permission denied" in str(e.details()).lower()
+                    ):
+                        self.lease_transferred = True
                         raise ExporterUnreachableError(
-                            f"Exporter {self.exporter_name} unavailable after {self.dial_timeout:.0f}s"
+                            f"Lease {self.name} has been transferred to another client"
                         ) from e
-                    delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
-                    logger.warning(
-                        "Exporter unavailable, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
-                        delay,
-                        attempt + 1,
-                        remaining,
-                    )
-                    await sleep(delay)
-                    attempt += 1
-                    continue
-                # Exporter went offline or lease ended - raise immediately
-                if "permission denied" in str(e.details()).lower():
-                    self.lease_transferred = True
-                    logger.warning(
-                        "Lease %s has been transferred to another client. Your session is no longer valid.",
-                        self.name,
-                    )
                     raise ExporterUnreachableError(
-                        f"Lease {self.name} transferred to another client"
+                        f"Connection to exporter {self.exporter_name} lost: {e.details()}"
                     ) from e
-                logger.warning("Connection to exporter lost: %s", e.details())
+            try:
+                async with connect_router_stream(
+                    response.router_endpoint, response.router_token, stream, self.tls_config, self.grpc_options
+                ):
+                    self._connected = True
+            except grpc.aio.AioRpcError as e:
                 raise ExporterUnreachableError(
-                    f"Connection to exporter {self.exporter_name} lost: {e.details()}"
+                    f"Router {response.router_endpoint} unreachable: {e.details()}"
                 ) from e
+            except OSError as e:
+                raise ExporterUnreachableError(
+                    f"Router {response.router_endpoint} connection failed: {e}"
+                ) from e
+        except BaseException:
+            await stream.aclose()
+            raise
 
     @asynccontextmanager
     async def serve_unix_async(self):
-        # Wait for exporter readiness before accepting connections.
-        # The response is intentionally discarded — each connection needs
-        # its own Dial to get a unique router tunnel.
-        await self._dial_with_retry()
-
-        async def _tunnel_handler(stream):
-            try:
-                response = await self.controller.Dial(
-                    jumpstarter_pb2.DialRequest(lease_name=self.name)
-                )
-            except AioRpcError as e:
-                raise ExporterUnreachableError(
-                    f"Per-connection Dial failed for {self.exporter_name}: {e.details()}"
-                ) from e
-            async with connect_router_stream(
-                response.router_endpoint,
-                response.router_token,
-                stream,
-                self.tls_config,
-                self.grpc_options,
-            ):
-                pass
-
-        async with TemporaryUnixListener(_tunnel_handler) as path:
+        async with TemporaryUnixListener(self.handle_async) as path:
             logger.debug("Serving Unix socket at %s", path)
             yield path
 

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Self
 
+import anyio
 import grpc
 from anyio import (
     AsyncContextManagerMixin,
@@ -101,6 +102,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
     )  # Called when lease is ending
     lease_ended: bool = field(default=False, init=False)  # Set when lease expires naturally
     lease_transferred: bool = field(default=False, init=False)  # Set when lease is transferred to another client
+    _connected: bool = field(default=False, init=False)  # True after first successful Dial
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -329,104 +331,125 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         with self.portal.wrap_async_context_manager(self) as value:
             yield value
 
-    async def _dial_with_retry(self):
-        """Dial the controller with exponential backoff, waiting for the exporter to be ready.
-
-        Returns DialResponse on success.
-        Raises ExporterUnreachableError on timeout or unrecoverable error.
-        """
-        logger.debug("Dialing controller for lease %s", self.name)
+    async def handle_async(self, stream: "anyio.abc.SocketStream") -> None:  # noqa: C901
+        logger.debug("Connecting to Lease with name %s", self.name)
+        started = time.monotonic()
         base_delay = 0.3
         max_delay = 2.0
-        deadline = time.monotonic() + self.dial_timeout
+        dial_deadline = started + self.dial_timeout
+        unavail_budget = self.retry_timeout if self._connected else self.dial_timeout
+        unavailable_deadline = started + unavail_budget if unavail_budget > 0 else None
         attempt = 0
-        while True:
-            try:
-                return await self.controller.Dial(jumpstarter_pb2.DialRequest(lease_name=self.name))
-            except AioRpcError as e:
-                if e.code() == grpc.StatusCode.FAILED_PRECONDITION and "not ready" in str(e.details()):
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
+        warned_unavailable = False
+        try:
+            while True:
+                try:
+                    # Cap each RPC by dial_timeout so one hung Dial cannot
+                    # consume the whole retry budget. Also cap by remaining
+                    # loop time so we do not wait past the deadline.
+                    now = time.monotonic()
+                    loop_deadline = (
+                        unavailable_deadline if unavailable_deadline is not None else dial_deadline
+                    )
+                    dial_remaining = max(min(self.dial_timeout, loop_deadline - now), 0.1)
+                    response = await self.controller.Dial(
+                        jumpstarter_pb2.DialRequest(lease_name=self.name),
+                        timeout=dial_remaining,
+                    )
+                    break
+                except AioRpcError as e:
+                    details_lower = str(e.details()).lower()
+                    if e.code() == grpc.StatusCode.FAILED_PRECONDITION and "hook failed" not in details_lower:
+                        remaining = dial_deadline - time.monotonic()
+                        if remaining <= 0:
+                            elapsed = time.monotonic() - started
+                            logger.debug(
+                                "Exporter %s not ready and dial timeout (%.1fs) exceeded after %d attempts",
+                                self.exporter_name,
+                                self.dial_timeout,
+                                attempt + 1,
+                            )
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} not ready after {elapsed:.0f}s: {e.details()}"
+                            ) from e
+                        delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
                         logger.debug(
-                            "Exporter not ready and dial timeout (%.1fs) exceeded after %d attempts",
-                            self.dial_timeout,
+                            "Exporter not ready (%s), retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
+                            e.details(),
+                            delay,
                             attempt + 1,
+                            remaining,
                         )
-                        raise ExporterUnreachableError(
-                            f"Exporter {self.exporter_name} not ready after {self.dial_timeout:.0f}s"
-                        ) from e
-                    delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
-                    logger.debug(
-                        "Exporter not ready, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
-                        delay,
-                        attempt + 1,
-                        remaining,
-                    )
-                    await sleep(delay)
-                    attempt += 1
-                    continue
-                if e.code() == grpc.StatusCode.UNAVAILABLE:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        logger.warning(
-                            "Exporter unavailable and dial timeout (%.1fs) exceeded after %d attempts",
-                            self.dial_timeout,
+                        await sleep(delay)
+                        attempt += 1
+                        continue
+                    if e.code() in (grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED):
+                        if unavailable_deadline is None:
+                            logger.warning("Exporter %s unavailable and retry disabled", self.exporter_name)
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} unavailable (retry disabled): {e.details()}"
+                            ) from e
+                        remaining = unavailable_deadline - time.monotonic()
+                        if remaining <= 0:
+                            elapsed = time.monotonic() - started
+                            logger.warning(
+                                "Exporter %s unavailable, retry budget (%.1fs) exceeded after %d attempts",
+                                self.exporter_name,
+                                unavail_budget,
+                                attempt + 1,
+                            )
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} permanently unavailable after "
+                                f"{elapsed:.0f}s of retrying: {e.details()}"
+                            ) from e
+                        if not warned_unavailable:
+                            warned_unavailable = True
+                            logger.warning(
+                                "Controller/exporter %s unavailable, retrying for %.0fs...",
+                                self.exporter_name,
+                                unavail_budget,
+                            )
+                        delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
+                        logger.info(
+                            "Exporter unavailable, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
+                            delay,
                             attempt + 1,
+                            remaining,
                         )
+                        await sleep(delay)
+                        attempt += 1
+                        continue
+                    if (
+                        e.code() == grpc.StatusCode.PERMISSION_DENIED
+                        or "permission denied" in str(e.details()).lower()
+                    ):
+                        self.lease_transferred = True
                         raise ExporterUnreachableError(
-                            f"Exporter {self.exporter_name} unavailable after {self.dial_timeout:.0f}s"
+                            f"Lease {self.name} has been transferred to another client"
                         ) from e
-                    delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
-                    logger.warning(
-                        "Exporter unavailable, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
-                        delay,
-                        attempt + 1,
-                        remaining,
-                    )
-                    await sleep(delay)
-                    attempt += 1
-                    continue
-                # Exporter went offline or lease ended - raise immediately
-                if "permission denied" in str(e.details()).lower():
-                    self.lease_transferred = True
-                    logger.warning(
-                        "Lease %s has been transferred to another client. Your session is no longer valid.",
-                        self.name,
-                    )
                     raise ExporterUnreachableError(
-                        f"Lease {self.name} transferred to another client"
+                        f"Connection to exporter {self.exporter_name} lost: {e.details()}"
                     ) from e
-                logger.warning("Connection to exporter lost: %s", e.details())
+            try:
+                async with connect_router_stream(
+                    response.router_endpoint, response.router_token, stream, self.tls_config, self.grpc_options
+                ):
+                    self._connected = True
+            except grpc.aio.AioRpcError as e:
                 raise ExporterUnreachableError(
-                    f"Connection to exporter {self.exporter_name} lost: {e.details()}"
+                    f"Router {response.router_endpoint} unreachable: {e.details()}"
                 ) from e
+            except OSError as e:
+                raise ExporterUnreachableError(
+                    f"Router {response.router_endpoint} connection failed: {e}"
+                ) from e
+        except BaseException:
+            await stream.aclose()
+            raise
 
     @asynccontextmanager
     async def serve_unix_async(self):
-        # Wait for exporter readiness before accepting connections.
-        # The response is intentionally discarded — each connection needs
-        # its own Dial to get a unique router tunnel.
-        await self._dial_with_retry()
-
-        async def _tunnel_handler(stream):
-            try:
-                response = await self.controller.Dial(
-                    jumpstarter_pb2.DialRequest(lease_name=self.name)
-                )
-            except AioRpcError as e:
-                raise ExporterUnreachableError(
-                    f"Per-connection Dial failed for {self.exporter_name}: {e.details()}"
-                ) from e
-            async with connect_router_stream(
-                response.router_endpoint,
-                response.router_token,
-                stream,
-                self.tls_config,
-                self.grpc_options,
-            ):
-                pass
-
-        async with TemporaryUnixListener(_tunnel_handler) as path:
+        async with TemporaryUnixListener(self.handle_async) as path:
             logger.debug("Serving Unix socket at %s", path)
             yield path
 

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Self
 
+import anyio
 import grpc
 from anyio import (
     AsyncContextManagerMixin,
@@ -101,6 +102,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
     )  # Called when lease is ending
     lease_ended: bool = field(default=False, init=False)  # Set when lease expires naturally
     lease_transferred: bool = field(default=False, init=False)  # Set when lease is transferred to another client
+    _connected: bool = field(default=False, init=False)  # True after first successful Dial
 
     def __post_init__(self):
         if hasattr(super(), "__post_init__"):
@@ -325,104 +327,118 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         with self.portal.wrap_async_context_manager(self) as value:
             yield value
 
-    async def _dial_with_retry(self):
-        """Dial the controller with exponential backoff, waiting for the exporter to be ready.
-
-        Returns DialResponse on success.
-        Raises ExporterUnreachableError on timeout or unrecoverable error.
-        """
-        logger.debug("Dialing controller for lease %s", self.name)
+    async def handle_async(self, stream: "anyio.abc.SocketStream") -> None:  # noqa: C901
+        logger.debug("Connecting to Lease with name %s", self.name)
+        started = time.monotonic()
         base_delay = 0.3
         max_delay = 2.0
-        deadline = time.monotonic() + self.dial_timeout
+        dial_deadline = started + self.dial_timeout
+        unavail_budget = self.retry_timeout if self._connected else self.dial_timeout
+        unavailable_deadline = started + unavail_budget if unavail_budget > 0 else None
         attempt = 0
-        while True:
-            try:
-                return await self.controller.Dial(jumpstarter_pb2.DialRequest(lease_name=self.name))
-            except AioRpcError as e:
-                if e.code() == grpc.StatusCode.FAILED_PRECONDITION and "not ready" in str(e.details()):
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
+        warned_unavailable = False
+        try:
+            while True:
+                try:
+                    dial_remaining = max(dial_deadline - time.monotonic(), 0.1)
+                    response = await self.controller.Dial(
+                        jumpstarter_pb2.DialRequest(lease_name=self.name),
+                        timeout=dial_remaining,
+                    )
+                    break
+                except AioRpcError as e:
+                    details_lower = str(e.details()).lower()
+                    if e.code() == grpc.StatusCode.FAILED_PRECONDITION and "hook failed" not in details_lower:
+                        remaining = dial_deadline - time.monotonic()
+                        if remaining <= 0:
+                            elapsed = time.monotonic() - started
+                            logger.debug(
+                                "Exporter %s not ready and dial timeout (%.1fs) exceeded after %d attempts",
+                                self.exporter_name,
+                                self.dial_timeout,
+                                attempt + 1,
+                            )
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} not ready after {elapsed:.0f}s: {e.details()}"
+                            ) from e
+                        delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
                         logger.debug(
-                            "Exporter not ready and dial timeout (%.1fs) exceeded after %d attempts",
-                            self.dial_timeout,
+                            "Exporter not ready (%s), retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
+                            e.details(),
+                            delay,
                             attempt + 1,
+                            remaining,
                         )
-                        raise ExporterUnreachableError(
-                            f"Exporter {self.exporter_name} not ready after {self.dial_timeout:.0f}s"
-                        ) from e
-                    delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
-                    logger.debug(
-                        "Exporter not ready, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
-                        delay,
-                        attempt + 1,
-                        remaining,
-                    )
-                    await sleep(delay)
-                    attempt += 1
-                    continue
-                if e.code() == grpc.StatusCode.UNAVAILABLE:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        logger.warning(
-                            "Exporter unavailable and dial timeout (%.1fs) exceeded after %d attempts",
-                            self.dial_timeout,
+                        await sleep(delay)
+                        attempt += 1
+                        continue
+                    if e.code() in (grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED):
+                        if unavailable_deadline is None:
+                            logger.warning("Exporter %s unavailable and retry disabled", self.exporter_name)
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} unavailable (retry disabled): {e.details()}"
+                            ) from e
+                        remaining = unavailable_deadline - time.monotonic()
+                        if remaining <= 0:
+                            elapsed = time.monotonic() - started
+                            logger.warning(
+                                "Exporter %s unavailable, retry budget (%.1fs) exceeded after %d attempts",
+                                self.exporter_name,
+                                unavail_budget,
+                                attempt + 1,
+                            )
+                            raise ExporterUnreachableError(
+                                f"Exporter {self.exporter_name} permanently unavailable after "
+                                f"{elapsed:.0f}s of retrying: {e.details()}"
+                            ) from e
+                        if not warned_unavailable:
+                            warned_unavailable = True
+                            logger.warning(
+                                "Controller/exporter %s unavailable, retrying for %.0fs...",
+                                self.exporter_name,
+                                unavail_budget,
+                            )
+                        delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
+                        logger.info(
+                            "Exporter unavailable, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
+                            delay,
                             attempt + 1,
+                            remaining,
                         )
+                        await sleep(delay)
+                        attempt += 1
+                        continue
+                    if (
+                        e.code() == grpc.StatusCode.PERMISSION_DENIED
+                        or "permission denied" in str(e.details()).lower()
+                    ):
+                        self.lease_transferred = True
                         raise ExporterUnreachableError(
-                            f"Exporter {self.exporter_name} unavailable after {self.dial_timeout:.0f}s"
+                            f"Lease {self.name} has been transferred to another client"
                         ) from e
-                    delay = min(base_delay * (2 ** min(attempt, 10)), max_delay, remaining)
-                    logger.warning(
-                        "Exporter unavailable, retrying Dial in %.1fs (attempt %d, %.1fs remaining)",
-                        delay,
-                        attempt + 1,
-                        remaining,
-                    )
-                    await sleep(delay)
-                    attempt += 1
-                    continue
-                # Exporter went offline or lease ended - raise immediately
-                if "permission denied" in str(e.details()).lower():
-                    self.lease_transferred = True
-                    logger.warning(
-                        "Lease %s has been transferred to another client. Your session is no longer valid.",
-                        self.name,
-                    )
                     raise ExporterUnreachableError(
-                        f"Lease {self.name} transferred to another client"
+                        f"Connection to exporter {self.exporter_name} lost: {e.details()}"
                     ) from e
-                logger.warning("Connection to exporter lost: %s", e.details())
+            try:
+                async with connect_router_stream(
+                    response.router_endpoint, response.router_token, stream, self.tls_config, self.grpc_options
+                ):
+                    self._connected = True
+            except grpc.aio.AioRpcError as e:
                 raise ExporterUnreachableError(
-                    f"Connection to exporter {self.exporter_name} lost: {e.details()}"
+                    f"Router {response.router_endpoint} unreachable: {e.details()}"
                 ) from e
+            except OSError as e:
+                raise ExporterUnreachableError(
+                    f"Router {response.router_endpoint} connection failed: {e}"
+                ) from e
+        except BaseException:
+            await stream.aclose()
+            raise
 
     @asynccontextmanager
     async def serve_unix_async(self):
-        # Wait for exporter readiness before accepting connections.
-        # The response is intentionally discarded — each connection needs
-        # its own Dial to get a unique router tunnel.
-        await self._dial_with_retry()
-
-        async def _tunnel_handler(stream):
-            try:
-                response = await self.controller.Dial(
-                    jumpstarter_pb2.DialRequest(lease_name=self.name)
-                )
-            except AioRpcError as e:
-                raise ExporterUnreachableError(
-                    f"Per-connection Dial failed for {self.exporter_name}: {e.details()}"
-                ) from e
-            async with connect_router_stream(
-                response.router_endpoint,
-                response.router_token,
-                stream,
-                self.tls_config,
-                self.grpc_options,
-            ):
-                pass
-
-        async with TemporaryUnixListener(_tunnel_handler) as path:
+        async with TemporaryUnixListener(self.handle_async) as path:
             logger.debug("Serving Unix socket at %s", path)
             yield path
 

--- a/python/packages/jumpstarter/jumpstarter/client/lease_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease_test.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import sys
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
@@ -31,6 +32,13 @@ class MockAioRpcError(AioRpcError):
 
     def details(self):
         return self._message
+
+
+def _mock_connect_router_stream(endpoint, token, stream, tls_config, grpc_options):
+    @asynccontextmanager
+    async def _ctx():
+        yield
+    return _ctx()
 
 
 class TestLeaseAcquisitionSpinner:
@@ -620,17 +628,26 @@ class TestMonitorAsyncError:
         assert remain_arg == timedelta(0)
 
 
-class TestDialWithRetry:
-    """Tests for Lease._dial_with_retry UNAVAILABLE retry behavior."""
+class TestHandleAsyncDialRetry:
+    """Tests for Dial retry behavior inside handle_async."""
 
-    def _make_lease_for_dial(self):
+    def _make_lease_for_dial(self, *, dial_timeout=5.0, retry_timeout=300.0):
         lease = object.__new__(Lease)
         lease.name = "test-lease"
         lease.exporter_name = "test-exporter"
-        lease.dial_timeout = 5.0
+        lease.dial_timeout = dial_timeout
+        lease.retry_timeout = retry_timeout
         lease.lease_transferred = False
+        lease._connected = False
         lease.controller = Mock()
+        lease.tls_config = Mock()
+        lease.grpc_options = {}
         return lease
+
+    def _make_mock_stream(self):
+        stream = Mock()
+        stream.aclose = AsyncMock()
+        return stream
 
     @pytest.mark.anyio
     async def test_dial_retries_unavailable_then_succeeds(self):
@@ -638,7 +655,7 @@ class TestDialWithRetry:
         lease = self._make_lease_for_dial()
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             if dial_call_count == 1:
@@ -647,85 +664,111 @@ class TestDialWithRetry:
 
         lease.controller.Dial = mock_dial
 
-        response = await lease._dial_with_retry()
+        with patch("jumpstarter.client.lease.connect_router_stream", new_callable=lambda: _mock_connect_router_stream):
+            await lease.handle_async(self._make_mock_stream())
 
         assert dial_call_count == 2
-        assert response.router_endpoint == "endpoint"
-        assert response.router_token == "token"
 
     @pytest.mark.anyio
-    async def test_dial_unavailable_exceeds_timeout_raises_exporter_unreachable(self):
-        """Dial returns UNAVAILABLE until dial_timeout is exceeded, raises ExporterUnreachableError."""
-
-        lease = self._make_lease_for_dial()
-        lease.dial_timeout = 0.5
+    async def test_dial_unavailable_exceeds_retry_timeout(self):
+        """Dial returns UNAVAILABLE until retry_timeout exceeded - raises ExporterUnreachableError."""
+        lease = self._make_lease_for_dial(retry_timeout=0.5)
+        lease._connected = True
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             raise MockAioRpcError(grpc.StatusCode.UNAVAILABLE, "permanently unavailable")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError):
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="permanently unavailable"):
+            await lease.handle_async(stream)
 
         assert dial_call_count >= 2
+        stream.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_dial_failed_precondition_exceeds_timeout_raises_exporter_unreachable(self):
-        """Dial returns FAILED_PRECONDITION until dial_timeout is exceeded, raises ExporterUnreachableError."""
-
-        lease = self._make_lease_for_dial()
-        lease.dial_timeout = 0.5
+    async def test_dial_failed_precondition_exceeds_dial_timeout(self):
+        """Dial returns FAILED_PRECONDITION until dial_timeout exceeded - raises ExporterUnreachableError."""
+        lease = self._make_lease_for_dial(dial_timeout=0.5)
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             raise MockAioRpcError(grpc.StatusCode.FAILED_PRECONDITION, "not ready")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError):
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="not ready"):
+            await lease.handle_async(stream)
 
         assert dial_call_count >= 2
+        stream.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_dial_permission_denied_raises_exporter_unreachable_and_sets_transferred(self):
-        """Dial returns permission denied error, raises ExporterUnreachableError and sets lease_transferred flag."""
-
+    async def test_dial_permission_denied_raises_and_sets_transferred(self):
+        """Permission denied sets lease_transferred and raises ExporterUnreachableError."""
         lease = self._make_lease_for_dial()
 
-        async def mock_dial(request):
-            raise MockAioRpcError(grpc.StatusCode.PERMISSION_DENIED, "permission denied")
+        async def mock_dial(request, **kwargs):
+            raise MockAioRpcError(grpc.StatusCode.UNKNOWN, "permission denied")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError) as exc_info:
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="transferred"):
+            await lease.handle_async(stream)
 
         assert lease.lease_transferred is True
-        assert "transferred to another client" in str(exc_info.value)
+        stream.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_dial_unknown_error_raises_exporter_unreachable(self):
-        """Dial returns unknown error, raises ExporterUnreachableError without retry."""
-
+    async def test_dial_unknown_error_raises(self):
+        """Unknown terminal error raises ExporterUnreachableError."""
         lease = self._make_lease_for_dial()
+        dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
+            nonlocal dial_call_count
+            dial_call_count += 1
             raise MockAioRpcError(grpc.StatusCode.INTERNAL, "something broke")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError) as exc_info:
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="something broke"):
+            await lease.handle_async(stream)
 
-        assert lease.lease_transferred is False
-        assert "lost" in str(exc_info.value).lower()
+        assert dial_call_count == 1
+        stream.aclose.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_dial_rpc_timeout_stays_capped_by_dial_timeout_during_retry(self):
+        """After dial_timeout elapses, each Dial RPC must still use up to
+        dial_timeout (not the 0.1s floor) while retry_timeout remains."""
+        lease = self._make_lease_for_dial(dial_timeout=0.2, retry_timeout=1.0)
+        lease._connected = True
+        samples = []
+        started = time.monotonic()
+
+        async def mock_dial(request, **kwargs):
+            samples.append((time.monotonic() - started, kwargs.get("timeout")))
+            raise MockAioRpcError(grpc.StatusCode.UNAVAILABLE, "controller restarting")
+
+        lease.controller.Dial = mock_dial
+
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="permanently unavailable"):
+            await lease.handle_async(stream)
+
+        late = [timeout for elapsed, timeout in samples if 0.25 < elapsed < 0.7]
+        assert late, "expected Dial retries after dial_timeout while retry budget remains"
+        assert all(timeout > 0.12 for timeout in late)
 
 
 class TestRequestAsyncExpiredLease:
@@ -822,8 +865,8 @@ class TestServeUnixAsync:
     """Unit tests for Lease.serve_unix_async."""
 
     @pytest.mark.anyio
-    async def test_serve_unix_async_readiness_check_and_per_connection_dial(self):
-        """serve_unix_async calls readiness check once, then per-connection Dial for each socket connection."""
+    async def test_serve_unix_async_per_connection_dial(self):
+        """serve_unix_async triggers per-connection Dial via handle_async for each socket connection."""
 
         lease = object.__new__(Lease)
         lease.name = "test-lease"
@@ -831,25 +874,20 @@ class TestServeUnixAsync:
         lease.tls_config = Mock()
         lease.grpc_options = {}
         lease.controller = Mock()
+        lease.dial_timeout = 5.0
+        lease.retry_timeout = 300.0
+        lease.lease_transferred = False
+        lease._connected = False
 
-        # Mock the readiness check
-        readiness_check_called = False
-
-        async def mock_dial_with_retry():
-            nonlocal readiness_check_called
-            readiness_check_called = True
-
-        # Mock per-connection Dial
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             return Mock(router_endpoint="test-endpoint", router_token="test-token")
 
         lease.controller.Dial = mock_dial
 
-        # Mock connect_router_stream
         router_stream_calls = []
 
         @asynccontextmanager
@@ -857,32 +895,23 @@ class TestServeUnixAsync:
             router_stream_calls.append((endpoint, token, tls_config, grpc_options))
             yield
 
-        with patch.object(lease, "_dial_with_retry", side_effect=mock_dial_with_retry):
-            with patch("jumpstarter.client.lease.connect_router_stream", side_effect=mock_connect_router_stream):
-                async with lease.serve_unix_async() as socket_path:
-                    # Readiness check should have been called
-                    assert readiness_check_called
+        with patch("jumpstarter.client.lease.connect_router_stream", side_effect=mock_connect_router_stream):
+            async with lease.serve_unix_async() as socket_path:
+                async with await anyio.connect_unix(socket_path):
+                    await anyio.sleep(0.1)
 
-                    # Connect to the Unix socket
-                    async with await anyio.connect_unix(socket_path):
-                        # Give the handler time to process
-                        await anyio.sleep(0.1)
-
-        # Verify per-connection Dial was called
         assert dial_call_count == 1
 
-        # Verify connect_router_stream was called with correct args
         assert len(router_stream_calls) == 1
-        endpoint, token, tls_config, grpc_options = router_stream_calls[0]
+        endpoint, token, tls_config, grpc_options = router_stream_calls[-1]
         assert endpoint == "test-endpoint"
         assert token == "test-token"
         assert tls_config is lease.tls_config
         assert grpc_options is lease.grpc_options
 
     @pytest.mark.anyio
-    async def test_serve_unix_async_per_connection_dial_failure_wrapped(self):
-        """Per-connection Dial failure raises ExporterUnreachableError instead of raw AioRpcError."""
-        from grpc import StatusCode
+    async def test_serve_unix_async_per_connection_dial_failure_raises(self):
+        """Per-connection Dial failure in handle_async raises ExporterUnreachableError."""
 
         lease = object.__new__(Lease)
         lease.name = "test-lease"
@@ -890,31 +919,20 @@ class TestServeUnixAsync:
         lease.tls_config = Mock()
         lease.grpc_options = {}
         lease.controller = Mock()
+        lease.dial_timeout = 0.3
+        lease.retry_timeout = 0
+        lease.lease_transferred = False
+        lease._connected = False
 
-        # Mock the readiness check
-        async def mock_dial_with_retry():
-            pass
-
-        # Mock per-connection Dial to raise AioRpcError
-        async def mock_dial_failure(request):
-            raise AioRpcError(
-                code=StatusCode.UNAVAILABLE,
-                initial_metadata=None,
-                trailing_metadata=None,
-                details="exporter offline",
-            )
+        async def mock_dial_failure(request, **kwargs):
+            raise MockAioRpcError(grpc.StatusCode.INTERNAL, "exporter offline")
 
         lease.controller.Dial = mock_dial_failure
 
-        # The ExceptionGroup surfaces when the TemporaryUnixListener task group
-        # tears down, so pytest.raises must wrap the entire serve_unix_async block.
-        with patch.object(lease, "_dial_with_retry", side_effect=mock_dial_with_retry):
-            with pytest.raises(BaseExceptionGroup) as exc_info:
-                async with lease.serve_unix_async() as socket_path:
-                    async with await anyio.connect_unix(socket_path):
-                        await anyio.sleep(0.1)
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async with lease.serve_unix_async() as socket_path:
+                async with await anyio.connect_unix(socket_path):
+                    await anyio.sleep(0.1)
 
-            exceptions = exc_info.value.exceptions
-            assert len(exceptions) == 1
-            assert isinstance(exceptions[0], ExporterUnreachableError)
-            assert "Per-connection Dial failed" in str(exceptions[0])
+        exceptions = exc_info.value.exceptions
+        assert any(isinstance(e, ExporterUnreachableError) for e in exceptions)

--- a/python/packages/jumpstarter/jumpstarter/client/lease_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease_test.py
@@ -33,6 +33,13 @@ class MockAioRpcError(AioRpcError):
         return self._message
 
 
+def _mock_connect_router_stream(endpoint, token, stream, tls_config, grpc_options):
+    @asynccontextmanager
+    async def _ctx():
+        yield
+    return _ctx()
+
+
 class TestLeaseAcquisitionSpinner:
     """Test cases for LeaseAcquisitionSpinner class."""
 
@@ -578,17 +585,26 @@ class TestMonitorAsyncError:
         assert remain_arg == timedelta(0)
 
 
-class TestDialWithRetry:
-    """Tests for Lease._dial_with_retry UNAVAILABLE retry behavior."""
+class TestHandleAsyncDialRetry:
+    """Tests for Dial retry behavior inside handle_async."""
 
-    def _make_lease_for_dial(self):
+    def _make_lease_for_dial(self, *, dial_timeout=5.0, retry_timeout=300.0):
         lease = object.__new__(Lease)
         lease.name = "test-lease"
         lease.exporter_name = "test-exporter"
-        lease.dial_timeout = 5.0
+        lease.dial_timeout = dial_timeout
+        lease.retry_timeout = retry_timeout
         lease.lease_transferred = False
+        lease._connected = False
         lease.controller = Mock()
+        lease.tls_config = Mock()
+        lease.grpc_options = {}
         return lease
+
+    def _make_mock_stream(self):
+        stream = Mock()
+        stream.aclose = AsyncMock()
+        return stream
 
     @pytest.mark.anyio
     async def test_dial_retries_unavailable_then_succeeds(self):
@@ -596,7 +612,7 @@ class TestDialWithRetry:
         lease = self._make_lease_for_dial()
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             if dial_call_count == 1:
@@ -605,85 +621,88 @@ class TestDialWithRetry:
 
         lease.controller.Dial = mock_dial
 
-        response = await lease._dial_with_retry()
+        with patch("jumpstarter.client.lease.connect_router_stream", new_callable=lambda: _mock_connect_router_stream):
+            await lease.handle_async(self._make_mock_stream())
 
         assert dial_call_count == 2
-        assert response.router_endpoint == "endpoint"
-        assert response.router_token == "token"
 
     @pytest.mark.anyio
-    async def test_dial_unavailable_exceeds_timeout_raises_exporter_unreachable(self):
-        """Dial returns UNAVAILABLE until dial_timeout is exceeded, raises ExporterUnreachableError."""
-
-        lease = self._make_lease_for_dial()
-        lease.dial_timeout = 0.5
+    async def test_dial_unavailable_exceeds_retry_timeout(self):
+        """Dial returns UNAVAILABLE until retry_timeout exceeded - raises ExporterUnreachableError."""
+        lease = self._make_lease_for_dial(retry_timeout=0.5)
+        lease._connected = True
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             raise MockAioRpcError(grpc.StatusCode.UNAVAILABLE, "permanently unavailable")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError):
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="permanently unavailable"):
+            await lease.handle_async(stream)
 
         assert dial_call_count >= 2
+        stream.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_dial_failed_precondition_exceeds_timeout_raises_exporter_unreachable(self):
-        """Dial returns FAILED_PRECONDITION until dial_timeout is exceeded, raises ExporterUnreachableError."""
-
-        lease = self._make_lease_for_dial()
-        lease.dial_timeout = 0.5
+    async def test_dial_failed_precondition_exceeds_dial_timeout(self):
+        """Dial returns FAILED_PRECONDITION until dial_timeout exceeded - raises ExporterUnreachableError."""
+        lease = self._make_lease_for_dial(dial_timeout=0.5)
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             raise MockAioRpcError(grpc.StatusCode.FAILED_PRECONDITION, "not ready")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError):
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="not ready"):
+            await lease.handle_async(stream)
 
         assert dial_call_count >= 2
+        stream.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_dial_permission_denied_raises_exporter_unreachable_and_sets_transferred(self):
-        """Dial returns permission denied error, raises ExporterUnreachableError and sets lease_transferred flag."""
-
+    async def test_dial_permission_denied_raises_and_sets_transferred(self):
+        """Permission denied sets lease_transferred and raises ExporterUnreachableError."""
         lease = self._make_lease_for_dial()
 
-        async def mock_dial(request):
-            raise MockAioRpcError(grpc.StatusCode.PERMISSION_DENIED, "permission denied")
+        async def mock_dial(request, **kwargs):
+            raise MockAioRpcError(grpc.StatusCode.UNKNOWN, "permission denied")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError) as exc_info:
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="transferred"):
+            await lease.handle_async(stream)
 
         assert lease.lease_transferred is True
-        assert "transferred to another client" in str(exc_info.value)
+        stream.aclose.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_dial_unknown_error_raises_exporter_unreachable(self):
-        """Dial returns unknown error, raises ExporterUnreachableError without retry."""
-
+    async def test_dial_unknown_error_raises(self):
+        """Unknown terminal error raises ExporterUnreachableError."""
         lease = self._make_lease_for_dial()
+        dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
+            nonlocal dial_call_count
+            dial_call_count += 1
             raise MockAioRpcError(grpc.StatusCode.INTERNAL, "something broke")
 
         lease.controller.Dial = mock_dial
 
-        with pytest.raises(ExporterUnreachableError) as exc_info:
-            await lease._dial_with_retry()
+        stream = self._make_mock_stream()
+        with pytest.raises(ExporterUnreachableError, match="something broke"):
+            await lease.handle_async(stream)
 
-        assert lease.lease_transferred is False
-        assert "lost" in str(exc_info.value).lower()
+        assert dial_call_count == 1
+        stream.aclose.assert_awaited_once()
 
 
 class TestRequestAsyncExpiredLease:
@@ -780,8 +799,8 @@ class TestServeUnixAsync:
     """Unit tests for Lease.serve_unix_async."""
 
     @pytest.mark.anyio
-    async def test_serve_unix_async_readiness_check_and_per_connection_dial(self):
-        """serve_unix_async calls readiness check once, then per-connection Dial for each socket connection."""
+    async def test_serve_unix_async_per_connection_dial(self):
+        """serve_unix_async triggers per-connection Dial via handle_async for each socket connection."""
 
         lease = object.__new__(Lease)
         lease.name = "test-lease"
@@ -789,25 +808,20 @@ class TestServeUnixAsync:
         lease.tls_config = Mock()
         lease.grpc_options = {}
         lease.controller = Mock()
+        lease.dial_timeout = 5.0
+        lease.retry_timeout = 300.0
+        lease.lease_transferred = False
+        lease._connected = False
 
-        # Mock the readiness check
-        readiness_check_called = False
-
-        async def mock_dial_with_retry():
-            nonlocal readiness_check_called
-            readiness_check_called = True
-
-        # Mock per-connection Dial
         dial_call_count = 0
 
-        async def mock_dial(request):
+        async def mock_dial(request, **kwargs):
             nonlocal dial_call_count
             dial_call_count += 1
             return Mock(router_endpoint="test-endpoint", router_token="test-token")
 
         lease.controller.Dial = mock_dial
 
-        # Mock connect_router_stream
         router_stream_calls = []
 
         @asynccontextmanager
@@ -815,32 +829,23 @@ class TestServeUnixAsync:
             router_stream_calls.append((endpoint, token, tls_config, grpc_options))
             yield
 
-        with patch.object(lease, "_dial_with_retry", side_effect=mock_dial_with_retry):
-            with patch("jumpstarter.client.lease.connect_router_stream", side_effect=mock_connect_router_stream):
-                async with lease.serve_unix_async() as socket_path:
-                    # Readiness check should have been called
-                    assert readiness_check_called
+        with patch("jumpstarter.client.lease.connect_router_stream", side_effect=mock_connect_router_stream):
+            async with lease.serve_unix_async() as socket_path:
+                async with await anyio.connect_unix(socket_path):
+                    await anyio.sleep(0.1)
 
-                    # Connect to the Unix socket
-                    async with await anyio.connect_unix(socket_path):
-                        # Give the handler time to process
-                        await anyio.sleep(0.1)
-
-        # Verify per-connection Dial was called
         assert dial_call_count == 1
 
-        # Verify connect_router_stream was called with correct args
         assert len(router_stream_calls) == 1
-        endpoint, token, tls_config, grpc_options = router_stream_calls[0]
+        endpoint, token, tls_config, grpc_options = router_stream_calls[-1]
         assert endpoint == "test-endpoint"
         assert token == "test-token"
         assert tls_config is lease.tls_config
         assert grpc_options is lease.grpc_options
 
     @pytest.mark.anyio
-    async def test_serve_unix_async_per_connection_dial_failure_wrapped(self):
-        """Per-connection Dial failure raises ExporterUnreachableError instead of raw AioRpcError."""
-        from grpc import StatusCode
+    async def test_serve_unix_async_per_connection_dial_failure_raises(self):
+        """Per-connection Dial failure in handle_async raises ExporterUnreachableError."""
 
         lease = object.__new__(Lease)
         lease.name = "test-lease"
@@ -848,31 +853,20 @@ class TestServeUnixAsync:
         lease.tls_config = Mock()
         lease.grpc_options = {}
         lease.controller = Mock()
+        lease.dial_timeout = 0.3
+        lease.retry_timeout = 0
+        lease.lease_transferred = False
+        lease._connected = False
 
-        # Mock the readiness check
-        async def mock_dial_with_retry():
-            pass
-
-        # Mock per-connection Dial to raise AioRpcError
-        async def mock_dial_failure(request):
-            raise AioRpcError(
-                code=StatusCode.UNAVAILABLE,
-                initial_metadata=None,
-                trailing_metadata=None,
-                details="exporter offline",
-            )
+        async def mock_dial_failure(request, **kwargs):
+            raise MockAioRpcError(grpc.StatusCode.INTERNAL, "exporter offline")
 
         lease.controller.Dial = mock_dial_failure
 
-        # The ExceptionGroup surfaces when the TemporaryUnixListener task group
-        # tears down, so pytest.raises must wrap the entire serve_unix_async block.
-        with patch.object(lease, "_dial_with_retry", side_effect=mock_dial_with_retry):
-            with pytest.raises(BaseExceptionGroup) as exc_info:
-                async with lease.serve_unix_async() as socket_path:
-                    async with await anyio.connect_unix(socket_path):
-                        await anyio.sleep(0.1)
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async with lease.serve_unix_async() as socket_path:
+                async with await anyio.connect_unix(socket_path):
+                    await anyio.sleep(0.1)
 
-            exceptions = exc_info.value.exceptions
-            assert len(exceptions) == 1
-            assert isinstance(exceptions[0], ExporterUnreachableError)
-            assert "Per-connection Dial failed" in str(exceptions[0])
+        exceptions = exc_info.value.exceptions
+        assert any(isinstance(e, ExporterUnreachableError) for e in exceptions)


### PR DESCRIPTION

Replace pre-flight _dial_with_retry with handle_async that retries Dial on every Unix socket connection independently. Use dial_timeout (60s) for FAILED_PRECONDITION ("not ready") and retry_timeout (300s, only when _connected=True) for UNAVAILABLE, so initial lease acquisition stays fast while established sessions survive controller restarts.

Fix permission-denied detection: controller sends fmt.Errorf("permission denied") which maps to UNKNOWN, not PERMISSION_DENIED - match on details text instead of status code.

Depends on #950