### PR TITLE
fix: forward kwargs in ExporterList.model_dump to fix JSON/YAML output

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -377,9 +377,13 @@ class ExporterList(BaseModel):
         if not self.include_disabled:
             exclude_fields.add("enabled")
 
+        caller_exclude = kwargs.pop("exclude", None)
+        if caller_exclude:
+            exclude_fields |= set(caller_exclude)
+
         return {
             "exporters": [
-                self._dump_exporter(exporter, exclude_fields)
+                self._dump_exporter(exporter, exclude_fields, **kwargs)
                 for exporter in self._visible_exporters()
             ]
         }

--- a/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
@@ -499,6 +499,29 @@ class TestExporterListDisabledFiltering:
         result = el.model_dump()
         assert len(result["exporters"]) == 2
 
+    def test_model_dump_json_mode_serializes_lease_timedelta(self):
+        lease = Lease(
+            namespace="default",
+            name="test-lease",
+            selector="env=test",
+            duration=timedelta(hours=1),
+            client="test-client",
+            exporter="test-exporter",
+            conditions=[],
+        )
+        exporter = Exporter(namespace="default", name="test", labels={}, lease=lease)
+        el = ExporterList(exporters=[exporter], next_page_token=None, include_leases=True)
+        result = el.model_dump(mode="json")
+        duration_val = result["exporters"][0]["lease"]["duration"]
+        assert duration_val == 3600.0
+
+    def test_model_dump_merges_caller_exclude(self):
+        exporter = Exporter(namespace="default", name="test", labels={"env": "prod"})
+        el = ExporterList(exporters=[exporter], next_page_token=None)
+        result = el.model_dump(exclude={"labels"})
+        assert "labels" not in result["exporters"][0]
+        assert result["exporters"][0]["name"] == "test"
+
 
 class TestLeaseRichDisplay:
     def create_lease(


### PR DESCRIPTION
ExporterList.model_dump() did not pass **kwargs through to _dump_exporter(), so mode="json" was lost. This caused timedelta fields in Lease to remain as raw Python objects, crashing both json.dumps and yaml.safe_dump when running:

  jmp get exporters --with leases -o json/yaml
