### PR TITLE
feat: netsim driver

### DIFF
--- a/docs/source/reference/package-apis/drivers/index.md
+++ b/docs/source/reference/package-apis/drivers/index.md
@@ -90,6 +90,7 @@ Drivers for virtual and emulated targets:
 - {doc}`Renode <renode>` (`jumpstarter-driver-renode`) - Renode embedded systems emulation
 - {doc}`Corellium <corellium>` (`jumpstarter-driver-corellium`) - Corellium virtualization platform
 - {doc}`Cuttlefish <cuttlefish>` (`jumpstarter-driver-cuttlefish`) - Android Cuttlefish virtual device management
+- {doc}`Netsim <netsim>` (`jumpstarter-driver-netsim`) - Android netsim virtual radio control (Bluetooth, WiFi, UWB)
 
 ### Utility
 
@@ -119,6 +120,7 @@ http.md
 http-power.md
 iscsi.md
 mitmproxy.md
+netsim.md
 network.md
 noyito-relay.md
 obd.md

--- a/docs/source/reference/package-apis/drivers/index.md
+++ b/docs/source/reference/package-apis/drivers/index.md
@@ -88,6 +88,7 @@ Drivers for virtual and emulated targets:
 - {doc}`Renode <renode>` (`jumpstarter-driver-renode`) - Renode embedded systems emulation
 - {doc}`Corellium <corellium>` (`jumpstarter-driver-corellium`) - Corellium virtualization platform
 - {doc}`Cuttlefish <cuttlefish>` (`jumpstarter-driver-cuttlefish`) - Android Cuttlefish virtual device management
+- {doc}`Netsim <netsim>` (`jumpstarter-driver-netsim`) - Android netsim virtual radio control (Bluetooth, WiFi, UWB)
 
 ### Utility
 
@@ -116,6 +117,7 @@ http.md
 http-power.md
 iscsi.md
 mitmproxy.md
+netsim.md
 network.md
 noyito-relay.md
 obd.md

--- a/docs/source/reference/package-apis/drivers/netsim.md
+++ b/docs/source/reference/package-apis/drivers/netsim.md
@@ -1,0 +1,1 @@
+../../../../../python/packages/jumpstarter-driver-netsim/README.md

--- a/python/packages/jumpstarter-all/pyproject.toml
+++ b/python/packages/jumpstarter-all/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "jumpstarter-driver-esp32",
   "jumpstarter-driver-flashers",
   "jumpstarter-driver-http",
+  "jumpstarter-driver-netsim",
   "jumpstarter-driver-network",
   "jumpstarter-driver-obd",
   "jumpstarter-driver-opendal",

--- a/python/packages/jumpstarter-driver-netsim/.gitignore
+++ b/python/packages/jumpstarter-driver-netsim/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-netsim/README.md
+++ b/python/packages/jumpstarter-driver-netsim/README.md
@@ -1,0 +1,210 @@
+# Netsim Driver
+
+`jumpstarter-driver-netsim` controls
+[Cuttlefish](https://source.android.com/docs/devices/cuttlefish)
+netsim virtual radio interfaces through the netsim REST API.
+It manages Bluetooth (classic + BLE), WiFi, and UWB radios on
+[Cuttlefish](https://source.android.com/docs/devices/cuttlefish) virtual devices:
+toggle state and capture HCI packets.
+
+## Installation
+
+```{code-block} console
+:substitutions:
+$ pip3 install --extra-index-url {{index_url}} jumpstarter-driver-netsim
+```
+
+### Prerequisites
+
+- A running netsim instance. Launch Cuttlefish with `--netsim=true` to enable all
+  virtual radios (Bluetooth, WiFi, UWB). For Bluetooth only, use `--netsim_bt=true`.
+- netsim REST API accessible (see port notes below)
+
+## Configuration
+
+Example exporter configuration:
+
+```yaml
+export:
+  netsim:
+    type: jumpstarter_driver_netsim.driver.Netsim
+    config:
+      host: localhost
+      port: 7681
+      netsim_cli: /usr/lib/cuttlefish-common/bin/netsim
+```
+
+### Configuration Parameters
+
+| Parameter  | Description                          | Type | Required | Default     |
+| ---------- | ------------------------------------ | ---- | -------- | ----------- |
+| host       | netsim hostname                      | str  | no       | "localhost" |
+| port       | netsim REST API port                 | int  | no       | 7681        |
+| netsim_cli | Path to netsim CLI (for captures)    | str  | no       | ""          |
+
+> **Port discovery:** netsimd assigns its REST port as `7681 + netsim_instance_num`.
+> The instance number depends on CVD numbering and isn't directly controllable -
+> failed CVD creates consume instance numbers. Port 7681 is only correct for
+> `netsim_instance_num=0`. Check your CVD config's `netsim_instance_num` field
+> and set `port: 7681 + N` in your exporter config.
+
+### ExporterConfig Example
+
+```yaml
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: netsim-local
+export:
+  netsim:
+    type: jumpstarter_driver_netsim.driver.Netsim
+    config:
+      host: localhost
+      port: 7681
+      netsim_cli: /usr/lib/cuttlefish-common/bin/netsim
+```
+
+> **`netsim_cli`**: Required for packet capture toggle (start/stop). The REST
+> PATCH endpoint for captures is broken in netsim <=0.3.100. Without this
+> config, `start_capture`, `stop_capture`, and `set_capture` will raise an
+> error. `list_captures` and `get_capture` (download) work via REST without it.
+
+## Usage
+
+### CLI
+
+```bash
+# Health check returns device count
+j netsim status
+
+# List all devices and radio states
+j netsim devices
+
+# Show a single device (by name or numeric ID)
+j netsim device cvd-1
+j netsim device 1
+
+# Toggle Bluetooth radios
+j netsim radio cvd-1 bt_classic on
+j netsim radio cvd-1 ble off
+
+# Toggle WiFi / UWB
+j netsim radio cvd-1 wifi on
+j netsim radio cvd-1 uwb off
+
+# Raw device patch (full flexibility)
+j netsim patch cvd-1 '{"visible": false}'
+
+# Reset all devices (WARNING: host-wide, see below)
+j netsim reset
+
+# Packet capture
+j netsim capture list
+j netsim capture start cvd-1                  # starts BT capture, returns ID
+j netsim capture start cvd-1 --chip UWB       # start UWB capture
+j netsim capture stop 10                      # stop by capture ID
+j netsim capture get 10 -o capture.pcap       # download pcap
+```
+
+### Python API
+
+```python
+from jumpstarter.common.utils import serve
+from jumpstarter_driver_netsim.driver import Netsim
+
+driver = Netsim(
+    host="localhost",
+    port=7684,  # port = 7681 + netsim_instance_num
+    netsim_cli="/usr/lib/cuttlefish-common/bin/netsim",  # for capture toggle
+)
+with serve(driver) as client:
+    # Health check returns device count
+    print(client.status())  # e.g. "OK (2 devices)"
+
+    # List devices
+    devices = client.list_devices()
+    print(devices)
+
+    # Get a single device (name, numeric ID, or substring)
+    cvd1 = client.get_device("cvd-1")
+    cvd1 = client.get_device("1")  # numeric ID
+
+    # Toggle Bluetooth
+    client.set_radio("cvd-1", "bt_classic", "on")
+    client.set_radio("cvd-1", "ble", "off")
+
+    # Start packet capture for a device (finds matching capture entry)
+    cap_id = client.start_capture("cvd-1")  # returns capture ID
+    # ... perform BT operations ...
+    client.stop_capture(cap_id)
+
+    # Download pcap
+    pcap_data = client.get_capture(cap_id)
+    with open("capture.pcap", "wb") as f:
+        f.write(pcap_data)
+
+    # Low-level capture control (by capture ID)
+    client.set_capture("1", "on")
+    client.set_capture("1", "off")
+
+    # Reset all (host-wide!)
+    client.reset_devices()
+```
+
+## Architecture
+
+```text
+┌────────────┐     gRPC      ┌────────────────┐    HTTP     ┌──────────────────┐
+│ jmp shell  │──────────────►│ Netsim         │────────────►│ netsim           │
+│ (client)   │               │ Driver         │  port 7681  │ (netsimd)        │
+└────────────┘               └────────────────┘             └────────┬─────────┘
+                                                                     │
+                                                              ┌──────┴──────┐
+                                                              │  rootcanal  │
+                                                              │  (BT HCI)  │
+                                                              └──────┬──────┘
+                                                                     │
+                                                            ┌────────┴────────┐
+                                                            │ CVD-1    CVD-2  │
+                                                            │ (virtual BT/    │
+                                                            │  WiFi/UWB)      │
+                                                            └─────────────────┘
+```
+
+The driver is a thin REST client that translates Jumpstarter driver calls into
+netsim API requests. netsim embeds rootcanal as the virtual Bluetooth HCI
+controller, each Cuttlefish CVD auto-registers its radio chips with netsim,
+and all CVDs on the same netsim instance share the virtual radio medium.
+
+### Radio Types
+
+| Radio       | CLI name     | Controls                              |
+| ----------- | ------------ | ------------------------------------- |
+| BT Classic  | `bt_classic` | Classic Bluetooth (A2DP, HFP, etc.)   |
+| BLE         | `ble`        | Bluetooth Low Energy                  |
+| WiFi        | `wifi`       | Virtual WiFi                          |
+| UWB         | `uwb`        | Ultra-Wideband                        |
+
+### Host-Wide Operations
+
+> **Warning:** `reset_devices` (CLI: `j netsim reset`) resets **all** devices
+> on the netsim instance, not just the ones you own. On a shared host with
+> multiple CVDs or tenants, this will affect everyone. Use with care in
+> multi-tenant environments.
+
+## API Reference
+
+### Driver
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_netsim.driver.Netsim()
+   :members:
+```
+
+### Client
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_netsim.client.NetsimClient()
+   :members:
+```

--- a/python/packages/jumpstarter-driver-netsim/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-netsim/examples/exporter.yaml
@@ -1,0 +1,11 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: netsim-local
+export:
+  netsim:
+    type: jumpstarter_driver_netsim.driver.Netsim
+    config:
+      host: localhost
+      port: 7681

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/client.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/client.py
@@ -1,0 +1,141 @@
+import json
+from base64 import b64decode
+
+import click
+
+from jumpstarter.client import DriverClient
+
+
+def _parse(raw: str) -> dict | list | str:
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+
+def _echo(obj) -> None:
+    if isinstance(obj, (dict, list)):
+        click.echo(json.dumps(obj, indent=2))
+    else:
+        click.echo(obj)
+
+
+class NetsimClient(DriverClient):
+    """Client for controlling Android netsim virtual radios."""
+
+    def list_devices(self) -> dict | list | str:
+        return _parse(self.call("list_devices"))
+
+    def get_device(self, name_or_id: str) -> dict | list | str:
+        return _parse(self.call("get_device", name_or_id))
+
+    def patch_device(self, name_or_id: str, patch_json: str) -> dict | list | str:
+        return _parse(self.call("patch_device", name_or_id, patch_json))
+
+    def set_radio(self, name_or_id: str, radio: str, enabled: str) -> dict | list | str:
+        return _parse(self.call("set_radio", name_or_id, radio, enabled))
+
+    def reset_devices(self) -> str:
+        return self.call("reset_devices")
+
+    def list_captures(self) -> dict | list | str:
+        return _parse(self.call("list_captures"))
+
+    def get_capture(self, capture_id: str) -> bytes:
+        """Download a packet capture via chunked streaming transfer."""
+        chunks = []
+        for b64_chunk in self.streamingcall("get_capture", capture_id):
+            chunks.append(b64decode(b64_chunk))
+        return b"".join(chunks)
+
+    def set_capture(self, capture_id: str, enabled: str) -> dict | list | str:
+        return _parse(self.call("set_capture", capture_id, enabled))
+
+    def start_capture(self, name_or_id: str, chip_kind: str = "BLUETOOTH") -> str:
+        return self.call("start_capture", name_or_id, chip_kind)
+
+    def stop_capture(self, capture_id: str) -> str:
+        return self.call("stop_capture", capture_id)
+
+    def status(self) -> str:
+        return self.call("status")
+
+    def cli(self):  # noqa: C901
+        @click.group()
+        def netsim():
+            """Android netsim virtual radio control.
+
+            Manage virtual Bluetooth, WiFi, and UWB radios:
+            toggle state, capture packets.
+            """
+
+        @netsim.command("devices")
+        def devices_cmd():
+            """List all devices and radio states."""
+            _echo(self.list_devices())
+
+        @netsim.command("device")
+        @click.argument("name")
+        def device_cmd(name: str):
+            """Show a single device by name or ID."""
+            _echo(self.get_device(name))
+
+        @netsim.command("radio")
+        @click.argument("device")
+        @click.argument("radio_type", type=click.Choice(["bt_classic", "ble", "wifi", "uwb"]))
+        @click.argument("state", type=click.Choice(["on", "off"]))
+        def radio_cmd(device: str, radio_type: str, state: str):
+            """Toggle a radio on or off."""
+            _echo(self.set_radio(device, radio_type, state))
+
+        @netsim.command("patch")
+        @click.argument("device")
+        @click.argument("patch_json")
+        def patch_cmd(device: str, patch_json: str):
+            """Send raw JSON patch to a device."""
+            _echo(self.patch_device(device, patch_json))
+
+        @netsim.command("reset")
+        def reset_cmd():
+            """Reset all devices to initial state."""
+            click.echo(self.reset_devices())
+
+        @netsim.group("capture")
+        def capture_group():
+            """Manage packet captures."""
+
+        @capture_group.command("list")
+        def capture_list():
+            """List all captures."""
+            _echo(self.list_captures())
+
+        @capture_group.command("start")
+        @click.argument("device")
+        @click.option("--chip", default="BLUETOOTH", help="Chip kind (BLUETOOTH, UWB)")
+        def capture_start(device: str, chip: str):
+            """Start packet capture for a device."""
+            cap_id = self.start_capture(device, chip)
+            click.echo(f"Capture started (id={cap_id})")
+
+        @capture_group.command("stop")
+        @click.argument("capture_id")
+        def capture_stop(capture_id: str):
+            """Stop a packet capture."""
+            click.echo(self.stop_capture(capture_id))
+
+        @capture_group.command("get")
+        @click.argument("capture_id")
+        @click.option("-o", "--output", required=True, help="Output file path")
+        def capture_get(capture_id: str, output: str):
+            """Download a packet capture to a file."""
+            data = self.get_capture(capture_id)
+            with open(output, "wb") as f:
+                f.write(data)
+            click.echo(f"Wrote {len(data)} bytes to {output}")
+
+        @netsim.command("status")
+        def status_cmd():
+            """Health check shows device count."""
+            click.echo(self.status())
+
+        return netsim

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/client.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/client.py
@@ -1,0 +1,137 @@
+import json
+from base64 import b64decode
+
+import click
+
+from jumpstarter.client import DriverClient
+
+
+def _parse(raw: str) -> dict | list | str:
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+
+def _echo(obj) -> None:
+    if isinstance(obj, (dict, list)):
+        click.echo(json.dumps(obj, indent=2))
+    else:
+        click.echo(obj)
+
+
+class NetsimClient(DriverClient):
+    """Client for controlling Android netsim virtual radios."""
+
+    def list_devices(self) -> dict | list | str:
+        return _parse(self.call("list_devices"))
+
+    def get_device(self, name_or_id: str) -> dict | list | str:
+        return _parse(self.call("get_device", name_or_id))
+
+    def patch_device(self, name_or_id: str, patch_json: str) -> dict | list | str:
+        return _parse(self.call("patch_device", name_or_id, patch_json))
+
+    def set_radio(self, name_or_id: str, radio: str, enabled: str) -> dict | list | str:
+        return _parse(self.call("set_radio", name_or_id, radio, enabled))
+
+    def reset_devices(self) -> str:
+        return self.call("reset_devices")
+
+    def list_captures(self) -> dict | list | str:
+        return _parse(self.call("list_captures"))
+
+    def get_capture(self, capture_id: str) -> bytes:
+        return b64decode(self.call("get_capture", capture_id))
+
+    def set_capture(self, capture_id: str, enabled: str) -> dict | list | str:
+        return _parse(self.call("set_capture", capture_id, enabled))
+
+    def start_capture(self, name_or_id: str, chip_kind: str = "BLUETOOTH") -> str:
+        return self.call("start_capture", name_or_id, chip_kind)
+
+    def stop_capture(self, capture_id: str) -> str:
+        return self.call("stop_capture", capture_id)
+
+    def status(self) -> str:
+        return self.call("status")
+
+    def cli(self):  # noqa: C901
+        @click.group()
+        def netsim():
+            """Android netsim virtual radio control.
+
+            Manage virtual Bluetooth, WiFi, and UWB radios:
+            toggle state, capture packets.
+            """
+
+        @netsim.command("devices")
+        def devices_cmd():
+            """List all devices and radio states."""
+            _echo(self.list_devices())
+
+        @netsim.command("device")
+        @click.argument("name")
+        def device_cmd(name: str):
+            """Show a single device by name or ID."""
+            _echo(self.get_device(name))
+
+        @netsim.command("radio")
+        @click.argument("device")
+        @click.argument("radio_type", type=click.Choice(["bt_classic", "ble", "wifi", "uwb"]))
+        @click.argument("state", type=click.Choice(["on", "off"]))
+        def radio_cmd(device: str, radio_type: str, state: str):
+            """Toggle a radio on or off."""
+            _echo(self.set_radio(device, radio_type, state))
+
+        @netsim.command("patch")
+        @click.argument("device")
+        @click.argument("patch_json")
+        def patch_cmd(device: str, patch_json: str):
+            """Send raw JSON patch to a device."""
+            _echo(self.patch_device(device, patch_json))
+
+        @netsim.command("reset")
+        def reset_cmd():
+            """Reset all devices to initial state."""
+            click.echo(self.reset_devices())
+
+        @netsim.group("capture")
+        def capture_group():
+            """Manage packet captures."""
+
+        @capture_group.command("list")
+        def capture_list():
+            """List all captures."""
+            _echo(self.list_captures())
+
+        @capture_group.command("start")
+        @click.argument("device")
+        @click.option("--chip", default="BLUETOOTH", help="Chip kind (BLUETOOTH, UWB)")
+        def capture_start(device: str, chip: str):
+            """Start packet capture for a device."""
+            cap_id = self.start_capture(device, chip)
+            click.echo(f"Capture started (id={cap_id})")
+
+        @capture_group.command("stop")
+        @click.argument("capture_id")
+        def capture_stop(capture_id: str):
+            """Stop a packet capture."""
+            click.echo(self.stop_capture(capture_id))
+
+        @capture_group.command("get")
+        @click.argument("capture_id")
+        @click.option("-o", "--output", required=True, help="Output file path")
+        def capture_get(capture_id: str, output: str):
+            """Download a packet capture to a file."""
+            data = self.get_capture(capture_id)
+            with open(output, "wb") as f:
+                f.write(data)
+            click.echo(f"Wrote {len(data)} bytes to {output}")
+
+        @netsim.command("status")
+        def status_cmd():
+            """Health check shows device count."""
+            click.echo(self.status())
+
+        return netsim

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/client_test.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/client_test.py
@@ -1,0 +1,219 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from .client import _echo, _parse
+from .driver import Netsim
+from jumpstarter.common.utils import serve
+
+CLI_PATH = "/usr/lib/cuttlefish-common/bin/netsim"
+
+BASE = "http://localhost:7681"
+
+DEVICES_RESPONSE = {
+    "devices": [
+        {"id": 1, "name": "cvd-1", "chips": [{"kind": "BLUETOOTH"}]},
+        {"id": 2, "name": "cvd-2", "chips": []},
+    ]
+}
+
+
+def test_parse_dict():
+    assert _parse('{"a": 1}') == {"a": 1}
+
+
+def test_parse_list():
+    assert _parse("[1]") == [1]
+
+
+def test_parse_plain():
+    assert _parse("text") == "text"
+
+
+def test_echo_dict(capsys):
+    _echo({"k": "v"})
+    assert '"k"' in capsys.readouterr().out
+
+
+def test_echo_list(capsys):
+    _echo([1])
+    assert "1" in capsys.readouterr().out
+
+
+def test_echo_str(capsys):
+    _echo("hi")
+    assert "hi" in capsys.readouterr().out
+
+
+def test_list_devices(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with serve(Netsim()) as client:
+        assert client.list_devices()["devices"][0]["name"] == "cvd-1"
+
+
+def test_get_device(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with serve(Netsim()) as client:
+        assert client.get_device("cvd-1")["name"] == "cvd-1"
+
+
+def test_patch_device(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    with serve(Netsim()) as client:
+        client.patch_device("cvd-1", '{"visible": false}')
+
+
+def test_set_radio(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    with serve(Netsim()) as client:
+        client.set_radio("cvd-1", "bt_classic", "on")
+
+
+def test_reset_devices(requests_mock):
+    requests_mock.post(f"{BASE}/v1/devices/reset", text="")
+    with serve(Netsim()) as client:
+        assert client.reset_devices() == "OK"
+
+
+def test_list_captures(requests_mock):
+    requests_mock.get(f"{BASE}/v1/captures", json={"captures": []})
+    with serve(Netsim()) as client:
+        assert client.list_captures()["captures"] == []
+
+
+def test_get_capture(requests_mock):
+    requests_mock.get(f"{BASE}/v1/captures/5", content=b"\x00pcap")
+    with serve(Netsim()) as client:
+        assert client.get_capture("5") == b"\x00pcap"
+
+
+@patch("subprocess.run")
+def test_set_capture(mock_run, requests_mock):
+    mock_run.return_value.returncode = 0
+    with serve(Netsim(netsim_cli=CLI_PATH)) as client:
+        client.set_capture("1", "on")
+
+
+@patch("subprocess.run")
+def test_start_capture(mock_run, requests_mock):
+    mock_run.return_value.returncode = 0
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    captures = {
+        "captures": [
+            {"id": 10, "deviceName": "cvd-1", "chipKind": "BLUETOOTH", "state": "OFF"},
+        ]
+    }
+    requests_mock.get(f"{BASE}/v1/captures", json=captures)
+    with serve(Netsim(netsim_cli=CLI_PATH)) as client:
+        cap_id = client.start_capture("cvd-1")
+        assert cap_id == "10"
+
+
+@patch("subprocess.run")
+def test_stop_capture(mock_run, requests_mock):
+    mock_run.return_value.returncode = 0
+    with serve(Netsim(netsim_cli=CLI_PATH)) as client:
+        assert client.stop_capture("10") == "OK"
+
+
+def test_status(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with serve(Netsim()) as client:
+        assert client.status() == "OK (2 devices)"
+
+
+def test_cli_devices(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["devices"])
+        assert r.exit_code == 0
+        assert "cvd-1" in r.output
+
+
+def test_cli_device(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["device", "cvd-1"])
+        assert r.exit_code == 0
+        assert "cvd-1" in r.output
+
+
+def test_cli_radio(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["radio", "cvd-1", "bt_classic", "on"])
+        assert r.exit_code == 0
+
+
+def test_cli_patch(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["patch", "cvd-1", '{"visible": false}'])
+        assert r.exit_code == 0
+
+
+def test_cli_reset(requests_mock):
+    requests_mock.post(f"{BASE}/v1/devices/reset", text="")
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["reset"])
+        assert r.exit_code == 0
+
+
+def test_cli_capture_list(requests_mock):
+    requests_mock.get(f"{BASE}/v1/captures", json={"captures": []})
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["capture", "list"])
+        assert r.exit_code == 0
+
+
+@patch("subprocess.run")
+def test_cli_capture_start(mock_run, requests_mock):
+    mock_run.return_value.returncode = 0
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    captures = {
+        "captures": [
+            {"id": 10, "deviceName": "cvd-1", "chipKind": "BLUETOOTH", "state": "OFF"},
+        ]
+    }
+    requests_mock.get(f"{BASE}/v1/captures", json=captures)
+    with serve(Netsim(netsim_cli=CLI_PATH)) as client:
+        r = CliRunner().invoke(client.cli(), ["capture", "start", "cvd-1"])
+        assert r.exit_code == 0
+        assert "id=10" in r.output
+
+
+@patch("subprocess.run")
+def test_cli_capture_stop(mock_run, requests_mock):
+    mock_run.return_value.returncode = 0
+    with serve(Netsim(netsim_cli=CLI_PATH)) as client:
+        r = CliRunner().invoke(client.cli(), ["capture", "stop", "10"])
+        assert r.exit_code == 0
+
+
+def test_cli_capture_get(requests_mock):
+    requests_mock.get(f"{BASE}/v1/captures/5", content=b"\x00pcap-data")
+    with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as f:
+        path = f.name
+    try:
+        with serve(Netsim()) as client:
+            r = CliRunner().invoke(client.cli(), ["capture", "get", "5", "-o", path])
+            assert r.exit_code == 0
+            assert "10 bytes" in r.output
+            with open(path, "rb") as f:
+                assert f.read() == b"\x00pcap-data"
+    finally:
+        os.unlink(path)
+
+
+def test_cli_status(requests_mock):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with serve(Netsim()) as client:
+        r = CliRunner().invoke(client.cli(), ["status"])
+        assert r.exit_code == 0
+        assert "OK (2 devices)" in r.output

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/conftest.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/conftest.py
@@ -1,0 +1,4 @@
+def pytest_addoption(parser):
+    parser.addoption("--live-netsim-host", default="localhost")
+    parser.addoption("--live-netsim-port", default="7681", type=int)
+    parser.addoption("--live-netsim-cli", default="")

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver.py
@@ -1,0 +1,274 @@
+import json
+import subprocess
+from base64 import b64encode
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+import requests
+
+from jumpstarter.driver import Driver, export
+
+
+class NetsimError(Exception):
+    """Raised when a netsim API call fails."""
+
+
+VALID_STATES = frozenset(("true", "1", "on", "false", "0", "off"))
+ON_STATES = frozenset(("true", "1", "on"))
+RADIO_TYPES = ("bt_classic", "ble", "wifi", "uwb")
+
+
+def _parse_bool(value: str, param_name: str) -> bool:
+    v = value.lower()
+    if v not in VALID_STATES:
+        raise NetsimError(f"invalid {param_name}: {value!r}. Use on/off, true/false, or 1/0")
+    return v in ON_STATES
+
+
+@dataclass(kw_only=True)
+class Netsim(Driver):
+    """Android netsim driver for controlling virtual radio interfaces (Bluetooth, WiFi, UWB)."""
+
+    host: str = "localhost"
+    # netsimd web port = 7681 + netsim_instance_num. The instance number
+    # depends on CVD numbering and isn't controllable. Port must be discovered
+    # or configured per deployment.
+    port: int = 7681
+    # Path to netsim CLI binary. Required for capture toggle. REST PATCH
+    # is broken in netsim <=0.3.100. Empty string = REST only (capture
+    # toggle will raise). Typical: /usr/lib/cuttlefish-common/bin/netsim
+    netsim_cli: str = ""
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_netsim.client.NetsimClient"
+
+    @property
+    def _base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def _fmt(self, result) -> str:
+        return json.dumps(result, indent=2) if isinstance(result, (dict, list)) else str(result)
+
+    def _request(self, method: str, path: str, data: dict | None = None, timeout: int = 10) -> dict | list | str:
+        try:
+            r = requests.request(method, f"{self._base_url}{path}", json=data, timeout=timeout)
+            r.raise_for_status()
+            try:
+                return r.json()
+            except requests.JSONDecodeError:
+                return r.text
+        except requests.ConnectionError as e:
+            raise NetsimError(f"not connected to netsim at {self.host}:{self.port}") from e
+        except requests.Timeout as e:
+            raise NetsimError(f"{method} {path} timed out after {timeout}s") from e
+        except requests.HTTPError as e:
+            raise NetsimError(f"{method} {path} failed: {e}") from e
+
+    def _request_bytes(self, path: str, timeout: int = 30) -> bytes:
+        try:
+            r = requests.get(f"{self._base_url}{path}", timeout=timeout)
+            r.raise_for_status()
+            return r.content
+        except requests.ConnectionError as e:
+            raise NetsimError(f"not connected to netsim at {self.host}:{self.port}") from e
+        except requests.Timeout as e:
+            raise NetsimError(f"GET {path} timed out after {timeout}s") from e
+        except requests.HTTPError as e:
+            raise NetsimError(f"GET {path} failed: {e}") from e
+
+    def _list_devices_raw(self) -> list[dict]:
+        result = self._request("GET", "/v1/devices")
+        if isinstance(result, dict):
+            return result.get("devices", [])
+        return []
+
+    def _resolve_device_id(self, name_or_id: str) -> int:
+        """Resolve a device name or numeric ID to a numeric ID.
+
+        Accepts: numeric string ("1"), exact name match, or substring match.
+        Raises NetsimError if no match or multiple substring matches.
+        """
+        if name_or_id.isdigit():
+            return int(name_or_id)
+
+        devices = self._list_devices_raw()
+        exact = [d for d in devices if d.get("name") == name_or_id]
+        if len(exact) == 1:
+            return exact[0]["id"]
+
+        substr = [d for d in devices if name_or_id in d.get("name", "")]
+        if len(substr) == 1:
+            return substr[0]["id"]
+        if len(substr) > 1:
+            names = [d["name"] for d in substr]
+            raise NetsimError(f"ambiguous device {name_or_id!r}, matches: {names}")
+
+        available = [d.get("name", str(d.get("id"))) for d in devices]
+        raise NetsimError(f"device not found: {name_or_id!r}. Available: {available}")
+
+    def _capture_toggle(self, capture_id: str, state: str) -> None:
+        """Toggle capture state. Uses CLI when configured, raises if not.
+
+        REST PATCH for captures is broken in netsim <=0.3.100.
+        """
+        if not capture_id.isdigit():
+            raise NetsimError(f"capture_id must be numeric, got {capture_id!r}")
+        if state not in ("on", "off"):
+            raise NetsimError(f"state must be 'on' or 'off', got {state!r}")
+        if not self.netsim_cli:
+            raise NetsimError(
+                "capture toggle requires netsim_cli config "
+                "(REST PATCH broken in netsim <=0.3.100). "
+                "Set netsim_cli to the netsim binary path, "
+                "e.g. /usr/lib/cuttlefish-common/bin/netsim"
+            )
+        self.logger.info("capture toggle via CLI: %s %s (cli=%s)", state, capture_id, self.netsim_cli)
+        try:
+            result = subprocess.run(
+                [self.netsim_cli, "capture", "patch", state, capture_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise NetsimError("netsim capture patch timed out after 10s") from e
+        except OSError as e:
+            raise NetsimError(f"failed to run netsim CLI ({self.netsim_cli!r}): {e}") from e
+        if result.returncode != 0:
+            raise NetsimError(f"netsim capture patch failed: {result.stderr.strip()}")
+
+    def _build_chip_patch(self, radio: str, **fields) -> list[dict]:
+        if radio not in RADIO_TYPES:
+            raise NetsimError(f"unknown radio: {radio}. Valid: {', '.join(RADIO_TYPES)}")
+        # bt_classic and ble both map to chip kind BLUETOOTH - they're sub-fields
+        # of the same chip, not separate chips.
+        if radio == "bt_classic":
+            return [{"kind": "BLUETOOTH", "bt": {"classic": fields}}]
+        if radio == "ble":
+            return [{"kind": "BLUETOOTH", "bt": {"low_energy": fields}}]
+        if radio == "wifi":
+            return [{"kind": "WIFI", "wifi": fields}]
+        return [{"kind": "UWB", "uwb": fields}]
+
+    @export
+    def list_devices(self) -> str:
+        """List all devices and their chips/radio states."""
+        return self._fmt(self._request("GET", "/v1/devices"))
+
+    @export
+    def get_device(self, name_or_id: str) -> str:
+        """Get a single device by name or ID."""
+        device_id = self._resolve_device_id(name_or_id)
+        for dev in self._list_devices_raw():
+            if dev.get("id") == device_id:
+                return self._fmt(dev)
+        raise NetsimError(f"device not found: {name_or_id}")
+
+    @export
+    def patch_device(self, name_or_id: str, patch_json: str) -> str:
+        """Send raw patch to a device. patch_json is the device object fields to update."""
+        try:
+            data = json.loads(patch_json)
+        except json.JSONDecodeError as e:
+            raise NetsimError(f"invalid JSON: {e}") from e
+        device_id = self._resolve_device_id(name_or_id)
+        return self._fmt(self._request("PATCH", f"/v1/devices/{device_id}", {"device": data}))
+
+    @export
+    def set_radio(self, name_or_id: str, radio: str, enabled: str) -> str:
+        """Toggle a radio on/off. radio: bt_classic, ble, wifi, uwb. enabled: on/off."""
+        state = _parse_bool(enabled, "enabled")
+        chips = self._build_chip_patch(radio, state=state)
+        device_id = self._resolve_device_id(name_or_id)
+        return self._fmt(self._request("PATCH", f"/v1/devices/{device_id}", {"device": {"chips": chips}}))
+
+    @export
+    def reset_devices(self) -> str:
+        """Reset all devices to initial state.
+
+        WARNING: this is host-wide - resets radios for ALL devices on this
+        netsim instance, not just yours. On a shared host, this affects
+        other tenants.
+        """
+        self.logger.warning("reset_devices is host-wide - all devices on this netsim instance will be reset")
+        self._request("POST", "/v1/devices/reset")
+        return "OK"
+
+    @export
+    def list_captures(self) -> str:
+        """List all packet captures."""
+        return self._fmt(self._request("GET", "/v1/captures"))
+
+    # 2 MiB raw per chunk → ~2.67 MiB base64, well under the 4 MiB default
+    # gRPC message limit. Captures of any size transfer safely.
+    _CAPTURE_CHUNK_SIZE = 2 * 1024 * 1024
+
+    @export
+    async def get_capture(self, capture_id: str) -> AsyncGenerator[str, None]:
+        """Download a packet capture as streaming base64-encoded pcap chunks.
+
+        Yields base64-encoded chunks to avoid gRPC message size limits.
+        """
+        if not capture_id.isdigit():
+            raise NetsimError(f"capture_id must be numeric, got {capture_id!r}")
+        data = self._request_bytes(f"/v1/captures/{capture_id}")
+        for i in range(0, len(data), self._CAPTURE_CHUNK_SIZE):
+            yield b64encode(data[i : i + self._CAPTURE_CHUNK_SIZE]).decode("ascii")
+
+    @export
+    def set_capture(self, capture_id: str, enabled: str) -> str:
+        """Start or stop a packet capture by capture ID. enabled: on/off.
+
+        Requires netsim_cli config. REST PATCH broken in netsim <=0.3.100.
+        """
+        state = "on" if _parse_bool(enabled, "enabled") else "off"
+        self._capture_toggle(capture_id, state)
+        return "OK"
+
+    @export
+    def start_capture(self, name_or_id: str, chip_kind: str = "BLUETOOTH") -> str:
+        """Start packet capture for a device, resolved by chip kind.
+
+        Finds the capture entry matching this device and chip kind,
+        then enables it via CLI. Returns the capture ID used.
+        Requires netsim_cli config.
+        """
+        if not self.netsim_cli:
+            raise NetsimError(
+                "capture toggle requires netsim_cli config "
+                "(REST PATCH broken in netsim <=0.3.100). "
+                "Set netsim_cli to the netsim binary path, "
+                "e.g. /usr/lib/cuttlefish-common/bin/netsim"
+            )
+        device_id = self._resolve_device_id(name_or_id)
+        devices = self._list_devices_raw()
+        device_name = None
+        for dev in devices:
+            if dev.get("id") == device_id:
+                device_name = dev.get("name")
+                break
+        if device_name is None:
+            raise NetsimError(f"device not found: {name_or_id}")
+
+        captures = self._request("GET", "/v1/captures")
+        if not isinstance(captures, dict):
+            raise NetsimError("unexpected captures response")
+        for cap in captures.get("captures", []):
+            if cap.get("deviceName") == device_name and cap.get("chipKind") == chip_kind:
+                cap_id = str(cap["id"])
+                self._capture_toggle(cap_id, "on")
+                return cap_id
+        raise NetsimError(f"no {chip_kind} capture found for device {device_name!r}")
+
+    @export
+    def stop_capture(self, capture_id: str) -> str:
+        """Stop a packet capture. Requires netsim_cli config."""
+        self._capture_toggle(capture_id, "off")
+        return "OK"
+
+    @export
+    def status(self) -> str:
+        """Health check — verifies netsim is reachable. Returns device count."""
+        devices = self._list_devices_raw()
+        return f"OK ({len(devices)} devices)"

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver.py
@@ -1,0 +1,268 @@
+import json
+import subprocess
+from base64 import b64encode
+from dataclasses import dataclass
+
+import requests
+
+from jumpstarter.driver import Driver, export
+
+
+class NetsimError(Exception):
+    """Raised when a netsim API call fails."""
+
+
+VALID_STATES = frozenset(("true", "1", "on", "false", "0", "off"))
+ON_STATES = frozenset(("true", "1", "on"))
+RADIO_TYPES = ("bt_classic", "ble", "wifi", "uwb")
+
+
+def _parse_bool(value: str, param_name: str) -> bool:
+    v = value.lower()
+    if v not in VALID_STATES:
+        raise NetsimError(f"invalid {param_name}: {value!r}. Use on/off, true/false, or 1/0")
+    return v in ON_STATES
+
+
+@dataclass(kw_only=True)
+class Netsim(Driver):
+    """Android netsim driver for controlling virtual radio interfaces (Bluetooth, WiFi, UWB)."""
+
+    host: str = "localhost"
+    # netsimd web port = 7681 + netsim_instance_num. The instance number
+    # depends on CVD numbering and isn't controllable. Port must be discovered
+    # or configured per deployment.
+    port: int = 7681
+    # Path to netsim CLI binary. Required for capture toggle. REST PATCH
+    # is broken in netsim <=0.3.100. Empty string = REST only (capture
+    # toggle will raise). Typical: /usr/lib/cuttlefish-common/bin/netsim
+    netsim_cli: str = ""
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_netsim.client.NetsimClient"
+
+    @property
+    def _base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def _fmt(self, result) -> str:
+        return json.dumps(result, indent=2) if isinstance(result, (dict, list)) else str(result)
+
+    def _request(self, method: str, path: str, data: dict | None = None, timeout: int = 10) -> dict | list | str:
+        try:
+            r = requests.request(method, f"{self._base_url}{path}", json=data, timeout=timeout)
+            r.raise_for_status()
+            try:
+                return r.json()
+            except requests.JSONDecodeError:
+                return r.text
+        except requests.ConnectionError as e:
+            raise NetsimError(f"not connected to netsim at {self.host}:{self.port}") from e
+        except requests.Timeout as e:
+            raise NetsimError(f"{method} {path} timed out after {timeout}s") from e
+        except requests.HTTPError as e:
+            raise NetsimError(f"{method} {path} failed: {e}") from e
+
+    def _request_bytes(self, path: str, timeout: int = 30) -> bytes:
+        try:
+            r = requests.get(f"{self._base_url}{path}", timeout=timeout)
+            r.raise_for_status()
+            return r.content
+        except requests.ConnectionError as e:
+            raise NetsimError(f"not connected to netsim at {self.host}:{self.port}") from e
+        except requests.Timeout as e:
+            raise NetsimError(f"GET {path} timed out after {timeout}s") from e
+        except requests.HTTPError as e:
+            raise NetsimError(f"GET {path} failed: {e}") from e
+
+    def _list_devices_raw(self) -> list[dict]:
+        result = self._request("GET", "/v1/devices")
+        if isinstance(result, dict):
+            return result.get("devices", [])
+        return []
+
+    def _resolve_device_id(self, name_or_id: str) -> int:
+        """Resolve a device name or numeric ID to a numeric ID.
+
+        Accepts: numeric string ("1"), exact name match, or substring match.
+        Raises NetsimError if no match or multiple substring matches.
+        """
+        if name_or_id.isdigit():
+            return int(name_or_id)
+
+        devices = self._list_devices_raw()
+        exact = [d for d in devices if d.get("name") == name_or_id]
+        if len(exact) == 1:
+            return exact[0]["id"]
+
+        substr = [d for d in devices if name_or_id in d.get("name", "")]
+        if len(substr) == 1:
+            return substr[0]["id"]
+        if len(substr) > 1:
+            names = [d["name"] for d in substr]
+            raise NetsimError(f"ambiguous device {name_or_id!r}, matches: {names}")
+
+        available = [d.get("name", str(d.get("id"))) for d in devices]
+        raise NetsimError(f"device not found: {name_or_id!r}. Available: {available}")
+
+    def _capture_toggle(self, capture_id: str, state: str) -> None:
+        """Toggle capture state. Uses CLI when configured, raises if not.
+
+        REST PATCH for captures is broken in netsim <=0.3.100.
+        """
+        if not capture_id.isdigit():
+            raise NetsimError(f"capture_id must be numeric, got {capture_id!r}")
+        if state not in ("on", "off"):
+            raise NetsimError(f"state must be 'on' or 'off', got {state!r}")
+        if not self.netsim_cli:
+            raise NetsimError(
+                "capture toggle requires netsim_cli config "
+                "(REST PATCH broken in netsim <=0.3.100). "
+                "Set netsim_cli to the netsim binary path, "
+                "e.g. /usr/lib/cuttlefish-common/bin/netsim"
+            )
+        self.logger.info("capture toggle via CLI: %s %s (cli=%s)", state, capture_id, self.netsim_cli)
+        try:
+            result = subprocess.run(
+                [self.netsim_cli, "capture", "patch", state, capture_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise NetsimError("netsim capture patch timed out after 10s") from e
+        except OSError as e:
+            raise NetsimError(f"failed to run netsim CLI ({self.netsim_cli!r}): {e}") from e
+        if result.returncode != 0:
+            raise NetsimError(f"netsim capture patch failed: {result.stderr.strip()}")
+
+    def _build_chip_patch(self, radio: str, **fields) -> list[dict]:
+        if radio not in RADIO_TYPES:
+            raise NetsimError(f"unknown radio: {radio}. Valid: {', '.join(RADIO_TYPES)}")
+        # bt_classic and ble both map to chip kind BLUETOOTH - they're sub-fields
+        # of the same chip, not separate chips.
+        if radio == "bt_classic":
+            return [{"kind": "BLUETOOTH", "bt": {"classic": fields}}]
+        if radio == "ble":
+            return [{"kind": "BLUETOOTH", "bt": {"low_energy": fields}}]
+        if radio == "wifi":
+            return [{"kind": "WIFI", "wifi": fields}]
+        return [{"kind": "UWB", "uwb": fields}]
+
+    @export
+    def list_devices(self) -> str:
+        """List all devices and their chips/radio states."""
+        return self._fmt(self._request("GET", "/v1/devices"))
+
+    @export
+    def get_device(self, name_or_id: str) -> str:
+        """Get a single device by name or ID."""
+        device_id = self._resolve_device_id(name_or_id)
+        for dev in self._list_devices_raw():
+            if dev.get("id") == device_id:
+                return self._fmt(dev)
+        raise NetsimError(f"device not found: {name_or_id}")
+
+    @export
+    def patch_device(self, name_or_id: str, patch_json: str) -> str:
+        """Send raw patch to a device. patch_json is the device object fields to update."""
+        try:
+            data = json.loads(patch_json)
+        except json.JSONDecodeError as e:
+            raise NetsimError(f"invalid JSON: {e}") from e
+        device_id = self._resolve_device_id(name_or_id)
+        return self._fmt(self._request("PATCH", f"/v1/devices/{device_id}", {"device": data}))
+
+    @export
+    def set_radio(self, name_or_id: str, radio: str, enabled: str) -> str:
+        """Toggle a radio on/off. radio: bt_classic, ble, wifi, uwb. enabled: on/off."""
+        state = _parse_bool(enabled, "enabled")
+        chips = self._build_chip_patch(radio, state=state)
+        device_id = self._resolve_device_id(name_or_id)
+        return self._fmt(self._request("PATCH", f"/v1/devices/{device_id}", {"device": {"chips": chips}}))
+
+    @export
+    def reset_devices(self) -> str:
+        """Reset all devices to initial state.
+
+        WARNING: this is host-wide - resets radios for ALL devices on this
+        netsim instance, not just yours. On a shared host, this affects
+        other tenants.
+        """
+        self.logger.warning("reset_devices is host-wide - all devices on this netsim instance will be reset")
+        self._request("POST", "/v1/devices/reset")
+        return "OK"
+
+    @export
+    def list_captures(self) -> str:
+        """List all packet captures."""
+        return self._fmt(self._request("GET", "/v1/captures"))
+
+    @export
+    def get_capture(self, capture_id: str) -> str:
+        """Download a packet capture as base64-encoded pcap data.
+
+        Returns base64 string (RPC cannot transport raw bytes safely).
+        """
+        if not capture_id.isdigit():
+            raise NetsimError(f"capture_id must be numeric, got {capture_id!r}")
+        data = self._request_bytes(f"/v1/captures/{capture_id}")
+        return b64encode(data).decode("ascii")
+
+    @export
+    def set_capture(self, capture_id: str, enabled: str) -> str:
+        """Start or stop a packet capture by capture ID. enabled: on/off.
+
+        Requires netsim_cli config. REST PATCH broken in netsim <=0.3.100.
+        """
+        state = "on" if _parse_bool(enabled, "enabled") else "off"
+        self._capture_toggle(capture_id, state)
+        return "OK"
+
+    @export
+    def start_capture(self, name_or_id: str, chip_kind: str = "BLUETOOTH") -> str:
+        """Start packet capture for a device, resolved by chip kind.
+
+        Finds the capture entry matching this device and chip kind,
+        then enables it via CLI. Returns the capture ID used.
+        Requires netsim_cli config.
+        """
+        if not self.netsim_cli:
+            raise NetsimError(
+                "capture toggle requires netsim_cli config "
+                "(REST PATCH broken in netsim <=0.3.100). "
+                "Set netsim_cli to the netsim binary path, "
+                "e.g. /usr/lib/cuttlefish-common/bin/netsim"
+            )
+        device_id = self._resolve_device_id(name_or_id)
+        devices = self._list_devices_raw()
+        device_name = None
+        for dev in devices:
+            if dev.get("id") == device_id:
+                device_name = dev.get("name")
+                break
+        if device_name is None:
+            raise NetsimError(f"device not found: {name_or_id}")
+
+        captures = self._request("GET", "/v1/captures")
+        if not isinstance(captures, dict):
+            raise NetsimError("unexpected captures response")
+        for cap in captures.get("captures", []):
+            if cap.get("deviceName") == device_name and cap.get("chipKind") == chip_kind:
+                cap_id = str(cap["id"])
+                self._capture_toggle(cap_id, "on")
+                return cap_id
+        raise NetsimError(f"no {chip_kind} capture found for device {device_name!r}")
+
+    @export
+    def stop_capture(self, capture_id: str) -> str:
+        """Stop a packet capture. Requires netsim_cli config."""
+        self._capture_toggle(capture_id, "off")
+        return "OK"
+
+    @export
+    def status(self) -> str:
+        """Health check — verifies netsim is reachable. Returns device count."""
+        devices = self._list_devices_raw()
+        return f"OK ({len(devices)} devices)"

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver_live_test.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver_live_test.py
@@ -1,0 +1,181 @@
+"""Live tests that run against a real netsim instance.
+
+Run with: make pkg-test-jumpstarter-driver-netsim PYTEST_ARGS="-m live --live-netsim-host=HOST --live-netsim-port=PORT"
+Skipped by default in CI.
+"""
+
+import time
+
+import pytest
+import requests
+
+from .driver import Netsim, NetsimError
+
+POLL_INTERVAL = 0.5
+POLL_TIMEOUT = 10
+
+
+@pytest.fixture
+def live_drv(request):
+    host = request.config.getoption("--live-netsim-host")
+    port = request.config.getoption("--live-netsim-port")
+    cli = request.config.getoption("--live-netsim-cli")
+    return Netsim(host=host, port=port, netsim_cli=cli)
+
+
+def _get_rx_count(drv, device_id="1"):
+    """Get BLE rx count for a device from the raw device list."""
+    for dev in drv._list_devices_raw():
+        if str(dev.get("id")) == device_id:
+            for chip in dev.get("chips", []):
+                if "bt" in chip:
+                    return chip["bt"]["lowEnergy"]["rxCount"]
+    return None
+
+
+def _poll_rx_growing(drv, device_id="1", timeout=POLL_TIMEOUT):
+    """Wait until rx count increments, return (before, after)."""
+    before = _get_rx_count(drv, device_id)
+    assert before is not None, f"no BLE rx count for device {device_id}"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(POLL_INTERVAL)
+        after = _get_rx_count(drv, device_id)
+        if after > before:
+            return before, after
+    return before, before
+
+
+def _poll_rx_frozen(drv, device_id="1", window=3.0):
+    """Assert rx count doesn't change over a window."""
+    before = _get_rx_count(drv, device_id)
+    assert before is not None, f"no BLE rx count for device {device_id}"
+    time.sleep(window)
+    after = _get_rx_count(drv, device_id)
+    return before, after
+
+
+@pytest.mark.live
+class TestLiveSmoke:
+    def test_status_reachable(self, live_drv):
+        result = live_drv.status()
+        assert result.startswith("OK (")
+        assert "devices)" in result
+
+    def test_list_devices_has_cvd(self, live_drv):
+        devices = live_drv._list_devices_raw()
+        assert len(devices) >= 1
+        assert any(d.get("id") == 1 for d in devices)
+
+    def test_device_has_bluetooth_chip(self, live_drv):
+        devices = live_drv._list_devices_raw()
+        cvd = next(d for d in devices if d.get("id") == 1)
+        bt_chips = [c for c in cvd.get("chips", []) if c.get("kind") == "BLUETOOTH"]
+        assert len(bt_chips) >= 1
+        assert "bt" in bt_chips[0]
+
+    def test_beacons_exist(self, live_drv):
+        devices = live_drv._list_devices_raw()
+        beacons = [d for d in devices if "beacon" in d.get("name", "").lower()]
+        assert len(beacons) >= 2
+
+
+@pytest.mark.live
+class TestLiveRadioToggle:
+    """set_radio off freezes BLE rx, on resumes it."""
+
+    def test_ble_off_stops_rx(self, live_drv):
+        live_drv.set_radio("1", "ble", "on")
+        time.sleep(1)
+
+        before, after = _poll_rx_growing(live_drv, "1")
+        assert after > before, "rx not growing with BLE on — can't test"
+
+        try:
+            live_drv.set_radio("1", "ble", "off")
+            before_off, after_off = _poll_rx_frozen(live_drv, "1", window=3.0)
+            assert before_off == after_off, f"rx still growing with BLE off: {before_off} -> {after_off}"
+        finally:
+            live_drv.set_radio("1", "ble", "on")
+
+        before_on, after_on = _poll_rx_growing(live_drv, "1")
+        assert after_on > before_on, "rx didn't resume after BLE re-enabled"
+
+
+@pytest.mark.live
+class TestLiveVersionEndpoint:
+    """/v1/version doesn't exist in netsim <=0.3.100."""
+
+    def test_no_version_endpoint(self, live_drv):
+        with pytest.raises(NetsimError, match="failed"):
+            live_drv._request("GET", "/v1/version")
+
+
+@pytest.mark.live
+class TestLiveCapturePatchBroken:
+    """REST PATCH for captures is broken in netsim <=0.3.100.
+
+    This test exists to detect when a netsim upgrade fixes it, so we
+    can remove the CLI fallback.
+    """
+
+    def test_rest_capture_patch_returns_error(self, live_drv):
+        captures = live_drv._request("GET", "/v1/captures")
+        assert isinstance(captures, dict), "unexpected captures format"
+        cap_list = captures.get("captures", [])
+        if not cap_list:
+            pytest.skip("no captures available")  # ty: ignore[call-non-callable]
+        cap_id = cap_list[0]["id"]
+        resp = requests.patch(
+            f"http://{live_drv.host}:{live_drv.port}/v1/captures/{cap_id}",
+            json={"capture": {"state": True}},
+            timeout=5,
+        )
+        assert not resp.ok or "Incorrect" in resp.text, (
+            "REST capture PATCH succeeded - netsim may have fixed the bug. Consider removing CLI fallback."
+        )
+
+
+@pytest.mark.live
+class TestLiveNumericIdRequired:
+    """netsim REST API requires numeric device IDs in paths.
+
+    Using a device name in the path (e.g. /v1/devices/cvd-1) returns
+    "Incorrect Id type" rather than resolving. This tests that assumption
+    so we know if a future version adds name-based paths.
+    """
+
+    def test_name_in_path_fails(self, live_drv):
+        devices = live_drv._list_devices_raw()
+        if not devices:
+            pytest.skip("no devices")  # ty: ignore[call-non-callable]
+        name = devices[0]["name"]
+        resp = requests.patch(
+            f"http://{live_drv.host}:{live_drv.port}/v1/devices/{name}",
+            json={"device": {"position": {"x": 0, "y": 0, "z": 0}}},
+            timeout=5,
+        )
+        assert not resp.ok or "Incorrect" in resp.text, (
+            "Name-based device path succeeded - netsim may support name IDs now. "
+            "Consider simplifying _resolve_device_id."
+        )
+
+
+@pytest.mark.live
+class TestLiveDeviceResolution:
+    def test_resolve_by_numeric_id(self, live_drv):
+        assert live_drv._resolve_device_id("1") == 1
+
+    def test_resolve_by_name(self, live_drv):
+        devices = live_drv._list_devices_raw()
+        if not devices:
+            pytest.skip("no devices")  # ty: ignore[call-non-callable]
+        name = devices[0]["name"]
+        assert live_drv._resolve_device_id(name) == devices[0]["id"]
+
+    def test_resolve_by_substring(self, live_drv):
+        devices = live_drv._list_devices_raw()
+        beacons = [d for d in devices if "beacon-1" in d.get("name", "")]
+        if not beacons:
+            pytest.skip("no beacon-1")  # ty: ignore[call-non-callable]
+        assert live_drv._resolve_device_id("beacon-1") == beacons[0]["id"]

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver_test.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver_test.py
@@ -1,0 +1,353 @@
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from .driver import Netsim, NetsimError, _parse_bool
+
+BASE = "http://localhost:7681"
+
+DEVICES_RESPONSE = {
+    "devices": [
+        {"id": 1, "name": "cvd-1", "chips": [{"kind": "BLUETOOTH"}]},
+        {"id": 2, "name": "cvd-2", "chips": []},
+    ]
+}
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def drv():
+    return Netsim()
+
+
+@pytest.fixture
+def drv_cli():
+    return Netsim(netsim_cli="/usr/lib/cuttlefish-common/bin/netsim")
+
+
+def test_parse_bool_on():
+    for v in ("true", "1", "on", "True", "ON"):
+        assert _parse_bool(v, "x") is True
+
+
+def test_parse_bool_off():
+    for v in ("false", "0", "off", "False", "OFF"):
+        assert _parse_bool(v, "x") is False
+
+
+def test_parse_bool_invalid():
+    with pytest.raises(NetsimError, match="invalid enabled.*yes"):
+        _parse_bool("yes", "enabled")
+
+
+def test_resolve_device_id_numeric(requests_mock, drv):
+    result = drv._resolve_device_id("42")
+    assert result == 42
+    assert not requests_mock.called
+
+
+def test_resolve_device_id_exact_name(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    assert drv._resolve_device_id("cvd-1") == 1
+
+
+def test_resolve_device_id_substring(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    assert drv._resolve_device_id("vd-2") == 2
+
+
+def test_resolve_device_id_ambiguous(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with pytest.raises(NetsimError, match="ambiguous.*cvd"):
+        drv._resolve_device_id("cvd")
+
+
+def test_resolve_device_id_not_found(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with pytest.raises(NetsimError, match="device not found.*nope"):
+        drv._resolve_device_id("nope")
+
+
+def test_status_returns_device_count(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    assert drv.status() == "OK (2 devices)"
+
+
+def test_status_empty(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json={"devices": []})
+    assert drv.status() == "OK (0 devices)"
+
+
+def test_status_connection_error(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", exc=requests.ConnectionError)
+    with pytest.raises(NetsimError, match="not connected"):
+        drv.status()
+
+
+def test_status_timeout(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", exc=requests.Timeout)
+    with pytest.raises(NetsimError, match="timed out"):
+        drv.status()
+
+
+def test_list_devices(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    result = json.loads(drv.list_devices())
+    assert result["devices"][0]["name"] == "cvd-1"
+
+
+def test_get_device_by_name(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    result = json.loads(drv.get_device("cvd-2"))
+    assert result["name"] == "cvd-2"
+    assert result["id"] == 2
+
+
+def test_get_device_by_numeric_id(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    result = json.loads(drv.get_device("1"))
+    assert result["name"] == "cvd-1"
+
+
+def test_get_device_not_found(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json={"devices": []})
+    with pytest.raises(NetsimError, match="device not found.*cvd-99"):
+        drv.get_device("cvd-99")
+
+
+def test_patch_device_by_name(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.patch_device("cvd-1", '{"visible": false}')
+    req = requests_mock.request_history[-1]
+    assert req.json() == {"device": {"visible": False}}
+
+
+def test_patch_device_by_numeric_id(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/5", json={})
+    drv.patch_device("5", '{"visible": false}')
+    assert requests_mock.request_history[-1].path == "/v1/devices/5"
+
+
+def test_patch_device_invalid_json(requests_mock, drv):
+    with pytest.raises(NetsimError, match="invalid JSON"):
+        drv.patch_device("cvd-1", "not json")
+    assert not requests_mock.called
+
+
+def test_set_radio_bt_classic(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("cvd-1", "bt_classic", "on")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["kind"] == "BLUETOOTH"
+    assert chips[0]["bt"]["classic"]["state"] is True
+
+
+def test_set_radio_ble_off(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("1", "ble", "off")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["bt"]["low_energy"]["state"] is False
+
+
+def test_set_radio_wifi(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("1", "wifi", "true")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["kind"] == "WIFI"
+    assert chips[0]["wifi"]["state"] is True
+
+
+def test_set_radio_uwb(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("1", "uwb", "1")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["kind"] == "UWB"
+    assert chips[0]["uwb"]["state"] is True
+
+
+def test_set_radio_invalid_type(requests_mock, drv):
+    with pytest.raises(NetsimError, match="unknown radio"):
+        drv.set_radio("cvd-1", "zigbee", "on")
+    assert not requests_mock.called
+
+
+def test_set_radio_invalid_state(requests_mock, drv):
+    with pytest.raises(NetsimError, match="invalid enabled.*yes"):
+        drv.set_radio("cvd-1", "ble", "yes")
+    assert not requests_mock.called
+
+
+def test_reset_devices(requests_mock, drv):
+    requests_mock.post(f"{BASE}/v1/devices/reset", text="")
+    assert drv.reset_devices() == "OK"
+
+
+def test_list_captures(requests_mock, drv):
+    body = {"captures": [{"id": 1, "state": "ON"}]}
+    requests_mock.get(f"{BASE}/v1/captures", json=body)
+    result = json.loads(drv.list_captures())
+    assert result["captures"][0]["id"] == 1
+
+
+@pytest.mark.anyio
+async def test_get_capture(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/captures/5", content=b"\x00pcap-data")
+    import base64
+
+    chunks = []
+    async for chunk in drv.get_capture("5"):
+        chunks.append(base64.b64decode(chunk))
+    assert b"".join(chunks) == b"\x00pcap-data"
+
+
+@pytest.mark.anyio
+async def test_get_capture_large(requests_mock, drv):
+    """Captures larger than chunk size are split into multiple chunks."""
+    import base64
+
+    large_data = b"\xab" * (3 * 1024 * 1024)  # 3 MiB
+    requests_mock.get(f"{BASE}/v1/captures/7", content=large_data)
+    chunks = []
+    async for chunk in drv.get_capture("7"):
+        chunks.append(base64.b64decode(chunk))
+    assert b"".join(chunks) == large_data
+    assert len(chunks) == 2  # 3 MiB / 2 MiB per chunk = 2 chunks
+
+
+@pytest.mark.anyio
+async def test_get_capture_invalid_id(drv):
+    with pytest.raises(NetsimError, match="capture_id must be numeric"):
+        async for _ in drv.get_capture("foo/bar"):
+            pass
+
+
+def test_set_capture_no_cli(drv):
+    with pytest.raises(NetsimError, match="capture toggle requires netsim_cli"):
+        drv.set_capture("1", "on")
+
+
+def test_set_capture_invalid_state(drv_cli):
+    with pytest.raises(NetsimError, match="invalid enabled"):
+        drv_cli.set_capture("1", "yes")
+
+
+@patch("subprocess.run")
+def test_set_capture_on(mock_run, drv_cli):
+    mock_run.return_value.returncode = 0
+    assert drv_cli.set_capture("1", "on") == "OK"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "on", "1"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@patch("subprocess.run")
+def test_set_capture_off(mock_run, drv_cli):
+    mock_run.return_value.returncode = 0
+    assert drv_cli.set_capture("1", "off") == "OK"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "off", "1"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@patch("subprocess.run")
+def test_start_capture(mock_run, requests_mock, drv_cli):
+    mock_run.return_value.returncode = 0
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    captures = {
+        "captures": [
+            {"id": 10, "deviceName": "cvd-1", "chipKind": "BLUETOOTH", "state": "OFF"},
+            {"id": 11, "deviceName": "cvd-2", "chipKind": "BLUETOOTH", "state": "OFF"},
+        ]
+    }
+    requests_mock.get(f"{BASE}/v1/captures", json=captures)
+    cap_id = drv_cli.start_capture("cvd-1")
+    assert cap_id == "10"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "on", "10"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_start_capture_no_cli(requests_mock, drv):
+    with pytest.raises(NetsimError, match="capture toggle requires netsim_cli"):
+        drv.start_capture("cvd-1")
+    assert not requests_mock.called
+
+
+def test_start_capture_not_found(requests_mock, drv_cli):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.get(f"{BASE}/v1/captures", json={"captures": []})
+    with pytest.raises(NetsimError, match="no BLUETOOTH capture found"):
+        drv_cli.start_capture("cvd-1")
+
+
+@patch("subprocess.run")
+def test_stop_capture(mock_run, drv_cli):
+    mock_run.return_value.returncode = 0
+    assert drv_cli.stop_capture("10") == "OK"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "off", "10"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_stop_capture_no_cli(drv):
+    with pytest.raises(NetsimError, match="capture toggle requires netsim_cli"):
+        drv.stop_capture("10")
+
+
+@patch("subprocess.run")
+def test_capture_toggle_cli_failure(mock_run, drv_cli):
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stderr = "netsim: error"
+    with pytest.raises(NetsimError, match="netsim capture patch failed"):
+        drv_cli.set_capture("1", "on")
+
+
+@patch("subprocess.run")
+def test_capture_toggle_timeout(mock_run, drv_cli):
+    import subprocess
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="netsim", timeout=10)
+    with pytest.raises(NetsimError, match="timed out"):
+        drv_cli.set_capture("1", "on")
+
+
+@patch("subprocess.run")
+def test_capture_toggle_bad_cli(mock_run, drv_cli):
+    mock_run.side_effect = FileNotFoundError("No such file")
+    with pytest.raises(NetsimError, match="failed to run netsim CLI"):
+        drv_cli.set_capture("1", "on")
+
+
+def test_request_http_error(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", status_code=500, text="error")
+    with pytest.raises(NetsimError, match="failed"):
+        drv.list_devices()
+
+
+def test_custom_host_port():
+    drv = Netsim(host="10.0.0.1", port=9090)
+    assert drv._base_url == "http://10.0.0.1:9090"

--- a/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver_test.py
+++ b/python/packages/jumpstarter-driver-netsim/jumpstarter_driver_netsim/driver_test.py
@@ -1,0 +1,329 @@
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from .driver import Netsim, NetsimError, _parse_bool
+
+BASE = "http://localhost:7681"
+
+DEVICES_RESPONSE = {
+    "devices": [
+        {"id": 1, "name": "cvd-1", "chips": [{"kind": "BLUETOOTH"}]},
+        {"id": 2, "name": "cvd-2", "chips": []},
+    ]
+}
+
+
+@pytest.fixture
+def drv():
+    return Netsim()
+
+
+@pytest.fixture
+def drv_cli():
+    return Netsim(netsim_cli="/usr/lib/cuttlefish-common/bin/netsim")
+
+
+def test_parse_bool_on():
+    for v in ("true", "1", "on", "True", "ON"):
+        assert _parse_bool(v, "x") is True
+
+
+def test_parse_bool_off():
+    for v in ("false", "0", "off", "False", "OFF"):
+        assert _parse_bool(v, "x") is False
+
+
+def test_parse_bool_invalid():
+    with pytest.raises(NetsimError, match="invalid enabled.*yes"):
+        _parse_bool("yes", "enabled")
+
+
+def test_resolve_device_id_numeric(requests_mock, drv):
+    result = drv._resolve_device_id("42")
+    assert result == 42
+    assert not requests_mock.called
+
+
+def test_resolve_device_id_exact_name(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    assert drv._resolve_device_id("cvd-1") == 1
+
+
+def test_resolve_device_id_substring(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    assert drv._resolve_device_id("vd-2") == 2
+
+
+def test_resolve_device_id_ambiguous(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with pytest.raises(NetsimError, match="ambiguous.*cvd"):
+        drv._resolve_device_id("cvd")
+
+
+def test_resolve_device_id_not_found(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    with pytest.raises(NetsimError, match="device not found.*nope"):
+        drv._resolve_device_id("nope")
+
+
+def test_status_returns_device_count(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    assert drv.status() == "OK (2 devices)"
+
+
+def test_status_empty(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json={"devices": []})
+    assert drv.status() == "OK (0 devices)"
+
+
+def test_status_connection_error(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", exc=requests.ConnectionError)
+    with pytest.raises(NetsimError, match="not connected"):
+        drv.status()
+
+
+def test_status_timeout(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", exc=requests.Timeout)
+    with pytest.raises(NetsimError, match="timed out"):
+        drv.status()
+
+
+def test_list_devices(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    result = json.loads(drv.list_devices())
+    assert result["devices"][0]["name"] == "cvd-1"
+
+
+def test_get_device_by_name(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    result = json.loads(drv.get_device("cvd-2"))
+    assert result["name"] == "cvd-2"
+    assert result["id"] == 2
+
+
+def test_get_device_by_numeric_id(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    result = json.loads(drv.get_device("1"))
+    assert result["name"] == "cvd-1"
+
+
+def test_get_device_not_found(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json={"devices": []})
+    with pytest.raises(NetsimError, match="device not found.*cvd-99"):
+        drv.get_device("cvd-99")
+
+
+def test_patch_device_by_name(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.patch_device("cvd-1", '{"visible": false}')
+    req = requests_mock.request_history[-1]
+    assert req.json() == {"device": {"visible": False}}
+
+
+def test_patch_device_by_numeric_id(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/5", json={})
+    drv.patch_device("5", '{"visible": false}')
+    assert requests_mock.request_history[-1].path == "/v1/devices/5"
+
+
+def test_patch_device_invalid_json(requests_mock, drv):
+    with pytest.raises(NetsimError, match="invalid JSON"):
+        drv.patch_device("cvd-1", "not json")
+    assert not requests_mock.called
+
+
+def test_set_radio_bt_classic(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("cvd-1", "bt_classic", "on")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["kind"] == "BLUETOOTH"
+    assert chips[0]["bt"]["classic"]["state"] is True
+
+
+def test_set_radio_ble_off(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("1", "ble", "off")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["bt"]["low_energy"]["state"] is False
+
+
+def test_set_radio_wifi(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("1", "wifi", "true")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["kind"] == "WIFI"
+    assert chips[0]["wifi"]["state"] is True
+
+
+def test_set_radio_uwb(requests_mock, drv):
+    requests_mock.patch(f"{BASE}/v1/devices/1", json={})
+    drv.set_radio("1", "uwb", "1")
+    req = requests_mock.request_history[-1]
+    chips = req.json()["device"]["chips"]
+    assert chips[0]["kind"] == "UWB"
+    assert chips[0]["uwb"]["state"] is True
+
+
+def test_set_radio_invalid_type(requests_mock, drv):
+    with pytest.raises(NetsimError, match="unknown radio"):
+        drv.set_radio("cvd-1", "zigbee", "on")
+    assert not requests_mock.called
+
+
+def test_set_radio_invalid_state(requests_mock, drv):
+    with pytest.raises(NetsimError, match="invalid enabled.*yes"):
+        drv.set_radio("cvd-1", "ble", "yes")
+    assert not requests_mock.called
+
+
+def test_reset_devices(requests_mock, drv):
+    requests_mock.post(f"{BASE}/v1/devices/reset", text="")
+    assert drv.reset_devices() == "OK"
+
+
+def test_list_captures(requests_mock, drv):
+    body = {"captures": [{"id": 1, "state": "ON"}]}
+    requests_mock.get(f"{BASE}/v1/captures", json=body)
+    result = json.loads(drv.list_captures())
+    assert result["captures"][0]["id"] == 1
+
+
+def test_get_capture(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/captures/5", content=b"\x00pcap-data")
+    data = drv.get_capture("5")
+    import base64
+
+    assert base64.b64decode(data) == b"\x00pcap-data"
+
+
+def test_get_capture_invalid_id(drv):
+    with pytest.raises(NetsimError, match="capture_id must be numeric"):
+        drv.get_capture("foo/bar")
+
+
+def test_set_capture_no_cli(drv):
+    with pytest.raises(NetsimError, match="capture toggle requires netsim_cli"):
+        drv.set_capture("1", "on")
+
+
+def test_set_capture_invalid_state(drv_cli):
+    with pytest.raises(NetsimError, match="invalid enabled"):
+        drv_cli.set_capture("1", "yes")
+
+
+@patch("subprocess.run")
+def test_set_capture_on(mock_run, drv_cli):
+    mock_run.return_value.returncode = 0
+    assert drv_cli.set_capture("1", "on") == "OK"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "on", "1"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@patch("subprocess.run")
+def test_set_capture_off(mock_run, drv_cli):
+    mock_run.return_value.returncode = 0
+    assert drv_cli.set_capture("1", "off") == "OK"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "off", "1"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@patch("subprocess.run")
+def test_start_capture(mock_run, requests_mock, drv_cli):
+    mock_run.return_value.returncode = 0
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    captures = {
+        "captures": [
+            {"id": 10, "deviceName": "cvd-1", "chipKind": "BLUETOOTH", "state": "OFF"},
+            {"id": 11, "deviceName": "cvd-2", "chipKind": "BLUETOOTH", "state": "OFF"},
+        ]
+    }
+    requests_mock.get(f"{BASE}/v1/captures", json=captures)
+    cap_id = drv_cli.start_capture("cvd-1")
+    assert cap_id == "10"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "on", "10"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_start_capture_no_cli(requests_mock, drv):
+    with pytest.raises(NetsimError, match="capture toggle requires netsim_cli"):
+        drv.start_capture("cvd-1")
+    assert not requests_mock.called
+
+
+def test_start_capture_not_found(requests_mock, drv_cli):
+    requests_mock.get(f"{BASE}/v1/devices", json=DEVICES_RESPONSE)
+    requests_mock.get(f"{BASE}/v1/captures", json={"captures": []})
+    with pytest.raises(NetsimError, match="no BLUETOOTH capture found"):
+        drv_cli.start_capture("cvd-1")
+
+
+@patch("subprocess.run")
+def test_stop_capture(mock_run, drv_cli):
+    mock_run.return_value.returncode = 0
+    assert drv_cli.stop_capture("10") == "OK"
+    mock_run.assert_called_once_with(
+        ["/usr/lib/cuttlefish-common/bin/netsim", "capture", "patch", "off", "10"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_stop_capture_no_cli(drv):
+    with pytest.raises(NetsimError, match="capture toggle requires netsim_cli"):
+        drv.stop_capture("10")
+
+
+@patch("subprocess.run")
+def test_capture_toggle_cli_failure(mock_run, drv_cli):
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stderr = "netsim: error"
+    with pytest.raises(NetsimError, match="netsim capture patch failed"):
+        drv_cli.set_capture("1", "on")
+
+
+@patch("subprocess.run")
+def test_capture_toggle_timeout(mock_run, drv_cli):
+    import subprocess
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="netsim", timeout=10)
+    with pytest.raises(NetsimError, match="timed out"):
+        drv_cli.set_capture("1", "on")
+
+
+@patch("subprocess.run")
+def test_capture_toggle_bad_cli(mock_run, drv_cli):
+    mock_run.side_effect = FileNotFoundError("No such file")
+    with pytest.raises(NetsimError, match="failed to run netsim CLI"):
+        drv_cli.set_capture("1", "on")
+
+
+def test_request_http_error(requests_mock, drv):
+    requests_mock.get(f"{BASE}/v1/devices", status_code=500, text="error")
+    with pytest.raises(NetsimError, match="failed"):
+        drv.list_devices()
+
+
+def test_custom_host_port():
+    drv = Netsim(host="10.0.0.1", port=9090)
+    assert drv._base_url == "http://10.0.0.1:9090"

--- a/python/packages/jumpstarter-driver-netsim/pyproject.toml
+++ b/python/packages/jumpstarter-driver-netsim/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "jumpstarter-driver-netsim"
+dynamic = ["version", "urls"]
+description = "Android netsim driver for controlling virtual radio interfaces"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [{ name = "Benny Zlotnik", email = "bzlotnik@redhat.com" }]
+requires-python = ">=3.11"
+dependencies = [
+    "click>=8.0.0",
+    "jumpstarter",
+    "requests>=2.28.0",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+Netsim = "jumpstarter_driver_netsim.driver:Netsim"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../' }
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/repo/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov=jumpstarter_driver_netsim --cov-report=html --cov-report=xml -m 'not live'"
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["jumpstarter_driver_netsim"]
+markers = [
+    "live: tests that require a real netsim instance (use -m live to run)",
+]
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+    "pytest-asyncio>=0.24.0",
+    "requests-mock>=1.12.0",
+]
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,7 @@ jumpstarter-driver-http = { workspace = true }
 jumpstarter-driver-http-power = { workspace = true }
 jumpstarter-driver-gpiod = { workspace = true }
 jumpstarter-driver-ridesx = { workspace = true }
+jumpstarter-driver-netsim = { workspace = true }
 jumpstarter-driver-network = { workspace = true }
 jumpstarter-driver-obd = { workspace = true }
 jumpstarter-driver-opendal = { workspace = true }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,6 +25,7 @@ jumpstarter-driver-http = { workspace = true }
 jumpstarter-driver-http-power = { workspace = true }
 jumpstarter-driver-gpiod = { workspace = true }
 jumpstarter-driver-ridesx = { workspace = true }
+jumpstarter-driver-netsim = { workspace = true }
 jumpstarter-driver-network = { workspace = true }
 jumpstarter-driver-obd = { workspace = true }
 jumpstarter-driver-opendal = { workspace = true }


### PR DESCRIPTION
- Adds jumpstarter-driver-netsim — a new driver for controlling Android netsim virtual radios (Bluetooth Classic, BLE, WiFi, UWB) via the netsim REST API
- Exposes device listing, radio toggle, raw patching, device reset, and pcap capture management (start/stop/download)
- Includes full CLI via Click with subcommands: devices, device, radio, patch, reset, capture {list,start,stop,get}, status
- Capture toggle uses netsim CLI binary as workaround for broken REST PATCH in netsim ≤0.3.100