### PR TITLE
[Backport release-0.9] fix: forward kwargs in ExporterList.model_dump to fix JSON/YAML output (#972)

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/client/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc.py
@@ -342,10 +342,12 @@ class ExporterList(BaseModel):
         for exporter in self._visible_exporters():
             exporter.rich_add_names(names)
 
+    def _dump_exporter(self, exporter, exclude_fields, **kwargs) -> dict:
+        return exporter.model_dump(exclude=exclude_fields, **kwargs)
+
     def model_dump_json(self, **kwargs):
         json_kwargs = {k: v for k, v in kwargs.items() if k in {"indent", "separators", "sort_keys", "ensure_ascii"}}
 
-        # Determine which fields to exclude
         exclude_fields = set()
         if not self.include_leases:
             exclude_fields.add("lease")
@@ -358,7 +360,7 @@ class ExporterList(BaseModel):
 
         data = {
             "exporters": [
-                exporter.model_dump(mode="json", exclude=exclude_fields)
+                self._dump_exporter(exporter, exclude_fields, mode="json")
                 for exporter in self._visible_exporters()
             ]
         }
@@ -375,9 +377,13 @@ class ExporterList(BaseModel):
         if not self.include_disabled:
             exclude_fields.add("enabled")
 
+        caller_exclude = kwargs.pop("exclude", None)
+        if caller_exclude:
+            exclude_fields |= set(caller_exclude)
+
         return {
             "exporters": [
-                exporter.model_dump(mode="json", exclude=exclude_fields)
+                self._dump_exporter(exporter, exclude_fields, **kwargs)
                 for exporter in self._visible_exporters()
             ]
         }

--- a/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/grpc_test.py
@@ -499,6 +499,29 @@ class TestExporterListDisabledFiltering:
         result = el.model_dump()
         assert len(result["exporters"]) == 2
 
+    def test_model_dump_json_mode_serializes_lease_timedelta(self):
+        lease = Lease(
+            namespace="default",
+            name="test-lease",
+            selector="env=test",
+            duration=timedelta(hours=1),
+            client="test-client",
+            exporter="test-exporter",
+            conditions=[],
+        )
+        exporter = Exporter(namespace="default", name="test", labels={}, lease=lease)
+        el = ExporterList(exporters=[exporter], next_page_token=None, include_leases=True)
+        result = el.model_dump(mode="json")
+        duration_val = result["exporters"][0]["lease"]["duration"]
+        assert duration_val == 3600.0
+
+    def test_model_dump_merges_caller_exclude(self):
+        exporter = Exporter(namespace="default", name="test", labels={"env": "prod"})
+        el = ExporterList(exporters=[exporter], next_page_token=None)
+        result = el.model_dump(exclude={"labels"})
+        assert "labels" not in result["exporters"][0]
+        assert result["exporters"][0]["name"] == "test"
+
 
 class TestLeaseRichDisplay:
     def create_lease(


### PR DESCRIPTION
## Summary
Backport of #972 to release-0.9.

Cherry-pick had a conflict because `_dump_exporter` helper method didn't exist on release-0.9 — the code inlined `exporter.model_dump(...)` directly. Resolution: added `_dump_exporter` method and updated both `model_dump_json` and `model_dump` to use it, matching main.

**Original fix**: `ExporterList.model_dump()` did not forward `**kwargs`, so `mode="json"` was lost — causing `timedelta` fields to remain as raw Python objects, crashing `json.dumps` and `yaml.safe_dump` for `jmp get exporters --with leases -o json/yaml`.