### PR TITLE
feat: trigger rolling restart on TLS certificate renewal

### DIFF
--- a/controller/deploy/operator/api/v1alpha1/jumpstarter_types.go
+++ b/controller/deploy/operator/api/v1alpha1/jumpstarter_types.go
@@ -298,6 +298,9 @@ type RoutersConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	Replicas int32 `json:"replicas,omitempty"`
 
+	// Custom annotations to add to router pod templates.
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
 	// Topology spread constraints for router pod distribution.
 	// Ensures router pods are distributed evenly across nodes and zones.
 	// Useful for high availability and fault tolerance.
@@ -332,6 +335,9 @@ type ControllerConfig struct {
 	// +kubebuilder:default=2
 	// +kubebuilder:validation:Minimum=1
 	Replicas int32 `json:"replicas,omitempty"`
+
+	// Custom annotations to add to controller pod templates.
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 
 	// Exporter options configuration.
 	// Controls how exporters connect and behave when communicating with the controller.

--- a/controller/deploy/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/controller/deploy/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -134,6 +134,13 @@ func (in *ConfigMapKeySelector) DeepCopy() *ConfigMapKeySelector {
 func (in *ControllerConfig) DeepCopyInto(out *ControllerConfig) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.ExporterOptions.DeepCopyInto(&out.ExporterOptions)
 	in.RestAPI.DeepCopyInto(&out.RestAPI)
 	in.GRPC.DeepCopyInto(&out.GRPC)
@@ -767,6 +774,13 @@ func (in *RouteConfig) DeepCopy() *RouteConfig {
 func (in *RoutersConfig) DeepCopyInto(out *RoutersConfig) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
 		*out = make([]v1.TopologySpreadConstraint, len(*in))

--- a/controller/deploy/operator/config/crd/bases/operator.jumpstarter.dev_jumpstarters.yaml
+++ b/controller/deploy/operator/config/crd/bases/operator.jumpstarter.dev_jumpstarters.yaml
@@ -1076,6 +1076,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Custom annotations to add to controller pod templates.
+                    type: object
                   replicas:
                     default: 2
                     description: |-
@@ -1833,6 +1838,11 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Custom annotations to add to router pod templates.
+                    type: object
                   replicas:
                     default: 3
                     description: |-

--- a/controller/deploy/operator/internal/controller/jumpstarter/hash_annotations_test.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/hash_annotations_test.go
@@ -1,0 +1,431 @@
+/*
+Copyright 2025. The Jumpstarter Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jumpstarter
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/deploy/operator/api/v1alpha1"
+)
+
+var _ = Describe("secretDataHash", func() {
+	It("should produce a deterministic hash", func() {
+		secret := &corev1.Secret{
+			Data: map[string][]byte{
+				"tls.crt": []byte("cert-data"),
+				"tls.key": []byte("key-data"),
+			},
+		}
+		hash1 := secretDataHash(secret)
+		hash2 := secretDataHash(secret)
+		Expect(hash1).To(Equal(hash2))
+		Expect(hash1).To(HaveLen(64))
+	})
+
+	It("should produce different hashes for different data", func() {
+		s1 := &corev1.Secret{
+			Data: map[string][]byte{"tls.crt": []byte("cert-a")},
+		}
+		s2 := &corev1.Secret{
+			Data: map[string][]byte{"tls.crt": []byte("cert-b")},
+		}
+		Expect(secretDataHash(s1)).NotTo(Equal(secretDataHash(s2)))
+	})
+
+	It("should not collide when key/value boundaries differ", func() {
+		// Without length prefixes these concatenate to the same byte stream: "axbby".
+		s1 := &corev1.Secret{
+			Data: map[string][]byte{
+				"a": []byte("xb"),
+				"b": []byte("y"),
+			},
+		}
+		s2 := &corev1.Secret{
+			Data: map[string][]byte{
+				"a": []byte("x"),
+				"b": []byte("by"),
+			},
+		}
+		Expect(secretDataHash(s1)).NotTo(Equal(secretDataHash(s2)))
+	})
+
+	It("should be order-independent", func() {
+		s1 := &corev1.Secret{
+			Data: map[string][]byte{
+				"aaa": []byte("1"),
+				"zzz": []byte("2"),
+			},
+		}
+		s2 := &corev1.Secret{
+			Data: map[string][]byte{
+				"zzz": []byte("2"),
+				"aaa": []byte("1"),
+			},
+		}
+		Expect(secretDataHash(s1)).To(Equal(secretDataHash(s2)))
+	})
+
+	It("should handle empty data", func() {
+		secret := &corev1.Secret{Data: map[string][]byte{}}
+		hash := secretDataHash(secret)
+		Expect(hash).To(HaveLen(64))
+	})
+})
+
+var _ = Describe("configMapDataHash", func() {
+	It("should produce a deterministic hash", func() {
+		cm := &corev1.ConfigMap{
+			Data: map[string]string{
+				"config.yaml": "key: value",
+			},
+		}
+		hash1 := configMapDataHash(cm)
+		hash2 := configMapDataHash(cm)
+		Expect(hash1).To(Equal(hash2))
+		Expect(hash1).To(HaveLen(64))
+	})
+
+	It("should produce different hashes for different data", func() {
+		cm1 := &corev1.ConfigMap{Data: map[string]string{"k": "v1"}}
+		cm2 := &corev1.ConfigMap{Data: map[string]string{"k": "v2"}}
+		Expect(configMapDataHash(cm1)).NotTo(Equal(configMapDataHash(cm2)))
+	})
+
+	It("should not collide when key/value boundaries differ", func() {
+		// Without length prefixes these concatenate to the same byte stream: "axbby".
+		cm1 := &corev1.ConfigMap{Data: map[string]string{"a": "xb", "b": "y"}}
+		cm2 := &corev1.ConfigMap{Data: map[string]string{"a": "x", "b": "by"}}
+		Expect(configMapDataHash(cm1)).NotTo(Equal(configMapDataHash(cm2)))
+	})
+})
+
+var _ = Describe("buildControllerPodAnnotations", func() {
+	var r *JumpstarterReconciler
+
+	BeforeEach(func() {
+		r = &JumpstarterReconciler{}
+	})
+
+	It("should always include configmap hash", func() {
+		js := &operatorv1alpha1.Jumpstarter{}
+		annotations := r.buildControllerPodAnnotations(js, "cm-hash", "")
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/configmap-sha256", "cm-hash"))
+		Expect(annotations).NotTo(HaveKey("jumpstarter.dev/tls-secret-sha256"))
+	})
+
+	It("should include TLS hash when non-empty", func() {
+		js := &operatorv1alpha1.Jumpstarter{}
+		annotations := r.buildControllerPodAnnotations(js, "cm-hash", "tls-hash")
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/configmap-sha256", "cm-hash"))
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/tls-secret-sha256", "tls-hash"))
+	})
+
+	It("should include user-provided pod annotations", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Controller: operatorv1alpha1.ControllerConfig{
+					PodAnnotations: map[string]string{
+						"custom.io/key": "custom-value",
+					},
+				},
+			},
+		}
+		annotations := r.buildControllerPodAnnotations(js, "cm-hash", "tls-hash")
+		Expect(annotations).To(HaveKeyWithValue("custom.io/key", "custom-value"))
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/configmap-sha256", "cm-hash"))
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/tls-secret-sha256", "tls-hash"))
+	})
+
+	It("should not allow user annotations to override operator annotations", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Controller: operatorv1alpha1.ControllerConfig{
+					PodAnnotations: map[string]string{
+						"jumpstarter.dev/configmap-sha256":  "user-override",
+						"jumpstarter.dev/tls-secret-sha256": "user-tls-override",
+					},
+				},
+			},
+		}
+		annotations := r.buildControllerPodAnnotations(js, "real-hash", "real-tls-hash")
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/configmap-sha256", "real-hash"))
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/tls-secret-sha256", "real-tls-hash"))
+	})
+})
+
+var _ = Describe("buildRouterPodAnnotations", func() {
+	var r *JumpstarterReconciler
+
+	BeforeEach(func() {
+		r = &JumpstarterReconciler{}
+	})
+
+	It("should return nil when no TLS hash and no user annotations", func() {
+		js := &operatorv1alpha1.Jumpstarter{}
+		annotations := r.buildRouterPodAnnotations(js, "")
+		Expect(annotations).To(BeNil())
+	})
+
+	It("should include TLS hash when non-empty", func() {
+		js := &operatorv1alpha1.Jumpstarter{}
+		annotations := r.buildRouterPodAnnotations(js, "tls-hash")
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/tls-secret-sha256", "tls-hash"))
+	})
+
+	It("should include user-provided pod annotations", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Routers: operatorv1alpha1.RoutersConfig{
+					PodAnnotations: map[string]string{
+						"prometheus.io/scrape": "true",
+					},
+				},
+			},
+		}
+		annotations := r.buildRouterPodAnnotations(js, "tls-hash")
+		Expect(annotations).To(HaveKeyWithValue("prometheus.io/scrape", "true"))
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/tls-secret-sha256", "tls-hash"))
+	})
+
+	It("should return non-nil when only user annotations are set", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Routers: operatorv1alpha1.RoutersConfig{
+					PodAnnotations: map[string]string{
+						"custom/key": "value",
+					},
+				},
+			},
+		}
+		annotations := r.buildRouterPodAnnotations(js, "")
+		Expect(annotations).To(HaveKeyWithValue("custom/key", "value"))
+	})
+
+	It("should not allow user annotations to override operator TLS hash", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Routers: operatorv1alpha1.RoutersConfig{
+					PodAnnotations: map[string]string{
+						"jumpstarter.dev/tls-secret-sha256": "user-tls-override",
+					},
+				},
+			},
+		}
+		annotations := r.buildRouterPodAnnotations(js, "real-tls-hash")
+		Expect(annotations).To(HaveKeyWithValue("jumpstarter.dev/tls-secret-sha256", "real-tls-hash"))
+	})
+})
+
+var _ = Describe("getControllerTLSSecretHash", func() {
+	var r *JumpstarterReconciler
+
+	BeforeEach(func() {
+		r = &JumpstarterReconciler{Client: k8sClient}
+	})
+
+	It("should return empty hash when no TLS is configured", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+		}
+		hash, err := r.getControllerTLSSecretHash(ctx, js)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(BeEmpty())
+	})
+
+	It("should return empty hash when secret does not exist yet", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Controller: operatorv1alpha1.ControllerConfig{
+					GRPC: operatorv1alpha1.GRPCConfig{
+						TLS: operatorv1alpha1.TLSConfig{
+							CertSecret: "nonexistent-secret",
+						},
+					},
+				},
+			},
+		}
+		hash, err := r.getControllerTLSSecretHash(ctx, js)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(BeEmpty())
+	})
+
+	It("should return hash when secret exists", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "controller-tls-test",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("test-cert"),
+				"tls.key": []byte("test-key"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+		}()
+
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Controller: operatorv1alpha1.ControllerConfig{
+					GRPC: operatorv1alpha1.GRPCConfig{
+						TLS: operatorv1alpha1.TLSConfig{
+							CertSecret: "controller-tls-test",
+						},
+					},
+				},
+			},
+		}
+		hash, err := r.getControllerTLSSecretHash(ctx, js)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(HaveLen(64))
+	})
+})
+
+var _ = Describe("getRouterTLSSecretHash", func() {
+	var r *JumpstarterReconciler
+
+	BeforeEach(func() {
+		r = &JumpstarterReconciler{Client: k8sClient}
+	})
+
+	It("should return empty hash when no TLS is configured", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+		}
+		hash, err := r.getRouterTLSSecretHash(ctx, js, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(BeEmpty())
+	})
+
+	It("should return empty hash when secret does not exist yet", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Routers: operatorv1alpha1.RoutersConfig{
+					GRPC: operatorv1alpha1.GRPCConfig{
+						TLS: operatorv1alpha1.TLSConfig{
+							CertSecret: "nonexistent-router-secret",
+						},
+					},
+				},
+			},
+		}
+		hash, err := r.getRouterTLSSecretHash(ctx, js, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(BeEmpty())
+	})
+
+	It("should return hash when shared CertSecret exists", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "router-tls-shared",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("router-cert"),
+				"tls.key": []byte("router-key"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+		}()
+
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				Routers: operatorv1alpha1.RoutersConfig{
+					GRPC: operatorv1alpha1.GRPCConfig{
+						TLS: operatorv1alpha1.TLSConfig{
+							CertSecret: "router-tls-shared",
+						},
+					},
+				},
+			},
+		}
+		hash0, err := r.getRouterTLSSecretHash(ctx, js, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash0).To(HaveLen(64))
+
+		// Shared secret path ignores replica index
+		hash1, err := r.getRouterTLSSecretHash(ctx, js, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash1).To(Equal(hash0))
+	})
+
+	It("should return hash for cert-manager per-replica secret", func() {
+		js := &operatorv1alpha1.Jumpstarter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm-router",
+				Namespace: "default",
+			},
+			Spec: operatorv1alpha1.JumpstarterSpec{
+				CertManager: operatorv1alpha1.CertManagerConfig{
+					Enabled: true,
+				},
+			},
+		}
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      GetRouterCertSecretName(js, 0),
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("cm-router-cert"),
+				"tls.key": []byte("cm-router-key"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		defer func() {
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+		}()
+
+		hash, err := r.getRouterTLSSecretHash(ctx, js, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(HaveLen(64))
+
+		// Different replica looks up a different secret name
+		hashMissing, err := r.getRouterTLSSecretHash(ctx, js, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hashMissing).To(BeEmpty())
+	})
+})

--- a/controller/deploy/operator/internal/controller/jumpstarter/jumpstarter_controller.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/jumpstarter_controller.go
@@ -21,8 +21,10 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"net"
 	"sort"
 	"strings"
@@ -184,8 +186,14 @@ func (r *JumpstarterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	configMapHash := configMapDataHash(desiredConfigMap)
 
+	// Compute TLS secret hashes so that certificate renewals trigger rolling restarts.
+	controllerTLSHash, err := r.getControllerTLSSecretHash(ctx, &jumpstarter)
+	if err != nil {
+		log.Error(err, "Failed to compute controller TLS secret hash")
+		return ctrl.Result{}, err
+	}
 	// Reconcile Controller Deployment
-	if err := r.reconcileControllerDeployment(ctx, &jumpstarter, configMapHash); err != nil {
+	if err := r.reconcileControllerDeployment(ctx, &jumpstarter, configMapHash, controllerTLSHash); err != nil {
 		log.Error(err, "Failed to reconcile Controller Deployment")
 		return ctrl.Result{}, err
 	}
@@ -238,10 +246,35 @@ func (r *JumpstarterReconciler) emitEventf(js *operatorv1alpha1.Jumpstarter, eve
 	r.Recorder.Eventf(js, eventType, reason, msgFmt, args...)
 }
 
+// getControllerTLSSecretHash resolves the controller TLS secret name and returns its data hash.
+func (r *JumpstarterReconciler) getControllerTLSSecretHash(ctx context.Context, jumpstarter *operatorv1alpha1.Jumpstarter) (string, error) {
+	var tlsSecretName string
+	if jumpstarter.Spec.CertManager.Enabled {
+		tlsSecretName = GetControllerCertSecretName(jumpstarter)
+	} else if jumpstarter.Spec.Controller.GRPC.TLS.CertSecret != "" {
+		tlsSecretName = jumpstarter.Spec.Controller.GRPC.TLS.CertSecret
+	}
+	return r.getTLSSecretHash(ctx, jumpstarter.Namespace, tlsSecretName)
+}
+
+// routerTLSSecretName returns the TLS secret name for a router replica.
+// An empty string means no TLS secret is configured.
+func routerTLSSecretName(jumpstarter *operatorv1alpha1.Jumpstarter, replicaIndex int32) string {
+	if jumpstarter.Spec.CertManager.Enabled {
+		return GetRouterCertSecretName(jumpstarter, replicaIndex)
+	}
+	return jumpstarter.Spec.Routers.GRPC.TLS.CertSecret
+}
+
+// getRouterTLSSecretHash resolves the router TLS secret name for a given replica and returns its data hash.
+func (r *JumpstarterReconciler) getRouterTLSSecretHash(ctx context.Context, jumpstarter *operatorv1alpha1.Jumpstarter, replicaIndex int32) (string, error) {
+	return r.getTLSSecretHash(ctx, jumpstarter.Namespace, routerTLSSecretName(jumpstarter, replicaIndex))
+}
+
 // reconcileControllerDeployment reconciles the controller deployment
-func (r *JumpstarterReconciler) reconcileControllerDeployment(ctx context.Context, jumpstarter *operatorv1alpha1.Jumpstarter, configMapHash string) error {
+func (r *JumpstarterReconciler) reconcileControllerDeployment(ctx context.Context, jumpstarter *operatorv1alpha1.Jumpstarter, configMapHash, tlsSecretHash string) error {
 	log := logf.FromContext(ctx)
-	desiredDeployment := r.createControllerDeployment(jumpstarter, configMapHash)
+	desiredDeployment := r.createControllerDeployment(jumpstarter, configMapHash, tlsSecretHash)
 
 	existingDeployment := &appsv1.Deployment{}
 	existingDeployment.Name = desiredDeployment.Name
@@ -319,9 +352,23 @@ func (r *JumpstarterReconciler) reconcileControllerDeployment(ctx context.Contex
 func (r *JumpstarterReconciler) reconcileRouterDeployment(ctx context.Context, jumpstarter *operatorv1alpha1.Jumpstarter) error {
 	log := logf.FromContext(ctx)
 
+	// Cache hashes by secret name so a shared CertSecret is fetched once across replicas.
+	tlsHashBySecret := make(map[string]string)
+
 	// Create one deployment per replica
 	for i := int32(0); i < jumpstarter.Spec.Routers.Replicas; i++ {
-		desiredDeployment := r.createRouterDeployment(jumpstarter, i)
+		secretName := routerTLSSecretName(jumpstarter, i)
+		routerTLSHash, ok := tlsHashBySecret[secretName]
+		if !ok {
+			var err error
+			routerTLSHash, err = r.getTLSSecretHash(ctx, jumpstarter.Namespace, secretName)
+			if err != nil {
+				log.Error(err, "Failed to compute router TLS secret hash", "replica", i)
+				return err
+			}
+			tlsHashBySecret[secretName] = routerTLSHash
+		}
+		desiredDeployment := r.createRouterDeployment(jumpstarter, i, routerTLSHash)
 
 		existingDeployment := &appsv1.Deployment{}
 		existingDeployment.Name = desiredDeployment.Name
@@ -652,6 +699,15 @@ func generateRandomKey(length int) (string, error) {
 
 // updateStatus is implemented in status.go
 
+// writeHashField writes a length-prefixed field so adjacent key/value concatenations
+// cannot collide (e.g. {"a":"xb","b":"y"} vs {"a":"x","b":"by"}).
+func writeHashField(h hash.Hash, data []byte) {
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(data)))
+	_, _ = h.Write(lenBuf[:])
+	_, _ = h.Write(data)
+}
+
 // configMapDataHash computes a deterministic SHA-256 hash over the Data keys and values
 // of a ConfigMap. Used as a pod template annotation to trigger rolling restarts when
 // the controller config changes (e.g. OIDC CA rotation).
@@ -663,14 +719,47 @@ func configMapDataHash(cm *corev1.ConfigMap) string {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		h.Write([]byte(k))
-		h.Write([]byte(cm.Data[k]))
+		writeHashField(h, []byte(k))
+		writeHashField(h, []byte(cm.Data[k]))
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// secretDataHash computes a deterministic SHA-256 hash over the Data keys and values
+// of a Secret. Used as a pod template annotation to trigger rolling restarts when
+// TLS certificates are renewed.
+func secretDataHash(secret *corev1.Secret) string {
+	h := sha256.New()
+	keys := make([]string, 0, len(secret.Data))
+	for k := range secret.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeHashField(h, []byte(k))
+		writeHashField(h, secret.Data[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// getTLSSecretHash fetches a TLS secret by name and returns its data hash.
+// Returns an empty string if the secret does not exist yet.
+func (r *JumpstarterReconciler) getTLSSecretHash(ctx context.Context, namespace, name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	var secret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &secret); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get TLS secret %s: %w", name, err)
+	}
+	return secretDataHash(&secret), nil
+}
+
 // createControllerDeployment creates a deployment for the controller
-func (r *JumpstarterReconciler) createControllerDeployment(jumpstarter *operatorv1alpha1.Jumpstarter, configMapHash string) *appsv1.Deployment {
+func (r *JumpstarterReconciler) createControllerDeployment(jumpstarter *operatorv1alpha1.Jumpstarter, configMapHash, tlsSecretHash string) *appsv1.Deployment {
 	labels := map[string]string{
 		"component":  "controller",
 		"app":        "jumpstarter-controller",
@@ -818,10 +907,8 @@ func (r *JumpstarterReconciler) createControllerDeployment(jumpstarter *operator
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
-					Annotations: map[string]string{
-						"jumpstarter.dev/configmap-sha256": configMapHash,
-					},
+					Labels:      labels,
+					Annotations: r.buildControllerPodAnnotations(jumpstarter, configMapHash, tlsSecretHash),
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -918,8 +1005,38 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+// buildControllerPodAnnotations builds the pod template annotations for the controller deployment.
+// Includes config/TLS hashes for rolling restart on changes, plus any user-provided pod annotations.
+func (r *JumpstarterReconciler) buildControllerPodAnnotations(jumpstarter *operatorv1alpha1.Jumpstarter, configMapHash, tlsSecretHash string) map[string]string {
+	annotations := make(map[string]string)
+	for k, v := range jumpstarter.Spec.Controller.PodAnnotations {
+		annotations[k] = v
+	}
+	annotations["jumpstarter.dev/configmap-sha256"] = configMapHash
+	if tlsSecretHash != "" {
+		annotations["jumpstarter.dev/tls-secret-sha256"] = tlsSecretHash
+	}
+	return annotations
+}
+
+// buildRouterPodAnnotations builds the pod template annotations for a router deployment.
+// Includes TLS hash for rolling restart on cert renewal, plus any user-provided pod annotations.
+func (r *JumpstarterReconciler) buildRouterPodAnnotations(jumpstarter *operatorv1alpha1.Jumpstarter, tlsSecretHash string) map[string]string {
+	annotations := make(map[string]string)
+	for k, v := range jumpstarter.Spec.Routers.PodAnnotations {
+		annotations[k] = v
+	}
+	if tlsSecretHash != "" {
+		annotations["jumpstarter.dev/tls-secret-sha256"] = tlsSecretHash
+	}
+	if len(annotations) == 0 {
+		return nil
+	}
+	return annotations
+}
+
 // createRouterDeployment creates a deployment for a specific router replica
-func (r *JumpstarterReconciler) createRouterDeployment(jumpstarter *operatorv1alpha1.Jumpstarter, replicaIndex int32) *appsv1.Deployment {
+func (r *JumpstarterReconciler) createRouterDeployment(jumpstarter *operatorv1alpha1.Jumpstarter, replicaIndex int32, tlsSecretHash string) *appsv1.Deployment {
 	// Base app label that ALL services for this replica will select
 	// Individual services will be named with endpoint suffixes, but all select the same pods
 	baseAppLabel := fmt.Sprintf("%s-router-%d", jumpstarter.Name, replicaIndex)
@@ -965,13 +1082,9 @@ func (r *JumpstarterReconciler) createRouterDeployment(jumpstarter *operatorv1al
 	var volumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
 
-	// Add TLS certificate mount when cert-manager is enabled OR when manual cert secret is provided
-	var tlsSecretName string
-	if jumpstarter.Spec.CertManager.Enabled {
-		tlsSecretName = GetRouterCertSecretName(jumpstarter, replicaIndex)
-	} else if jumpstarter.Spec.Routers.GRPC.TLS.CertSecret != "" {
-		tlsSecretName = jumpstarter.Spec.Routers.GRPC.TLS.CertSecret
-	}
+	// Add TLS certificate mount when cert-manager is enabled OR when manual cert secret is provided.
+	// Use routerTLSSecretName so the mounted secret matches the hash annotation.
+	tlsSecretName := routerTLSSecretName(jumpstarter, replicaIndex)
 
 	if tlsSecretName != "" {
 		envVars = append(envVars,
@@ -1018,7 +1131,8 @@ func (r *JumpstarterReconciler) createRouterDeployment(jumpstarter *operatorv1al
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: r.buildRouterPodAnnotations(jumpstarter, tlsSecretHash),
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -1542,37 +1656,56 @@ func defaultRouterResources(spec corev1.ResourceRequirements) corev1.ResourceReq
 	return spec
 }
 
-// Index field names used to look up Jumpstarter CRs from referenced CA resources.
+// Index field names used to look up Jumpstarter CRs from referenced resources.
 const (
-	// indexCASecret is the field index that maps each Jumpstarter CR to the
-	// "namespace/name" keys of Secrets referenced as JWT CA certificates.
-	indexCASecret = ".spec.authentication.jwt.certificateAuthoritySecret"
+	// indexReferencedSecret is the field index that maps each Jumpstarter CR to the
+	// "namespace/name" keys of all Secrets it references (JWT CA certs + TLS certs).
+	indexReferencedSecret = ".spec.referencedSecrets"
 	// indexCAConfigMap is the field index that maps each Jumpstarter CR to the
 	// "namespace/name" keys of ConfigMaps referenced as JWT CA certificates.
 	indexCAConfigMap = ".spec.authentication.jwt.certificateAuthorityConfigMap"
 )
 
 // SetupWithManager sets up the controller with the Manager.
-// In addition to watching owned resources, it watches any Secrets and ConfigMaps
-// referenced as JWT CA certificates so that CA rotations are picked up automatically.
+// In addition to watching owned resources, it watches Secrets (JWT CA certs and TLS certs)
+// and ConfigMaps referenced as JWT CA certificates so that rotations trigger reconciliation.
 func (r *JumpstarterReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Index Jumpstarter CRs by the Secrets they reference as CA certificates.
+	// Index Jumpstarter CRs by all Secrets they reference (JWT CA certs + TLS certs).
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
 		&operatorv1alpha1.Jumpstarter{},
-		indexCASecret,
+		indexReferencedSecret,
 		func(obj client.Object) []string {
 			jumpstarter := obj.(*operatorv1alpha1.Jumpstarter)
 			var keys []string
+
+			// JWT CA certificate secrets
 			for _, jwtCfg := range jumpstarter.Spec.Authentication.JWT {
 				if ref := jwtCfg.CertificateAuthoritySecret; ref != nil {
 					keys = append(keys, jumpstarter.Namespace+"/"+ref.Name)
 				}
 			}
+
+			// Controller TLS cert secret
+			if jumpstarter.Spec.CertManager.Enabled {
+				keys = append(keys, jumpstarter.Namespace+"/"+GetControllerCertSecretName(jumpstarter))
+			} else if s := jumpstarter.Spec.Controller.GRPC.TLS.CertSecret; s != "" {
+				keys = append(keys, jumpstarter.Namespace+"/"+s)
+			}
+
+			// Router TLS cert secrets
+			if jumpstarter.Spec.CertManager.Enabled {
+				for i := int32(0); i < jumpstarter.Spec.Routers.Replicas; i++ {
+					keys = append(keys, jumpstarter.Namespace+"/"+GetRouterCertSecretName(jumpstarter, i))
+				}
+			} else if s := jumpstarter.Spec.Routers.GRPC.TLS.CertSecret; s != "" {
+				keys = append(keys, jumpstarter.Namespace+"/"+s)
+			}
+
 			return keys
 		},
 	); err != nil {
-		return fmt.Errorf("failed to set up %s index: %w", indexCASecret, err)
+		return fmt.Errorf("failed to set up %s index: %w", indexReferencedSecret, err)
 	}
 
 	// Index Jumpstarter CRs by the ConfigMaps they reference as CA certificates.
@@ -1595,16 +1728,16 @@ func (r *JumpstarterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// mapSecretToJumpstarters returns a reconcile request for every Jumpstarter
-	// CR that references the changed Secret as a JWT CA certificate.
+	// CR that references the changed Secret (JWT CA cert or TLS cert).
 	mapSecretToJumpstarters := func(ctx context.Context, obj client.Object) []ctrl.Request {
 		secret := obj.(*corev1.Secret)
 		key := secret.Namespace + "/" + secret.Name
 
 		var jumpstarterList operatorv1alpha1.JumpstarterList
 		if err := mgr.GetClient().List(ctx, &jumpstarterList, client.MatchingFields{
-			indexCASecret: key,
+			indexReferencedSecret: key,
 		}); err != nil {
-			logf.FromContext(ctx).Error(err, "Failed to list Jumpstarters for Secret CA ref", "secret", key)
+			logf.FromContext(ctx).Error(err, "Failed to list Jumpstarters for Secret ref", "secret", key)
 			return nil
 		}
 
@@ -1645,8 +1778,8 @@ func (r *JumpstarterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		// Note: Secrets and ServiceAccounts are intentionally NOT owned to prevent deletion.
-		// However, we do watch Secrets and ConfigMaps referenced as JWT CA certificates so
-		// that CA rotations are picked up automatically and the ConfigMap is updated.
+		// We watch Secrets referenced as JWT CA certificates and TLS certs so that
+		// rotations trigger reconciliation and rolling restarts via hash annotations.
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(mapSecretToJumpstarters)).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(mapConfigMapToJumpstarters)).
 		Complete(r)


### PR DESCRIPTION
Hash TLS secret data into pod template annotations so that cert-manager renewals automatically trigger rolling restarts, eliminating the need for manual pod restarts.

Extends the existing configmap-sha256 annotation pattern to TLS secrets and expands the secret field indexer to watch TLS cert secrets alongside JWT CA secrets.

Fixes #852