### PR TITLE
fix: catch Exception in _flush_lines

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks.py
@@ -427,6 +427,11 @@ class HookExecutor:
                                 # PTY closed or read error
                                 logger.debug("read_pty_output: OSError in loop: %s", e)
                                 break
+
+                            except Exception as e:
+                                logger.debug("read_pty_output: unexpected error in loop: %s", e)
+                                break
+
                     finally:
                         # Drain any remaining data from the PTY buffer.
                         # On macOS, PTY output may still be in the kernel buffer

--- a/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/hooks_test.py
@@ -1043,6 +1043,33 @@ class TestHookExecutor:
             assert result is None
 
     @macos_pty_xfail
+    async def test_main_loop_non_oserror_is_caught(self, lease_scope) -> None:
+        """Verify that a non-OSError exception in the main read loop is caught
+        by the except-Exception handler and does not propagate to the caller.
+        """
+        hook_config = HookConfigV1Alpha1(
+            before_lease=HookInstanceConfigV1Alpha1(
+                script="echo MAIN_LOOP_ERROR",
+                timeout=10,
+            ),
+        )
+        executor = HookExecutor(config=hook_config)
+
+        def flush_lines_always_error(buffer, output_lines):
+            raise ValueError("simulated non-OSError")
+
+        with (
+              patch("jumpstarter.exporter.hooks._flush_lines", side_effect=flush_lines_always_error),
+              patch("jumpstarter.exporter.hooks.logger") as mock_logger,
+          ):
+              result = await executor.execute_before_lease_hook(lease_scope)
+              assert result is None
+              debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+              assert any("unexpected error in loop" in c for c in debug_calls), (
+                  f"Expected main-loop exception handler to log, got: {debug_calls}"
+              )
+
+    @macos_pty_xfail
     async def test_drain_retries_empty_select_then_captures_data(self, lease_scope) -> None:
         """Verify that the drain retries after empty select() calls and still
         captures data that arrives later.


### PR DESCRIPTION
In case there are unexepected exceptions, to avoid hitting flakes https://github.com/jumpstarter-dev/jumpstarter/actions/runs/31179469197/attempts/1