### PR TITLE
fix: backport retry transient gRPC failures in status reports (#911) to release-0.9

### DIFF
--- a/controller/internal/service/auth/auth.go
+++ b/controller/internal/service/auth/auth.go
@@ -8,9 +8,11 @@ import (
 	"github.com/jumpstarter-dev/jumpstarter-controller/internal/authorization"
 	"github.com/jumpstarter-dev/jumpstarter-controller/internal/oidc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Auth struct {
@@ -54,7 +56,9 @@ func (s *Auth) AuthClient(ctx context.Context, namespace string) (*jumpstarterde
 	return jclient, nil
 }
 
-func (s *Auth) AuthExporter(ctx context.Context, namespace string) (*jumpstarterdevv1alpha1.Exporter, error) {
+// VerifyExporter authenticates the exporter token in ctx and returns the
+// matching Exporter object without enforcing a namespace.
+func (s *Auth) VerifyExporter(ctx context.Context) (*jumpstarterdevv1alpha1.Exporter, error) {
 	jexporter, err := oidc.VerifyExporterObjectToken(
 		ctx,
 		s.authn,
@@ -63,6 +67,27 @@ func (s *Auth) AuthExporter(ctx context.Context, namespace string) (*jumpstarter
 		s.client,
 	)
 
+	if err != nil {
+		log.FromContext(ctx).Info("exporter authentication failed", "error", err.Error())
+		return nil, err
+	}
+
+	return jexporter, nil
+}
+
+// IsExporter checks the jumpstarter-kind metadata to determine if the caller
+// is an exporter.
+func (s *Auth) IsExporter(ctx context.Context) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	kinds := md.Get("jumpstarter-kind")
+	return len(kinds) == 1 && kinds[0] == "Exporter"
+}
+
+func (s *Auth) AuthExporter(ctx context.Context, namespace string) (*jumpstarterdevv1alpha1.Exporter, error) {
+	jexporter, err := s.VerifyExporter(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/internal/service/auth/auth_test.go
+++ b/controller/internal/service/auth/auth_test.go
@@ -1,0 +1,114 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter-controller/internal/authentication"
+	"google.golang.org/grpc/metadata"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type stubAuthenticator struct {
+	resp *authenticator.Response
+	ok   bool
+	err  error
+}
+
+func (s *stubAuthenticator) AuthenticateContext(_ context.Context) (*authenticator.Response, bool, error) {
+	return s.resp, s.ok, s.err
+}
+
+type stubAttributesGetter struct {
+	attrs authorizer.Attributes
+	err   error
+}
+
+func (s *stubAttributesGetter) ContextAttributes(_ context.Context, _ user.Info) (authorizer.Attributes, error) {
+	return s.attrs, s.err
+}
+
+type stubAuthorizer struct {
+	decision authorizer.Decision
+	reason   string
+	err      error
+}
+
+func (s *stubAuthorizer) Authorize(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+	return s.decision, s.reason, s.err
+}
+
+func buildScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = jumpstarterdevv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
+func newFakeClient(objs ...kclient.Object) kclient.Client {
+	return fake.NewClientBuilder().
+		WithScheme(buildScheme()).
+		WithObjects(objs...).
+		Build()
+}
+
+func newAuth(authn authentication.ContextAuthenticator, authz *stubAuthorizer, attr *stubAttributesGetter, objs ...kclient.Object) *Auth {
+	return NewAuth(newFakeClient(objs...), authn, authz, attr)
+}
+
+func TestIsExporter(t *testing.T) {
+	authn := &stubAuthenticator{}
+	attr := &stubAttributesGetter{}
+	authz := &stubAuthorizer{}
+	a := newAuth(authn, authz, attr)
+
+	tests := []struct {
+		name     string
+		metadata metadata.MD
+		want     bool
+	}{
+		{
+			name:     "exporter kind",
+			metadata: metadata.Pairs("jumpstarter-kind", "Exporter"),
+			want:     true,
+		},
+		{
+			name:     "client kind",
+			metadata: metadata.Pairs("jumpstarter-kind", "Client"),
+			want:     false,
+		},
+		{
+			name:     "no metadata",
+			metadata: metadata.MD{},
+			want:     false,
+		},
+		{
+			name:     "missing kind",
+			metadata: metadata.Pairs("jumpstarter-namespace", "default"),
+			want:     false,
+		},
+		{
+			name:     "multiple kind values",
+			metadata: metadata.Pairs("jumpstarter-kind", "Exporter", "jumpstarter-kind", "Client"),
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if len(tt.metadata) > 0 {
+				ctx = metadata.NewIncomingContext(ctx, tt.metadata)
+			}
+			got := a.IsExporter(ctx)
+			if got != tt.want {
+				t.Errorf("IsExporter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/internal/service/controller_service.go
+++ b/controller/internal/service/controller_service.go
@@ -55,6 +55,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -1035,10 +1036,55 @@ func (s *ControllerService) RequestLease(
 	}, nil
 }
 
+func (s *ControllerService) releaseLeaseAsExporter(
+	ctx context.Context,
+	exporter *jumpstarterdevv1alpha1.Exporter,
+	req *pb.ReleaseLeaseRequest,
+) (*pb.ReleaseLeaseResponse, error) {
+	var lease jumpstarterdevv1alpha1.Lease
+	if err := s.Client.Get(ctx, types.NamespacedName{
+		Namespace: exporter.Namespace,
+		Name:      req.Name,
+	}, &lease); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "lease %s not found", req.Name)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get lease: %s", err)
+	}
+
+	if lease.Status.ExporterRef == nil || lease.Status.ExporterRef.Name != exporter.Name {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"lease %s is not held by exporter %s", req.Name, exporter.Name)
+	}
+
+	// Idempotent: already ended or marked for release
+	if lease.Status.Ended || lease.Spec.Release {
+		return &pb.ReleaseLeaseResponse{}, nil
+	}
+
+	original := client.MergeFrom(lease.DeepCopy())
+	lease.Spec.Release = true
+
+	if err := s.Client.Patch(ctx, &lease, original); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to mark lease for release: %s", err)
+	}
+
+	return &pb.ReleaseLeaseResponse{}, nil
+}
+
 func (s *ControllerService) ReleaseLease(
 	ctx context.Context,
 	req *pb.ReleaseLeaseRequest,
 ) (*pb.ReleaseLeaseResponse, error) {
+	// Route based on jumpstarter-kind metadata to avoid spurious auth failures
+	if auth.NewAuth(s.Client, s.Authn, s.Authz, s.Attr).IsExporter(ctx) {
+		exporter, err := s.authenticateExporter(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return s.releaseLeaseAsExporter(ctx, exporter, req)
+	}
+
 	jclient, err := s.authenticateClient(ctx)
 	if err != nil {
 		return nil, err
@@ -1054,6 +1100,11 @@ func (s *ControllerService) ReleaseLease(
 
 	if lease.Spec.ClientRef.Name != jclient.Name {
 		return nil, fmt.Errorf("ReleaseLease permission denied")
+	}
+
+	// Idempotent: already ended or marked for release
+	if lease.Status.Ended || lease.Spec.Release {
+		return &pb.ReleaseLeaseResponse{}, nil
 	}
 
 	original := client.MergeFrom(lease.DeepCopy())

--- a/controller/internal/service/controller_service_integration_test.go
+++ b/controller/internal/service/controller_service_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	pb "github.com/jumpstarter-dev/jumpstarter-controller/internal/protocol/jumpstarter/v1"
 )
 
 var _ = Describe("ControllerService Integration", func() {
@@ -267,6 +268,190 @@ var _ = Describe("ControllerService Integration", func() {
 			err := controllerService.handleExporterLeaseRelease(ctx, exporter)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not held by exporter"))
+		})
+	})
+
+	Context("releaseLeaseAsExporter", func() {
+		var (
+			controllerService *ControllerService
+			exporter          *jumpstarterdevv1alpha1.Exporter
+			lease             *jumpstarterdevv1alpha1.Lease
+		)
+
+		BeforeEach(func() {
+			controllerService = &ControllerService{
+				Client: k8sClient,
+			}
+		})
+
+		AfterEach(func() {
+			// Clean up resources
+			if exporter != nil {
+				_ = k8sClient.Delete(ctx, exporter)
+			}
+			if lease != nil {
+				_ = k8sClient.Delete(ctx, lease)
+			}
+		})
+
+		It("should release lease when called by owning exporter", func() {
+			// Create lease
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-release-by-exporter",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status to have ExporterRef
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "test-exporter"},
+				Ended:       false,
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-release-by-exporter"}
+			resp, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+
+			// Verify lease was marked for release
+			var updatedLease jumpstarterdevv1alpha1.Lease
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "lease-release-by-exporter",
+			}, &updatedLease)).To(Succeed())
+			Expect(updatedLease.Spec.Release).To(BeTrue())
+		})
+
+		It("should return permission denied when exporter doesn't own lease", func() {
+			// Create lease owned by different exporter
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-owned-by-other",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status with different exporter
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "other-exporter"},
+				Ended:       false,
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-owned-by-other"}
+			_, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not held by exporter"))
+		})
+
+		It("should be idempotent when lease already marked for release", func() {
+			// Create lease already marked for release
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-already-releasing",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   true, // Already marked for release
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "test-exporter"},
+				Ended:       false,
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-already-releasing"}
+			resp, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("should be idempotent when lease already ended", func() {
+			// Create ended lease
+			lease = &jumpstarterdevv1alpha1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lease-already-ended",
+					Namespace: testNamespace,
+				},
+				Spec: jumpstarterdevv1alpha1.LeaseSpec{
+					ClientRef: corev1.LocalObjectReference{Name: "test-client"},
+					Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+					Release:   false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+
+			// Update lease status as ended
+			lease.Status = jumpstarterdevv1alpha1.LeaseStatus{
+				ExporterRef: &corev1.LocalObjectReference{Name: "test-exporter"},
+				Ended:       true, // Already ended
+			}
+			Expect(k8sClient.Status().Update(ctx, lease)).To(Succeed())
+
+			// Create exporter
+			exporter = &jumpstarterdevv1alpha1.Exporter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exporter",
+					Namespace: testNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, exporter)).To(Succeed())
+
+			// Call releaseLeaseAsExporter
+			req := &pb.ReleaseLeaseRequest{Name: "lease-already-ended"}
+			resp, err := controllerService.releaseLeaseAsExporter(ctx, exporter, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
 		})
 	})
 })

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -35,6 +35,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# gRPC retry configuration
+# Worst case ~18 min (21 attempts × 30s timeout + backoff sum ~8 min).
+# The exporter has nothing useful to do while the controller is unreachable —
+# even a restart just fails at _register_with_controller (no retry).
+_TRANSIENT_GRPC_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED})
+_RPC_MAX_RETRIES = 20
+_RPC_BACKOFF_BASE = 1.0
+_RPC_BACKOFF_CAP = 30.0
+_RPC_TIMEOUT = 30
+
+# Status codes indicating old controller without exporter auth on ReleaseLease
+_RELEASE_LEASE_UNSUPPORTED_CODES = frozenset({
+    grpc.StatusCode.PERMISSION_DENIED,
+    grpc.StatusCode.INVALID_ARGUMENT,
+    grpc.StatusCode.UNAUTHENTICATED,
+    grpc.StatusCode.UNIMPLEMENTED,
+})
+
 
 async def _standalone_shutdown_waiter():
     """Wait forever; used so serve_standalone_tcp can be cancelled by stop()."""
@@ -183,6 +201,32 @@ class Exporter(AsyncContextManagerMixin, Metadata):
     ensuring proper cleanup when the lease ends. The LeaseScope itself is just
     a reference holder and doesn't manage resource lifecycles directly.
     """
+
+    _release_lease_unsupported: bool = field(init=False, default=False)
+    """Caches whether the controller doesn't support exporter auth on ReleaseLease.
+
+    When True, _request_lease_release skips the ReleaseLease RPC and goes straight
+    to the deprecated ReportStatus(release_lease=true) fallback. Avoids rediscovering
+    the auth rejection on every lease cycle.
+    TODO: Remove this field when all controllers support ReleaseLease for exporters.
+    """
+
+    _status_drain_active: bool = field(init=False, default=False)
+    """True only while serve()'s task group is running and the drain task is active.
+
+    When True, _report_status enqueues status updates for background processing.
+    When False (registration, unregistration), _report_status awaits directly.
+    """
+
+    _pending_status_request: jumpstarter_pb2.ReportStatusRequest | None = field(init=False, default=None)
+    """Latest status update pending delivery by the background drain task.
+
+    "Latest wins" semantics: if multiple _report_status calls happen while the
+    drain task is busy retrying, only the most recent one is sent.
+    """
+
+    _status_rpc_event: Event = field(init=False, default_factory=Event)
+    """Signals the drain task that a new status update is pending."""
 
     def stop(self, wait_for_lease_exit=False, should_unregister=False, exit_code: int | None = None):
         """Signal the exporter to stop.
@@ -335,6 +379,88 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         if self._lease_context is None:
             await self._report_status(ExporterStatus.AVAILABLE, "Exporter registered and available")
 
+    async def _retry_rpc(
+        self,
+        rpc_call: Callable,
+        description: str,
+        *,
+        non_retryable_codes: frozenset[grpc.StatusCode] = frozenset(),
+    ) -> tuple[bool, grpc.StatusCode | None]:
+        """Retry a unary gRPC call with exponential backoff.
+
+        Args:
+            rpc_call: Async callable that takes a controller stub and performs the RPC
+            description: Human-readable description for log messages
+            non_retryable_codes: gRPC status codes that should cause immediate return
+                without retry (e.g. UNIMPLEMENTED for unsupported RPCs)
+
+        Returns:
+            (True, None) on success.
+            (False, status_code) on non-retryable error or retry exhaustion.
+            (False, None) on non-gRPC exception.
+        """
+        for attempt in range(_RPC_MAX_RETRIES + 1):
+            try:
+                async with self._controller_stub() as controller:
+                    await rpc_call(controller)
+                return True, None
+            except grpc.aio.AioRpcError as e:
+                if e.code() in non_retryable_codes:
+                    return False, e.code()
+                if e.code() in _TRANSIENT_GRPC_CODES and attempt < _RPC_MAX_RETRIES:
+                    backoff = min(_RPC_BACKOFF_BASE * (2**attempt), _RPC_BACKOFF_CAP)
+                    logger.warning(
+                        "Transient error %s (attempt %d/%d), retrying in %.1fs: %s",
+                        description,
+                        attempt + 1,
+                        _RPC_MAX_RETRIES + 1,
+                        backoff,
+                        e,
+                    )
+                    await anyio.sleep(backoff)
+                    continue
+                logger.error("Failed to %s: %s", description, e)
+                return False, e.code()
+            except Exception as e:
+                logger.error("Failed to %s: %s", description, e)
+                return False, None
+
+    async def _send_report_status_rpc(self, request: jumpstarter_pb2.ReportStatusRequest) -> bool:
+        """Send ReportStatus RPC to the controller with retry on transient errors.
+
+        Returns:
+            True if the RPC succeeded, False if unsupported or retries exhausted
+        """
+        ok, code = await self._retry_rpc(
+            lambda ctrl: ctrl.ReportStatus(request, timeout=_RPC_TIMEOUT),
+            "report status",
+            non_retryable_codes=frozenset({grpc.StatusCode.UNIMPLEMENTED}),
+        )
+        if not ok and code == grpc.StatusCode.UNIMPLEMENTED:
+            # Legacy support: ReportStatus added Nov 2025 (commit b76f6c87).
+            # All production controllers support it; safe to remove in future versions.
+            logger.warning("ReportStatus not supported by controller, status updates will be skipped")
+        return ok
+
+    async def _drain_status_reports(self):
+        """Background task that sends status updates to the controller.
+
+        Runs during serve() to make _report_status non-blocking. Uses "latest wins"
+        semantics: if multiple status updates arrive while retrying, only the most
+        recent one is sent. This prevents blocking the client connection path when
+        the controller is temporarily unreachable.
+        """
+        while True:
+            await self._status_rpc_event.wait()
+            self._status_rpc_event = Event()  # Reset for next update
+            request = self._pending_status_request
+            if request and await self._send_report_status_rpc(request):
+                logger.info(
+                    "Updated status to %s: %s",
+                    ExporterStatus.from_proto(request.status),
+                    request.message,
+                )
+
     async def _report_status(self, status: ExporterStatus, message: str = ""):
         """Report the exporter status with the controller and session."""
         self._exporter_status = status
@@ -348,22 +474,42 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             logger.debug("Updated status to %s: %s (standalone, no controller)", status, message)
             return
 
-        try:
-            async with self._controller_stub() as controller:
-                await controller.ReportStatus(
-                    jumpstarter_pb2.ReportStatusRequest(
-                        status=status.to_proto(),
-                        message=message,
-                    )
-                )
-            logger.info(f"Updated status to {status}: {message}")
-        except grpc.aio.AioRpcError as e:
-            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
-                logger.warning("ReportStatus not supported by controller, status updates will be skipped")
-            else:
-                logger.error(f"Failed to update status: {e}")
-        except Exception as e:
-            logger.error(f"Failed to update status: {e}")
+        request = jumpstarter_pb2.ReportStatusRequest(
+            status=status.to_proto(),
+            message=message,
+        )
+
+        if self._status_drain_active:
+            # During serve(): enqueue for background drain (non-blocking)
+            self._pending_status_request = request
+            self._status_rpc_event.set()
+        else:
+            # Outside serve() (registration, unregistration): send directly
+            if await self._send_report_status_rpc(request):
+                logger.info("Updated status to %s: %s", status, message)
+
+    async def _send_compat_release(self, lease_name: str):
+        """Release lease via ReportStatus with release_lease=true (DEPRECATED).
+
+        Backward-compat fallback for controllers that don't support exporter auth
+        on ReleaseLease. Uses non-AVAILABLE status to block new lease assignment
+        (filterOutNotReadyExporters) until the final AVAILABLE status, preventing
+        retry from releasing a newly-assigned lease.
+
+        TODO: Remove when all controllers support ReleaseLease for exporters.
+        """
+        release_status = self._exporter_status
+        if release_status == ExporterStatus.AVAILABLE:
+            release_status = ExporterStatus.AFTER_LEASE_HOOK
+
+        if await self._send_report_status_rpc(
+            jumpstarter_pb2.ReportStatusRequest(
+                status=release_status.to_proto(),
+                message="Lease released (compat: ReportStatus with release_lease)",
+                release_lease=True,
+            )
+        ):
+            logger.info("Requested controller to release lease %s (compat path)", lease_name)
 
     async def _request_lease_release(self):
         """Request the controller to release the current lease.
@@ -371,14 +517,17 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         Called after the afterLease hook completes to ensure the lease is
         released even if the client disconnects unexpectedly. This moves
         the lease release responsibility from the client to the exporter.
+
+        Tries the ReleaseLease RPC first (semantically correct, retry-safe).
+        Falls back to ReportStatus(release_lease=true) for old controllers that
+        don't support exporter auth on ReleaseLease (deprecated path).
         """
         if not self._lease_context or not self._lease_context.lease_name:
             logger.debug("No active lease to release")
             return
 
         # If the lease has already ended (controller sent leased=false, or a previous
-        # call already released it), skip the release RPC. A stale release_lease=true
-        # would release a subsequently-assigned lease on the controller.
+        # call already released it), skip the release RPC.
         if self._lease_context.lease_ended.is_set():
             logger.debug("Lease already ended, skipping release request")
             return
@@ -387,20 +536,33 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             self._lease_context.lease_ended.set()
             return
 
-        try:
-            async with self._controller_stub() as controller:
-                await controller.ReportStatus(
-                    jumpstarter_pb2.ReportStatusRequest(
-                        status=ExporterStatus.AVAILABLE.to_proto(),
-                        message="Lease released after afterLease hook",
-                        release_lease=True,
-                    )
+        lease_name = self._lease_context.lease_name
+
+        if self._release_lease_unsupported:
+            await self._send_compat_release(lease_name)
+        else:
+            ok, code = await self._retry_rpc(
+                lambda ctrl: ctrl.ReleaseLease(
+                    jumpstarter_pb2.ReleaseLeaseRequest(name=lease_name), timeout=_RPC_TIMEOUT
+                ),
+                "release lease",
+                non_retryable_codes=_RELEASE_LEASE_UNSUPPORTED_CODES,
+            )
+
+            if ok:
+                logger.info("Released lease %s via ReleaseLease RPC", lease_name)
+            elif code in _RELEASE_LEASE_UNSUPPORTED_CODES:
+                self._release_lease_unsupported = True
+                logger.info(
+                    "Controller doesn't support ReleaseLease for exporters (%s), "
+                    "falling back to ReportStatus with release_lease",
+                    code.name,
                 )
-            logger.info("Requested controller to release lease %s", self._lease_context.lease_name)
-        except Exception as e:
-            logger.error("Failed to request lease release: %s", e)
-            # Fall through - the client can still release the lease as a fallback,
-            # or the lease will eventually expire
+                await self._send_compat_release(lease_name)
+            else:
+                logger.warning("Failed to release lease %s after retries, proceeding to AVAILABLE", lease_name)
+
+        await self._report_status(ExporterStatus.AVAILABLE, "Exporter available after lease release")
 
         # Directly signal lease ended so handle_lease can exit.
         # The controller may not send another leased=False after our release request,
@@ -790,6 +952,11 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
         async with create_task_group() as tg:
             self._tg = tg
+            # Start background status drain (makes _report_status non-blocking)
+            self._status_rpc_event = Event()
+            self._pending_status_request = None
+            self._status_drain_active = True
+            tg.start_soon(self._drain_status_reports)
             # Start status stream with retry logic
             tg.start_soon(
                 self._retry_stream,
@@ -861,6 +1028,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
                 self._previous_leased = current_leased
         self._tg = None
+        self._status_drain_active = False
 
     async def serve_standalone_tcp(
         self,

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -16,6 +16,12 @@ import pytest
 from anyio import Event, create_task_group
 
 from jumpstarter.common import ExporterStatus
+from jumpstarter.exporter.exporter import (
+    _RPC_BACKOFF_BASE,
+    _RPC_BACKOFF_CAP,
+    _RPC_MAX_RETRIES,
+    _RPC_TIMEOUT,
+)
 from jumpstarter.exporter.lease_context import LeaseContext
 
 pytestmark = pytest.mark.anyio
@@ -439,6 +445,7 @@ def _make_exporter_for_report_status():
     exporter._exporter_status = ExporterStatus.AVAILABLE
     exporter._lease_context = None
     exporter._standalone = False
+    exporter._release_lease_unsupported = False
     return exporter
 
 
@@ -487,24 +494,36 @@ class TestBeforeLeaseHookRaceGuard:
         )
 
 
+def _setup_mock_controller_stub(exporter, side_effect=None):
+    """Helper to set up mock controller stub for testing ReportStatus.
+
+    Returns:
+        tuple: (mock_controller, stub_context_manager)
+    """
+    mock_controller = AsyncMock()
+    if side_effect is not None:
+        mock_controller.ReportStatus = AsyncMock(side_effect=side_effect)
+
+    stub_ctx = AsyncMock()
+    stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+    stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_controller, stub_ctx
+
+
 class TestReportStatusGrpcErrorHandling:
     async def test_unimplemented_grpc_error_logs_warning(self, caplog):
         """When ReportStatus returns UNIMPLEMENTED, a warning is logged
         instead of an error."""
         exporter = _make_exporter_for_report_status()
 
-        mock_controller = AsyncMock()
         error = grpc.aio.AioRpcError(
             code=grpc.StatusCode.UNIMPLEMENTED,
             initial_metadata=grpc.aio.Metadata(),
             trailing_metadata=grpc.aio.Metadata(),
             details="Method not implemented",
         )
-        mock_controller.ReportStatus = AsyncMock(side_effect=error)
-
-        stub_ctx = AsyncMock()
-        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
-        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=error)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
             with caplog.at_level(logging.WARNING, logger="jumpstarter.exporter.exporter"):
@@ -519,35 +538,499 @@ class TestReportStatusGrpcErrorHandling:
         assert len(error_msgs) == 0, (
             f"No error should be logged for UNIMPLEMENTED, got: {[r.message for r in error_msgs]}"
         )
+        # Ensure no retry - UNIMPLEMENTED should fail fast
+        assert mock_controller.ReportStatus.call_count == 1
 
     async def test_other_grpc_error_logs_error(self, caplog):
         """When ReportStatus returns a gRPC error other than UNIMPLEMENTED,
-        it is logged at ERROR level."""
+        it retries and eventually logs at ERROR level."""
         exporter = _make_exporter_for_report_status()
 
-        mock_controller = AsyncMock()
         error = grpc.aio.AioRpcError(
             code=grpc.StatusCode.UNAVAILABLE,
             initial_metadata=grpc.aio.Metadata(),
             trailing_metadata=grpc.aio.Metadata(),
             details="Service unavailable",
         )
-        mock_controller.ReportStatus = AsyncMock(side_effect=error)
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=error)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), \
+                patch("anyio.sleep") as mock_sleep:
+            with caplog.at_level(logging.DEBUG, logger="jumpstarter.exporter.exporter"):
+                await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Should log retry warnings (_RPC_MAX_RETRIES)
+        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        retry_warnings = [r for r in warning_msgs if "Transient error" in r.message]
+        assert len(retry_warnings) == _RPC_MAX_RETRIES, (
+            f"Expected {_RPC_MAX_RETRIES} retry warnings, got: {len(retry_warnings)}"
+        )
+
+        # Verify exponential backoff with cap at _RPC_BACKOFF_CAP
+        backoff_values = [call.args[0] for call in mock_sleep.call_args_list]
+        expected_backoffs = [min(_RPC_BACKOFF_BASE * (2**i), _RPC_BACKOFF_CAP) for i in range(_RPC_MAX_RETRIES)]
+        assert backoff_values == expected_backoffs, f"Expected {expected_backoffs}, got: {backoff_values}"
+
+        # _RPC_MAX_RETRIES + 1 total attempts
+        assert mock_controller.ReportStatus.call_count == _RPC_MAX_RETRIES + 1
+
+        # Eventually logs ERROR after exhausting retries
+        error_msgs = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("Failed to report status" in r.message for r in error_msgs), (
+            f"Expected error about failed status update, got: {[r.message for r in caplog.records]}"
+        )
+        # Ensure no WARNING about "not supported" was logged
+        assert not any("ReportStatus not supported" in r.message for r in warning_msgs), (
+            "UNAVAILABLE error should not produce 'not supported' warning"
+        )
+
+    @pytest.mark.parametrize("error_code", [
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+    ])
+    async def test_report_status_retries_on_transient_failure(self, error_code):
+        """Transient gRPC errors (UNAVAILABLE, DEADLINE_EXCEEDED) are retried.
+        If the error resolves before exhausting retries, the status is delivered."""
+        exporter = _make_exporter_for_report_status()
+
+        transient_error = grpc.aio.AioRpcError(
+            code=error_code,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details=f"{error_code.name} error",
+        )
+
+        delivered_statuses = []
+        call_count = 0
+
+        async def fail_twice_then_succeed(request, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise transient_error
+            # Third attempt succeeds
+            delivered_statuses.append(ExporterStatus.from_proto(request.status))
+
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=fail_twice_then_succeed)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), \
+                patch("anyio.sleep") as mock_sleep:
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Status was delivered on the third attempt
+        assert ExporterStatus.AVAILABLE in delivered_statuses
+        assert call_count == 3
+
+        # Verify exponential backoff for the 2 retries before success
+        backoff_values = [call.args[0] for call in mock_sleep.call_args_list]
+        assert backoff_values == [1.0, 2.0], f"Expected [1.0, 2.0], got: {backoff_values}"
+
+    async def test_report_status_does_not_retry_non_transient_grpc_error(self):
+        """Non-transient gRPC errors (PERMISSION_DENIED, INVALID_ARGUMENT, etc.)
+        are not retried — fail fast."""
+        exporter = _make_exporter_for_report_status()
+
+        permission_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.PERMISSION_DENIED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Permission denied",
+        )
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=permission_error)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Called exactly once (no retry)
+        assert mock_controller.ReportStatus.call_count == 1
+
+    async def test_report_status_does_not_retry_non_grpc_exception(self):
+        """Non-gRPC exceptions (ConnectionError, etc.) are not retried."""
+        exporter = _make_exporter_for_report_status()
+
+        connection_error = ConnectionError("Network unreachable")
+        mock_controller, stub_ctx = _setup_mock_controller_stub(exporter, side_effect=connection_error)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Called exactly once (no retry)
+        assert mock_controller.ReportStatus.call_count == 1
+
+    async def test_rpc_timeout_parameter_passed(self):
+        """Verify that timeout=_RPC_TIMEOUT is passed to gRPC calls."""
+        exporter = _make_exporter_for_report_status()
+
+        captured_calls = []
+
+        async def capture_call(*args, **kwargs):
+            captured_calls.append(kwargs)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_call)
 
         stub_ctx = AsyncMock()
         stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
         stub_ctx.__aexit__ = AsyncMock(return_value=False)
 
         with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
-            with caplog.at_level(logging.DEBUG, logger="jumpstarter.exporter.exporter"):
-                await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+            await exporter._report_status(ExporterStatus.AVAILABLE, "test")
 
-        error_msgs = [r for r in caplog.records if r.levelno == logging.ERROR]
-        assert any("Failed to update status" in r.message for r in error_msgs), (
-            f"Expected error about failed status update, got: {[r.message for r in caplog.records]}"
+        # Verify timeout parameter was passed
+        assert len(captured_calls) == 1
+        assert "timeout" in captured_calls[0]
+        assert captured_calls[0]["timeout"] == _RPC_TIMEOUT
+
+    async def test_report_status_non_blocking_during_serve(self):
+        """Verify _report_status returns immediately when drain is active (serve running)."""
+        exporter = _make_exporter_for_report_status()
+
+        # Simulate serve() drain active
+        exporter._status_drain_active = True
+        exporter._status_rpc_event = Event()
+        exporter._pending_status_request = None
+
+        # Call _report_status — should return immediately without awaiting RPC
+        await exporter._report_status(ExporterStatus.AVAILABLE, "test")
+
+        # Verify it enqueued the request
+        assert exporter._pending_status_request is not None
+        assert exporter._pending_status_request.message == "test"
+        assert exporter._status_rpc_event.is_set()
+
+        # Now verify latest-wins: call again with different status
+        exporter._status_rpc_event = Event()  # Reset
+        await exporter._report_status(ExporterStatus.LEASE_READY, "ready")
+
+        # The pending request should be replaced
+        assert exporter._pending_status_request.message == "ready"
+        assert ExporterStatus.from_proto(exporter._pending_status_request.status) == ExporterStatus.LEASE_READY
+
+    async def test_request_lease_release_succeeds_on_first_attempt(self):
+        """When ReleaseLease succeeds immediately, send AVAILABLE and exit."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
         )
-        # Ensure no WARNING about "not supported" was logged
-        warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert not any("ReportStatus not supported" in r.message for r in warning_msgs), (
-            "UNAVAILABLE error should not produce 'not supported' warning"
+        exporter._lease_context = lease_ctx
+
+        release_calls = []
+        report_calls = []
+
+        async def capture_release(request, **kwargs):
+            release_calls.append(request)
+
+        async def capture_report(request, **kwargs):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=capture_release)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # ReleaseLease called once with correct lease name
+        assert len(release_calls) == 1
+        assert release_calls[0].name == "test-lease"
+
+        # ReportStatus called once (AVAILABLE only, no release_lease)
+        assert len(report_calls) == 1
+        assert report_calls[0].release_lease is False
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AVAILABLE
+
+        # Lease ended event set
+        assert lease_ctx.lease_ended.is_set()
+
+    async def test_request_lease_release_retries_on_transient_failure(self):
+        """When ReleaseLease fails with UNAVAILABLE on first attempt, retry and succeed."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
         )
+        exporter._lease_context = lease_ctx
+
+        unavailable_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Service unavailable",
+        )
+
+        release_calls = []
+        report_calls = []
+        release_call_count = 0
+
+        async def fail_first_then_succeed(request, **kwargs):
+            nonlocal release_call_count
+            release_call_count += 1
+            if release_call_count == 1:
+                raise unavailable_error
+            release_calls.append(request)
+
+        async def capture_report(request, **kwargs):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=fail_first_then_succeed)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
+            await exporter._request_lease_release()
+
+        # ReleaseLease called twice (failed once, succeeded on retry)
+        assert release_call_count == 2
+        assert len(release_calls) == 1
+        assert release_calls[0].name == "test-lease"
+
+        # ReportStatus called once (AVAILABLE)
+        assert len(report_calls) == 1
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AVAILABLE
+
+    async def test_request_lease_release_exhausts_retries(self):
+        """When ReleaseLease and AVAILABLE status both fail, lease_ended is still set
+        so handle_lease can exit (prevents being stuck forever)."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        unavailable_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Service unavailable",
+        )
+
+        release_call_count = 0
+        report_call_count = 0
+
+        async def always_fail_release(request, **kwargs):
+            nonlocal release_call_count
+            release_call_count += 1
+            raise unavailable_error
+
+        async def always_fail_report(request, **kwargs):
+            nonlocal report_call_count
+            report_call_count += 1
+            raise unavailable_error
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=always_fail_release)
+        mock_controller.ReportStatus = AsyncMock(side_effect=always_fail_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx), patch("anyio.sleep"):
+            await exporter._request_lease_release()
+
+        # ReleaseLease: _RPC_MAX_RETRIES + 1 attempts (all fail)
+        assert release_call_count == _RPC_MAX_RETRIES + 1
+
+        # ReportStatus: _RPC_MAX_RETRIES + 1 attempts via _send_report_status_rpc (all fail)
+        assert report_call_count == _RPC_MAX_RETRIES + 1
+
+        # Critical: lease_ended must be set even when everything fails,
+        # otherwise handle_lease never exits
+        assert lease_ctx.lease_ended.is_set()
+
+    async def test_request_lease_release_falls_back_on_unsupported(self):
+        """When ReleaseLease fails with PERMISSION_DENIED, fall back to compat path."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+        exporter._exporter_status = ExporterStatus.AVAILABLE
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        permission_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.PERMISSION_DENIED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Exporter auth not supported",
+        )
+
+        report_calls = []
+
+        async def fail_with_permission(request, **kwargs):
+            raise permission_error
+
+        async def capture_report(request, **kwargs):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=fail_with_permission)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # ReleaseLease called once, failed with PERMISSION_DENIED
+        assert mock_controller.ReleaseLease.call_count == 1
+
+        # Fallback: ReportStatus called twice
+        # First call: release_lease=true with AFTER_LEASE_HOOK (AVAILABLE reverted)
+        # Second call: AVAILABLE
+        assert len(report_calls) == 2
+        assert report_calls[0].release_lease is True
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AFTER_LEASE_HOOK
+        assert report_calls[1].release_lease is False
+        assert ExporterStatus.from_proto(report_calls[1].status) == ExporterStatus.AVAILABLE
+
+        # _release_lease_unsupported should be cached
+        assert exporter._release_lease_unsupported is True
+
+    async def test_request_lease_release_skips_release_lease_when_cached_unsupported(self):
+        """When _release_lease_unsupported is True, skip ReleaseLease entirely."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = True  # Cached from prior attempt
+        exporter._exporter_status = ExporterStatus.AVAILABLE
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        report_calls = []
+
+        async def capture_report(request, **kwargs):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock()  # Should never be called
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # ReleaseLease NOT called (cached as unsupported)
+        assert mock_controller.ReleaseLease.call_count == 0
+
+        # Went straight to fallback path
+        assert len(report_calls) == 2
+        assert report_calls[0].release_lease is True
+        assert report_calls[1].release_lease is False
+
+    async def test_request_lease_release_preserves_failure_status_in_fallback(self):
+        """When falling back with a failure status, preserve it (don't revert to AFTER_LEASE_HOOK)."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = True
+        exporter._exporter_status = ExporterStatus.AFTER_LEASE_HOOK_FAILED  # Failure status
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        report_calls = []
+
+        async def capture_report(request, **kwargs):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # First call: release_lease=true with AFTER_LEASE_HOOK_FAILED (preserved, not reverted)
+        assert report_calls[0].release_lease is True
+        assert ExporterStatus.from_proto(report_calls[0].status) == ExporterStatus.AFTER_LEASE_HOOK_FAILED
+
+        # Second call: AVAILABLE
+        assert report_calls[1].release_lease is False
+        assert ExporterStatus.from_proto(report_calls[1].status) == ExporterStatus.AVAILABLE
+
+    async def test_request_lease_release_unimplemented(self):
+        """When ReleaseLease returns UNIMPLEMENTED, treat as unsupported and fall back."""
+        exporter = _make_exporter_for_report_status()
+        exporter._release_lease_unsupported = False
+        exporter._exporter_status = ExporterStatus.AVAILABLE
+
+        lease_ctx = LeaseContext(
+            lease_name="test-lease",
+            before_lease_hook=Event(),
+            client_name="test-client",
+        )
+        exporter._lease_context = lease_ctx
+
+        unimplemented_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNIMPLEMENTED,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Method not implemented",
+        )
+
+        report_calls = []
+
+        async def fail_with_unimplemented(request, **kwargs):
+            raise unimplemented_error
+
+        async def capture_report(request, **kwargs):
+            report_calls.append(request)
+
+        mock_controller = AsyncMock()
+        mock_controller.ReleaseLease = AsyncMock(side_effect=fail_with_unimplemented)
+        mock_controller.ReportStatus = AsyncMock(side_effect=capture_report)
+
+        stub_ctx = AsyncMock()
+        stub_ctx.__aenter__ = AsyncMock(return_value=mock_controller)
+        stub_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(exporter, "_controller_stub", return_value=stub_ctx):
+            await exporter._request_lease_release()
+
+        # ReleaseLease called once (UNIMPLEMENTED)
+        assert mock_controller.ReleaseLease.call_count == 1
+
+        # Falls back to compat path
+        assert len(report_calls) == 2
+        assert report_calls[0].release_lease is True
+
+        # Cached as unsupported
+        assert exporter._release_lease_unsupported is True
+
+


### PR DESCRIPTION
## Summary

Backport of #911 to `release-0.9` branch.

Adds retry logic with exponential backoff for transient gRPC failures in exporter status reporting and lease release, with per-RPC deadlines to prevent hanging. Ensures exporters recover from controller outages instead of becoming permanently stuck.

### Changes from original PR adapted for release-0.9

- **Go module path**: All imports use `jumpstarter-controller` (not `jumpstarter/controller`)
- **`auth.go`**: Added `VerifyExporter()` and `IsExporter()` methods needed by the new `ReleaseLease` routing
- **`auth_test.go`**: Includes `TestIsExporter` only (logging tests excluded — `jlog.LogContext` not on release-0.9)
- **`controller_service.go`**: Uses `auth.NewAuth(...)` instead of `s.getAuth()` (not on release-0.9)
- **`exporter.py`**: Excluded `clear_log_context()` (logging module not on release-0.9)
- **`exporter_test.py`**: Excluded `TestHandleLeaseStaleSkip` (depends on `_skip_stale_lease` from #947), `TestExitOnLeaseEnd` (depends on `exit_on_lease_end` from #947), and `TestContextPropagation` (depends on `set_log_context`/`clear_log_context`)

### Key features backported
- Shared `_retry_rpc` helper with exponential backoff (max 20 retries, ~18 min window)
- Per-RPC 30s timeout to prevent TCP/keepalive hangs
- Non-blocking status reports during `serve()` via background drain task
- `ReleaseLease` RPC with exporter auth and backward-compat fallback
- `IsExporter` metadata-based routing in `ReleaseLease`

## Test plan

- [x] Go builds clean (`go build ./...`)
- [x] Go auth tests pass (6/6)
- [x] Python exporter tests pass (28/28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)