### PR TITLE
feat: generic video driver

### DIFF
--- a/docs/source/reference/package-apis/drivers/index.md
+++ b/docs/source/reference/package-apis/drivers/index.md
@@ -55,6 +55,7 @@ Drivers that control storage devices and manage data:
 Drivers that handle media streams:
 
 - {doc}`uStreamer <ustreamer>` (`jumpstarter-driver-ustreamer`) - Video streaming
+- {doc}`Video <video>` (`jumpstarter-driver-video`) - Video interface and HTTP/MJPEG camera sources
 
 ### Automotive Diagnostics
 
@@ -143,6 +144,7 @@ uds.md
 uds-can.md
 uds-doip.md
 ustreamer.md
+video.md
 vnc.md
 xcp.md
 yepkit.md

--- a/docs/source/reference/package-apis/drivers/video.md
+++ b/docs/source/reference/package-apis/drivers/video.md
@@ -1,0 +1,1 @@
+../../../../../python/packages/jumpstarter-driver-video/README.md

--- a/python/packages/jumpstarter-all/pyproject.toml
+++ b/python/packages/jumpstarter-all/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "jumpstarter-driver-uds-can",
   "jumpstarter-driver-uds-doip",
   "jumpstarter-driver-ustreamer",
+  "jumpstarter-driver-video",
   "jumpstarter-driver-vnc",
   "jumpstarter-driver-yepkit",
   "jumpstarter-imagehash",

--- a/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/client.py
+++ b/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/client.py
@@ -1,136 +1,22 @@
-import io
-import webbrowser
-from base64 import b64decode
-
 import click
-from aiohttp import web
-from anyio import EndOfStream, get_cancelled_exc_class, move_on_after
-from PIL import Image
+from jumpstarter_driver_video.client import VideoClient
 
 from .common import UStreamerState
-from jumpstarter.client import DriverClient
-from jumpstarter.client.decorators import driver_click_group
-
-LANDING_PAGE = """\
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Video</title>
-  <style>
-    body { background: #1a1a1a; color: #eee; font-family: system-ui; margin: 0;
-           display: flex; flex-direction: column; align-items: center; padding: 20px; }
-    img { max-width: 100%; border: 1px solid #333; }
-    a { color: #6cf; }
-    .info { margin: 10px 0; font-size: 14px; color: #aaa; }
-  </style>
-</head>
-<body>
-  <h2>Jumpstarter Video Stream</h2>
-  <img src="/stream" alt="Live video stream" />
-  <p class="info"><a href="/snapshot">Single snapshot (JPEG)</a></p>
-</body>
-</html>
-"""
 
 
-def _parse_content_type(header_bytes: bytes) -> str:
-    """Extract Content-Type from raw HTTP response headers."""
-    for line in header_bytes.decode("ascii", errors="replace").split("\r\n"):
-        if line.lower().startswith("content-type:"):
-            return line.split(":", 1)[1].strip()
-    return "multipart/x-mixed-replace; boundary=--"
-
-
-def _run_server(client, app, port, open_browser):
-    """Run an aiohttp app, opening the browser and blocking until Ctrl+C."""
-    runner = web.AppRunner(app)
-
-    async def serve():
-        await runner.setup()
-        try:
-            site = web.TCPSite(runner, "127.0.0.1", port)
-            await site.start()
-
-            addresses = runner.addresses
-            if not addresses:
-                raise RuntimeError("Video server started without a bound address")
-            actual_port = int(addresses[0][1])
-            url = f"http://127.0.0.1:{actual_port}"
-            click.echo(f"Video stream available at: {url}")
-            click.echo(f"Snapshot endpoint: {url}/snapshot")
-            click.echo("Press Ctrl+C to stop.")
-
-            if open_browser:
-                webbrowser.open(url)
-
-            from anyio import sleep_forever
-            await sleep_forever()
-        finally:
-            with move_on_after(2, shield=True):
-                await runner.cleanup()
-
-    try:
-        client.portal.call(serve)
-    except KeyboardInterrupt:
-        click.echo("\nStopping video server.")
-
-
-async def _proxy_mjpeg_stream(client, request):
-    """Proxy ustreamer's native MJPEG stream through the jumpstarter tunnel."""
-    async with client.stream_async("connect") as tunnel:
-        await tunnel.send(b"GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n")
-
-        buf = b""
-        while b"\r\n\r\n" not in buf:
-            buf += await tunnel.receive()
-
-        header_part, _, body_start = buf.partition(b"\r\n\r\n")
-
-        response = web.StreamResponse()
-        response.content_type = _parse_content_type(header_part)
-        await response.prepare(request)
-
-        if body_start:
-            await response.write(body_start)
-
-        try:
-            while True:
-                chunk = await tunnel.receive()
-                await response.write(chunk)
-        except (EndOfStream, ConnectionResetError, ConnectionAbortedError, get_cancelled_exc_class()):
-            pass
-
-    return response
-
-
-class UStreamerClient(DriverClient):
+class UStreamerClient(VideoClient):
     """UStreamer client class
 
-    Client methods for the UStreamer driver.
+    Client methods for the UStreamer driver. Inherits snapshot and
+    streaming functionality from VideoClient.
     """
 
     def state(self):
         """Get state of ustreamer service"""
         return UStreamerState.model_validate(self.call("state"))
 
-    def snapshot(self):
-        """Get a snapshot image from the video input
-
-        :return: PIL Image object of the snapshot image
-        :rtype: PIL.Image
-        """
-        input_jpg_data = b64decode(self.call("snapshot"))
-        return Image.open(io.BytesIO(input_jpg_data))
-
-    def snapshot_bytes(self):
-        """Get raw JPEG bytes from the video input"""
-        return b64decode(self.call("snapshot"))
-
     def cli(self):
-        @driver_click_group(self)
-        def video():
-            """Video capture and streaming"""
-            pass
+        video = super().cli()
 
         @video.command()
         def state():
@@ -142,40 +28,5 @@ class UStreamerClient(DriverClient):
             click.echo(f"Resolution: {src.resolution.width}x{src.resolution.height}")
             click.echo(f"FPS:        {src.captured_fps}/{src.desired_fps}")
             click.echo(f"Encoder:    {enc.type} (quality: {enc.quality})")
-
-        @video.command()
-        @click.option("-o", "--output", default="snapshot.jpg", help="Output file path")
-        def snapshot(output):
-            """Save a single snapshot to file"""
-            img = self.snapshot()
-            img.save(output)
-            click.echo(f"Saved snapshot to {output}")
-
-        @video.command()
-        @click.option("-p", "--port", default=0, type=int, help="Local server port (0 = auto)")
-        @click.option("--browser/--no-browser", default=True, help="Open in web browser")
-        def stream(port, browser):
-            """Start local MJPEG streaming server
-
-            Proxies ustreamer's native MJPEG stream through the jumpstarter
-            tunnel. Frame rate is controlled by ustreamer's configuration.
-            """
-
-            async def handle_index(request):
-                return web.Response(text=LANDING_PAGE, content_type="text/html")
-
-            async def handle_snapshot(request):
-                data = b64decode(await self.call_async("snapshot"))
-                return web.Response(body=data, content_type="image/jpeg")
-
-            async def handle_stream(request):
-                return await _proxy_mjpeg_stream(self, request)
-
-            app = web.Application()
-            app.router.add_get("/", handle_index)
-            app.router.add_get("/snapshot", handle_snapshot)
-            app.router.add_get("/stream", handle_stream)
-
-            _run_server(self, app, port, browser)
 
         return video

--- a/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/client_test.py
+++ b/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/client_test.py
@@ -1,21 +1,10 @@
-import base64
-import contextlib
-import io
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-import anyio
-import pytest
 from click.testing import CliRunner
-from PIL import Image
+from jumpstarter_driver_video.client import VideoClient
+from jumpstarter_driver_video.common import VideoState
 
-from jumpstarter_driver_ustreamer.client import (
-    LANDING_PAGE,
-    UStreamerClient,
-    _parse_content_type,
-    _proxy_mjpeg_stream,
-    _run_server,
-)
+from jumpstarter_driver_ustreamer.client import UStreamerClient
 from jumpstarter_driver_ustreamer.common import UStreamerState
 
 
@@ -44,73 +33,6 @@ def _make_state():
     )
 
 
-def _make_jpeg_bytes():
-    buffer = io.BytesIO()
-    Image.new("RGB", (2, 1), color="red").save(buffer, format="JPEG")
-    return buffer.getvalue()
-
-
-def _get_route_handler(app, path):
-    for resource in app.router.resources():
-        if getattr(resource, "canonical", None) == path:
-            return next(iter(resource)).handler
-    raise AssertionError(f"Route {path} was not registered")
-
-
-class _FakeStreamContext:
-    def __init__(self, tunnel):
-        self.tunnel = tunnel
-
-    async def __aenter__(self):
-        return self.tunnel
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-
-class _FakeTunnel:
-    def __init__(self, chunks):
-        self._chunks = iter(chunks)
-        self.sent = []
-
-    async def send(self, data):
-        self.sent.append(data)
-
-    async def receive(self):
-        chunk = next(self._chunks)
-        if isinstance(chunk, BaseException):
-            raise chunk
-        return chunk
-
-
-class _FakeStreamResponse:
-    def __init__(self):
-        self.content_type = None
-        self.prepared_request = None
-        self.writes = []
-
-    async def prepare(self, request):
-        self.prepared_request = request
-
-    async def write(self, data):
-        self.writes.append(data)
-
-
-@pytest.fixture
-def anyio_backend():
-    return "asyncio"
-
-
-def test_parse_content_type_returns_header_value():
-    header_bytes = b"HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nX-Test: 1\r\n"
-
-    assert _parse_content_type(header_bytes) == "image/jpeg"
-
-
-def test_parse_content_type_falls_back_to_mjpeg_default():
-    assert _parse_content_type(b"HTTP/1.1 200 OK\r\nX-Test: 1\r\n") == "multipart/x-mixed-replace; boundary=--"
-
-
 def test_state_returns_validated_model():
     client = _make_client()
     client.call = MagicMock(return_value=_make_state().model_dump(mode="python"))
@@ -121,24 +43,26 @@ def test_state_returns_validated_model():
     client.call.assert_called_once_with("state")
 
 
-def test_snapshot_returns_image():
-    client = _make_client()
-    jpeg_bytes = _make_jpeg_bytes()
-    client.call = MagicMock(return_value=base64.b64encode(jpeg_bytes).decode("ascii"))
+def test_state_exposes_common_video_state_fields():
+    """UStreamerState extends VideoState, so generic consumers can read the
+    common fields while ustreamer's own detail stays available."""
+    state = _make_state()
 
-    image = UStreamerClient.snapshot(client)
+    assert isinstance(state, VideoState)
+    assert state.online is True
+    assert (state.width, state.height) == (1280, 720)
+    assert state.fps == 29
+    # ustreamer-specific detail is unchanged
+    assert state.result.encoder.type == "CPU"
+    assert state.result.source.desired_fps == 30
 
-    assert image.size == (2, 1)
-    client.call.assert_called_once_with("snapshot")
 
-
-def test_snapshot_bytes_returns_decoded_jpeg():
-    client = _make_client()
-    jpeg_bytes = _make_jpeg_bytes()
-    client.call = MagicMock(return_value=base64.b64encode(jpeg_bytes).decode("ascii"))
-
-    assert UStreamerClient.snapshot_bytes(client) == jpeg_bytes
-    client.call.assert_called_once_with("snapshot")
+def test_ustreamer_inherits_video_client_methods():
+    """UStreamerClient must expose the full VideoClient API."""
+    assert issubclass(UStreamerClient, VideoClient)
+    # snapshot/snapshot_bytes/stream come from VideoClient
+    assert UStreamerClient.snapshot is VideoClient.snapshot
+    assert UStreamerClient.snapshot_bytes is VideoClient.snapshot_bytes
 
 
 def test_state_command_prints_source_and_encoder_details():
@@ -152,167 +76,3 @@ def test_state_command_prints_source_and_encoder_details():
     assert "Resolution: 1280x720" in result.output
     assert "FPS:        29/30" in result.output
     assert "Encoder:    CPU (quality: 85)" in result.output
-
-
-def test_snapshot_command_saves_snapshot_to_requested_path():
-    client = _make_client()
-    image = MagicMock()
-    client.snapshot = MagicMock(return_value=image)
-
-    result = CliRunner().invoke(client.cli(), ["snapshot", "--output", "frame.jpg"])
-
-    assert result.exit_code == 0
-    image.save.assert_called_once_with("frame.jpg")
-    assert "Saved snapshot to frame.jpg" in result.output
-
-
-def test_stream_command_registers_routes_and_starts_server():
-    client = _make_client()
-    client.call_async = AsyncMock(return_value=base64.b64encode(b"jpeg-data").decode("ascii"))
-
-    captured = {}
-    proxied_response = object()
-
-    with (
-        patch(
-            "jumpstarter_driver_ustreamer.client._run_server",
-            side_effect=lambda client_arg, app, port, browser: captured.update(
-                {"client": client_arg, "app": app, "port": port, "browser": browser}
-            ),
-        ),
-        patch(
-            "jumpstarter_driver_ustreamer.client._proxy_mjpeg_stream",
-            new=AsyncMock(return_value=proxied_response),
-        ) as mock_proxy,
-    ):
-        result = CliRunner().invoke(client.cli(), ["stream", "--port", "1234", "--no-browser"])
-
-        assert result.exit_code == 0
-        assert captured["client"] is client
-        assert captured["port"] == 1234
-        assert captured["browser"] is False
-
-        async def exercise_routes():
-            app = captured["app"]
-            index_handler = _get_route_handler(app, "/")
-            snapshot_handler = _get_route_handler(app, "/snapshot")
-            stream_handler = _get_route_handler(app, "/stream")
-
-            index_response = await index_handler(object())
-            assert index_response.text == LANDING_PAGE
-
-            snapshot_response = await snapshot_handler(object())
-            assert snapshot_response.body == b"jpeg-data"
-            assert snapshot_response.content_type == "image/jpeg"
-
-            request = object()
-            response = await stream_handler(request)
-            assert response is proxied_response
-            mock_proxy.assert_awaited_once_with(client, request)
-
-        anyio.run(exercise_routes)
-
-    client.call_async.assert_awaited_once_with("snapshot")
-
-
-def test_run_server_uses_public_site_port_and_cleans_up():
-    runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock(), addresses=[("127.0.0.1", 59172)])
-    site = SimpleNamespace(start=AsyncMock())
-    client = SimpleNamespace(portal=SimpleNamespace(call=lambda fn, *args: anyio.run(fn, *args)))
-
-    async def raise_keyboard_interrupt():
-        raise KeyboardInterrupt
-
-    with (
-        patch("jumpstarter_driver_ustreamer.client.web.AppRunner", return_value=runner),
-        patch("jumpstarter_driver_ustreamer.client.web.TCPSite", return_value=site),
-        patch(
-            "jumpstarter_driver_ustreamer.client.move_on_after",
-            side_effect=lambda *args, **kwargs: contextlib.nullcontext(),
-        ),
-        patch("anyio.sleep_forever", new=raise_keyboard_interrupt),
-        patch("jumpstarter_driver_ustreamer.client.webbrowser.open") as mock_open,
-        patch("jumpstarter_driver_ustreamer.client.click.echo") as mock_echo,
-    ):
-        _run_server(client, object(), 0, True)
-
-    runner.setup.assert_awaited_once()
-    site.start.assert_awaited_once()
-    runner.cleanup.assert_awaited_once()
-    mock_open.assert_called_once_with("http://127.0.0.1:59172")
-    mock_echo.assert_any_call("Video stream available at: http://127.0.0.1:59172")
-    mock_echo.assert_any_call("Snapshot endpoint: http://127.0.0.1:59172/snapshot")
-    mock_echo.assert_any_call("Press Ctrl+C to stop.")
-    mock_echo.assert_any_call("\nStopping video server.")
-
-
-def test_run_server_propagates_startup_errors():
-    runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock(), addresses=[])
-    site = SimpleNamespace(start=AsyncMock(side_effect=OSError("port in use")))
-    client = SimpleNamespace(portal=SimpleNamespace(call=lambda fn, *args: anyio.run(fn, *args)))
-
-    with (
-        patch("jumpstarter_driver_ustreamer.client.web.AppRunner", return_value=runner),
-        patch("jumpstarter_driver_ustreamer.client.web.TCPSite", return_value=site),
-        patch(
-            "jumpstarter_driver_ustreamer.client.move_on_after",
-            side_effect=lambda *args, **kwargs: contextlib.nullcontext(),
-        ),
-        patch("jumpstarter_driver_ustreamer.client.click.echo") as mock_echo,
-    ):
-        with pytest.raises(OSError, match="port in use"):
-            _run_server(client, object(), 0, False)
-
-    runner.setup.assert_awaited_once()
-    site.start.assert_awaited_once()
-    runner.cleanup.assert_awaited_once()
-    mock_echo.assert_not_called()
-
-
-def test_run_server_raises_when_no_bound_address_is_reported():
-    runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock(), addresses=[])
-    site = SimpleNamespace(start=AsyncMock())
-    client = SimpleNamespace(portal=SimpleNamespace(call=lambda fn, *args: anyio.run(fn, *args)))
-
-    with (
-        patch("jumpstarter_driver_ustreamer.client.web.AppRunner", return_value=runner),
-        patch("jumpstarter_driver_ustreamer.client.web.TCPSite", return_value=site),
-        patch(
-            "jumpstarter_driver_ustreamer.client.move_on_after",
-            side_effect=lambda *args, **kwargs: contextlib.nullcontext(),
-        ),
-    ):
-        with pytest.raises(RuntimeError, match="without a bound address"):
-            _run_server(client, object(), 0, False)
-
-    runner.setup.assert_awaited_once()
-    site.start.assert_awaited_once()
-    runner.cleanup.assert_awaited_once()
-
-
-@pytest.mark.anyio
-async def test_proxy_mjpeg_stream_forwards_headers_and_body_chunks():
-    tunnel = _FakeTunnel(
-        [
-            (
-                b"HTTP/1.1 200 OK\r\n"
-                b"Content-Type: multipart/x-mixed-replace; boundary=frame\r\n"
-                b"\r\n"
-                b"--frame-1"
-            ),
-            b"--frame-2",
-            anyio.EndOfStream(),
-        ]
-    )
-    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
-    response = _FakeStreamResponse()
-    request = object()
-
-    with patch("jumpstarter_driver_ustreamer.client.web.StreamResponse", return_value=response):
-        result = await _proxy_mjpeg_stream(client, request)
-
-    assert result is response
-    assert tunnel.sent == [b"GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n"]
-    assert response.content_type == "multipart/x-mixed-replace; boundary=frame"
-    assert response.prepared_request is request
-    assert response.writes == [b"--frame-1", b"--frame-2"]

--- a/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/common.py
+++ b/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/common.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel
+from jumpstarter_driver_video.common import VideoState
+from pydantic import BaseModel, model_validator
 
 
-class UStreamerState(BaseModel):
+class UStreamerState(VideoState):
     class Result(BaseModel):
         class Encoder(BaseModel):
             type: str
@@ -31,3 +32,12 @@ class UStreamerState(BaseModel):
     ok: bool
 
     result: Result
+
+    @model_validator(mode="after")
+    def _fill_common_state(self):
+        """Populate the common VideoState fields from ustreamer's own shape."""
+        self.online = self.result.source.online
+        self.width = self.result.source.resolution.width
+        self.height = self.result.source.resolution.height
+        self.fps = self.result.source.captured_fps
+        return self

--- a/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/driver.py
+++ b/python/packages/jumpstarter-driver-ustreamer/jumpstarter_driver_ustreamer/driver.py
@@ -12,6 +12,7 @@ from tempfile import TemporaryDirectory
 
 from aiohttp import ClientSession, UnixConnector
 from anyio import connect_unix
+from jumpstarter_driver_video.driver import VideoInterface
 
 from .common import UStreamerState
 from jumpstarter.driver import Driver, export, exportstream
@@ -53,9 +54,7 @@ def _get_preexec_fn() -> Callable[[], None] | None:
 
 
 @dataclass(kw_only=True)
-class UStreamer(Driver):
-    driver_type = "video"
-
+class UStreamer(VideoInterface, Driver):
     executable: str = field(default_factory=find_ustreamer)
     args: dict[str, str] = field(default_factory=dict)
     tempdir: TemporaryDirectory = field(default_factory=TemporaryDirectory)
@@ -107,6 +106,10 @@ class UStreamer(Driver):
                 length = len(data)
                 self.logger.debug(f"snapshot: {length} bytes")
                 return b64encode(data).decode("ascii")
+
+    @export
+    def stream_path(self) -> str:
+        return "/stream"
 
     @exportstream
     @asynccontextmanager

--- a/python/packages/jumpstarter-driver-ustreamer/pyproject.toml
+++ b/python/packages/jumpstarter-driver-ustreamer/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["jumpstarter", "pillow>=10.4.0"]
+dependencies = ["jumpstarter", "jumpstarter-driver-video", "pillow>=10.4.0"]
 
 [project.entry-points."jumpstarter.drivers"]
 UStreamer = "jumpstarter_driver_ustreamer.driver:UStreamer"

--- a/python/packages/jumpstarter-driver-video/.gitignore
+++ b/python/packages/jumpstarter-driver-video/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.coverage
+coverage.xml

--- a/python/packages/jumpstarter-driver-video/README.md
+++ b/python/packages/jumpstarter-driver-video/README.md
@@ -1,0 +1,86 @@
+# Video driver
+
+`jumpstarter-driver-video` provides the common interface for video source
+drivers (`VideoInterface` / `VideoClient`) and an `HttpVideo` driver for
+HTTP/MJPEG camera sources.
+
+`HttpVideo` covers cameras that are reachable from the exporter over the
+network rather than attached to it as a local V4L2 device — for example a
+camera connected to the DUT itself, such as ESP32 camera firmware serving
+an MJPEG stream over WiFi, or a generic IP camera.
+
+## Installation
+
+```shell
+pip3 install --extra-index-url https://pkg.jumpstarter.dev/simple/ jumpstarter-driver-video
+```
+
+## Configuration
+
+Example configuration:
+
+```yaml
+export:
+  video:
+    type: jumpstarter_driver_video.driver.HttpVideo
+    config:
+      # MJPEG stream URL
+      url: http://192.168.1.50/stream
+      # optional single-JPEG endpoint; if omitted, snapshots are taken by
+      # grabbing the first frame off the MJPEG stream
+      snapshot_url: http://192.168.1.50/snapshot.jpg
+```
+
+## Usage
+
+```python
+# take a snapshot (returns a PIL Image)
+img = client.video.snapshot()
+img.save("frame.jpg")
+
+# raw JPEG bytes
+data = client.video.snapshot_bytes()
+
+# source state: online, resolution, and fps when the source reports it
+state = client.video.state()
+print(state.online, state.width, state.height, state.fps)
+```
+
+CLI (inside a `jmp shell`):
+
+```shell
+j video state                   # show whether the source is online, and its resolution
+j video snapshot -o frame.jpg   # save a single frame
+j video stream                  # local MJPEG server proxying the stream, opens browser
+```
+
+## Implementing a video driver
+
+Video source drivers should implement `VideoInterface`:
+
+- `snapshot()` (`@export`): return a single JPEG frame, base64 encoded
+- `state()` (`@export`): return a `VideoState` (online, resolution, fps)
+- `stream_path()` (`@export`): HTTP path serving MJPEG on the `connect` stream
+- `connect()` (`@exportstream`): byte stream to an HTTP server serving MJPEG
+
+`VideoClient` then provides snapshots, the streaming CLI, and the local
+stream proxy for free. The `UStreamer` driver in
+`jumpstarter-driver-ustreamer` is an example implementation for local V4L2
+devices.
+
+A source with richer state can return a model that **extends** `VideoState`,
+so generic consumers keep reading the common fields while source-specific
+detail stays available. `UStreamerState` does exactly that: it fills
+`online`/`width`/`height`/`fps` from ustreamer's own status document, which
+remains reachable through its `result` field.
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_video.driver.HttpVideo
+```
+
+```{eval-rst}
+.. autoclass:: jumpstarter_driver_video.client.VideoClient
+    :members:
+```

--- a/python/packages/jumpstarter-driver-video/examples/exporter.yaml
+++ b/python/packages/jumpstarter-driver-video/examples/exporter.yaml
@@ -1,0 +1,13 @@
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterConfig
+metadata:
+  namespace: default
+  name: demo
+endpoint: grpc.jumpstarter.192.168.0.203.nip.io:8082
+token: "<token>"
+export:
+  video:
+    type: jumpstarter_driver_video.driver.HttpVideo
+    config:
+      url: http://192.168.1.50/stream
+      snapshot_url: http://192.168.1.50/snapshot.jpg

--- a/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/client.py
+++ b/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/client.py
@@ -1,0 +1,242 @@
+import io
+import webbrowser
+from base64 import b64decode
+
+import click
+from aiohttp import web
+from anyio import EndOfStream, get_cancelled_exc_class, move_on_after, sleep_forever
+from PIL import Image
+
+from .common import VideoState
+from jumpstarter.client import DriverClient
+from jumpstarter.client.decorators import driver_click_group
+
+LANDING_PAGE = """\
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Video</title>
+  <style>
+    body { background: #1a1a1a; color: #eee; font-family: system-ui; margin: 0;
+           display: flex; flex-direction: column; align-items: center; padding: 20px; }
+    img { max-width: 100%; border: 1px solid #333; }
+    a { color: #6cf; }
+    .info { margin: 10px 0; font-size: 14px; color: #aaa; }
+  </style>
+</head>
+<body>
+  <h2>Jumpstarter Video Stream</h2>
+  <img src="/stream" alt="Live video stream" />
+  <p class="info"><a href="/snapshot">Single snapshot (JPEG)</a></p>
+</body>
+</html>
+"""
+
+
+def _parse_content_type(header_bytes: bytes) -> str:
+    """Extract Content-Type from raw HTTP response headers."""
+    for line in header_bytes.decode("ascii", errors="replace").split("\r\n"):
+        if line.lower().startswith("content-type:"):
+            return line.split(":", 1)[1].strip()
+    return "multipart/x-mixed-replace; boundary=--"
+
+
+def _is_chunked(header_bytes: bytes) -> bool:
+    """Whether the response body uses HTTP chunked transfer encoding."""
+    for line in header_bytes.decode("ascii", errors="replace").split("\r\n"):
+        name, _, value = line.partition(":")
+        if name.strip().lower() == "transfer-encoding" and "chunked" in value.lower():
+            return True
+    return False
+
+
+async def _iter_body(tunnel, buf: bytes, chunked: bool):
+    """Yield response body bytes from the tunnel, undoing chunked framing.
+
+    Sources that serve MJPEG from an HTTP server which chunks its output (the
+    ESP-IDF http server does) would otherwise leak chunk-size lines into the
+    multipart body, corrupting the stream for the client.
+    """
+    if not chunked:
+        if buf:
+            yield buf
+        while True:
+            yield await tunnel.receive()
+
+    while True:
+        while b"\r\n" not in buf:
+            buf += await tunnel.receive()
+        size_line, _, buf = buf.partition(b"\r\n")
+        try:
+            size = int(size_line.split(b";")[0].strip(), 16)
+        except ValueError:
+            raise web.HTTPBadGateway(reason="invalid chunk size from upstream") from None
+        if size == 0:
+            return
+        if size > _MAX_CHUNK_SIZE:
+            raise web.HTTPBadGateway(reason="upstream chunk too large")
+        while len(buf) < size + 2:
+            buf += await tunnel.receive()
+        yield buf[:size]
+        buf = buf[size + 2 :]  # drop the CRLF terminating the chunk
+
+
+def run_video_server(client, app, port, open_browser):
+    """Run an aiohttp app, opening the browser and blocking until Ctrl+C."""
+    runner = web.AppRunner(app)
+
+    async def serve():
+        await runner.setup()
+        try:
+            site = web.TCPSite(runner, "127.0.0.1", port)
+            await site.start()
+
+            addresses = runner.addresses
+            if not addresses:
+                raise RuntimeError("Video server started without a bound address")
+            actual_port = int(addresses[0][1])
+            url = f"http://127.0.0.1:{actual_port}"
+            click.echo(f"Video stream available at: {url}")
+            click.echo(f"Snapshot endpoint: {url}/snapshot")
+            click.echo("Press Ctrl+C to stop.")
+
+            if open_browser:
+                webbrowser.open(url)
+
+            await sleep_forever()
+        finally:
+            with move_on_after(2, shield=True):
+                await runner.cleanup()
+
+    try:
+        client.portal.call(serve)
+    except KeyboardInterrupt:
+        click.echo("\nStopping video server.")
+
+
+def _parse_status_code(header_bytes: bytes) -> int:
+    """Extract HTTP status code from the first line of raw response headers."""
+    first_line = header_bytes.decode("ascii", errors="replace").split("\r\n", 1)[0]
+    parts = first_line.split(None, 2)
+    if len(parts) >= 2 and parts[1].isdigit():
+        return int(parts[1])
+    return 0
+
+
+_MAX_HEADER_SIZE = 16 * 1024
+_MAX_CHUNK_SIZE = 16 * 1024 * 1024  # 16 MB — generous for MJPEG frames
+
+
+async def proxy_mjpeg_stream(client, request, path):
+    """Proxy the source's native MJPEG stream through the jumpstarter tunnel."""
+    async with client.stream_async("connect") as tunnel:
+        await tunnel.send(f"GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode("ascii"))
+
+        buf = b""
+        try:
+            while b"\r\n\r\n" not in buf:
+                if len(buf) > _MAX_HEADER_SIZE:
+                    raise web.HTTPBadGateway(reason="upstream response headers too large")
+                buf += await tunnel.receive()
+        except EndOfStream:
+            raise web.HTTPBadGateway(reason="upstream closed before sending complete headers") from None
+
+        header_part, _, body_start = buf.partition(b"\r\n\r\n")
+
+        status = _parse_status_code(header_part)
+        if status == 0:
+            raise web.HTTPBadGateway(reason="invalid upstream status line")
+
+        response = web.StreamResponse(status=status)
+        response.content_type = _parse_content_type(header_part)
+        await response.prepare(request)
+
+        try:
+            async for chunk in _iter_body(tunnel, body_start, _is_chunked(header_part)):
+                await response.write(chunk)
+        except (EndOfStream, ConnectionResetError, ConnectionAbortedError, get_cancelled_exc_class()):
+            pass
+
+    return response
+
+
+class VideoClient(DriverClient):
+    """Client for video source drivers implementing VideoInterface."""
+
+    def snapshot(self):
+        """Get a snapshot image from the video input
+
+        :return: PIL Image object of the snapshot image
+        :rtype: PIL.Image
+        """
+        return Image.open(io.BytesIO(self.snapshot_bytes()))
+
+    def snapshot_bytes(self) -> bytes:
+        """Get raw JPEG bytes from the video input"""
+        return b64decode(self.call("snapshot"))
+
+    def stream_path(self) -> str:
+        """HTTP path serving the MJPEG stream on the ``connect`` tunnel"""
+        return self.call("stream_path")
+
+    def state(self) -> VideoState:
+        """Get state of the video source
+
+        :return: common video source state
+        :rtype: VideoState
+        """
+        return VideoState.model_validate(self.call("state"))
+
+    def cli(self):
+        @driver_click_group(self)
+        def video():
+            """Video capture and streaming"""
+            pass
+
+        @video.command()
+        def state():
+            """Show video source state"""
+            s = self.state()
+            click.echo(f"Online:     {s.online}")
+            if s.width is not None and s.height is not None:
+                click.echo(f"Resolution: {s.width}x{s.height}")
+            if s.fps is not None:
+                click.echo(f"FPS:        {s.fps}")
+
+        @video.command()
+        @click.option("-o", "--output", default="snapshot.jpg", help="Output file path")
+        def snapshot(output):
+            """Save a single snapshot to file"""
+            img = self.snapshot()
+            img.save(output)
+            click.echo(f"Saved snapshot to {output}")
+
+        @video.command()
+        @click.option("-p", "--port", default=0, type=int, help="Local server port (0 = auto)")
+        @click.option("--browser/--no-browser", default=True, help="Open in web browser")
+        def stream(port, browser):
+            """Start local MJPEG streaming server
+
+            Proxies the source's native MJPEG stream through the jumpstarter
+            tunnel. Frame rate is controlled by the video source.
+            """
+            path = self.stream_path()
+
+            async def handle_index(request):
+                return web.Response(text=LANDING_PAGE, content_type="text/html")
+
+            async def handle_snapshot(request):
+                data = b64decode(await self.call_async("snapshot"))
+                return web.Response(body=data, content_type="image/jpeg")
+
+            async def handle_stream(request):
+                return await proxy_mjpeg_stream(self, request, path)
+
+            app = web.Application()
+            app.router.add_get("/", handle_index)
+            app.router.add_get("/snapshot", handle_snapshot)
+            app.router.add_get("/stream", handle_stream)
+
+            run_video_server(self, app, port, browser)
+
+        return video

--- a/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/client_test.py
+++ b/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/client_test.py
@@ -1,0 +1,396 @@
+import base64
+import contextlib
+import io
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import anyio
+import pytest
+from aiohttp import web
+from click.testing import CliRunner
+from PIL import Image
+
+from jumpstarter_driver_video.client import (
+    _MAX_CHUNK_SIZE,
+    _MAX_HEADER_SIZE,
+    LANDING_PAGE,
+    VideoClient,
+    _parse_content_type,
+    _parse_status_code,
+    proxy_mjpeg_stream,
+    run_video_server,
+)
+
+
+def _make_client():
+    client = object.__new__(VideoClient)
+    client.description = None
+    client.methods_description = {}
+    client.stack = MagicMock()
+    return client
+
+
+def _make_jpeg_bytes():
+    buffer = io.BytesIO()
+    Image.new("RGB", (2, 1), color="red").save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _get_route_handler(app, path):
+    for resource in app.router.resources():
+        if getattr(resource, "canonical", None) == path:
+            return next(iter(resource)).handler
+    raise AssertionError(f"Route {path} was not registered")
+
+
+class _FakeStreamContext:
+    def __init__(self, tunnel):
+        self.tunnel = tunnel
+
+    async def __aenter__(self):
+        return self.tunnel
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeTunnel:
+    def __init__(self, chunks):
+        self._chunks = iter(chunks)
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def receive(self):
+        chunk = next(self._chunks)
+        if isinstance(chunk, BaseException):
+            raise chunk
+        return chunk
+
+
+class _FakeStreamResponse:
+    def __init__(self):
+        self.content_type = None
+        self.prepared_request = None
+        self.writes = []
+
+    async def prepare(self, request):
+        self.prepared_request = request
+
+    async def write(self, data):
+        self.writes.append(data)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_parse_content_type_returns_header_value():
+    header_bytes = b"HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nX-Test: 1\r\n"
+
+    assert _parse_content_type(header_bytes) == "image/jpeg"
+
+
+def test_parse_content_type_falls_back_to_mjpeg_default():
+    assert _parse_content_type(b"HTTP/1.1 200 OK\r\nX-Test: 1\r\n") == "multipart/x-mixed-replace; boundary=--"
+
+
+def test_snapshot_returns_image():
+    client = _make_client()
+    jpeg_bytes = _make_jpeg_bytes()
+    client.call = MagicMock(return_value=base64.b64encode(jpeg_bytes).decode("ascii"))
+
+    image = VideoClient.snapshot(client)
+
+    assert image.size == (2, 1)
+    client.call.assert_called_once_with("snapshot")
+
+
+def test_snapshot_bytes_returns_decoded_jpeg():
+    client = _make_client()
+    jpeg_bytes = _make_jpeg_bytes()
+    client.call = MagicMock(return_value=base64.b64encode(jpeg_bytes).decode("ascii"))
+
+    assert VideoClient.snapshot_bytes(client) == jpeg_bytes
+    client.call.assert_called_once_with("snapshot")
+
+
+def test_snapshot_command_saves_snapshot_to_requested_path():
+    client = _make_client()
+    image = MagicMock()
+    client.snapshot = MagicMock(return_value=image)
+
+    result = CliRunner().invoke(client.cli(), ["snapshot", "--output", "frame.jpg"])
+
+    assert result.exit_code == 0
+    image.save.assert_called_once_with("frame.jpg")
+    assert "Saved snapshot to frame.jpg" in result.output
+
+
+def test_stream_command_registers_routes_and_starts_server():
+    client = _make_client()
+    client.call_async = AsyncMock(return_value=base64.b64encode(b"jpeg-data").decode("ascii"))
+    client.stream_path = MagicMock(return_value="/video.mjpg")
+
+    captured = {}
+    proxied_response = object()
+
+    with (
+        patch(
+            "jumpstarter_driver_video.client.run_video_server",
+            side_effect=lambda client_arg, app, port, browser: captured.update(
+                {"client": client_arg, "app": app, "port": port, "browser": browser}
+            ),
+        ),
+        patch(
+            "jumpstarter_driver_video.client.proxy_mjpeg_stream",
+            new=AsyncMock(return_value=proxied_response),
+        ) as mock_proxy,
+    ):
+        result = CliRunner().invoke(client.cli(), ["stream", "--port", "1234", "--no-browser"])
+
+        assert result.exit_code == 0
+        assert captured["client"] is client
+        assert captured["port"] == 1234
+        assert captured["browser"] is False
+
+        async def exercise_routes():
+            app = captured["app"]
+            index_handler = _get_route_handler(app, "/")
+            snapshot_handler = _get_route_handler(app, "/snapshot")
+            stream_handler = _get_route_handler(app, "/stream")
+
+            index_response = await index_handler(object())
+            assert index_response.text == LANDING_PAGE
+
+            snapshot_response = await snapshot_handler(object())
+            assert snapshot_response.body == b"jpeg-data"
+            assert snapshot_response.content_type == "image/jpeg"
+
+            request = object()
+            response = await stream_handler(request)
+            assert response is proxied_response
+            mock_proxy.assert_awaited_once_with(client, request, "/video.mjpg")
+
+        anyio.run(exercise_routes)
+
+    client.call_async.assert_awaited_once_with("snapshot")
+
+
+def test_run_server_uses_public_site_port_and_cleans_up():
+    runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock(), addresses=[("127.0.0.1", 59172)])
+    site = SimpleNamespace(start=AsyncMock())
+    client = SimpleNamespace(portal=SimpleNamespace(call=lambda fn, *args: anyio.run(fn, *args)))
+
+    async def raise_keyboard_interrupt():
+        raise KeyboardInterrupt
+
+    with (
+        patch("jumpstarter_driver_video.client.web.AppRunner", return_value=runner),
+        patch("jumpstarter_driver_video.client.web.TCPSite", return_value=site),
+        patch(
+            "jumpstarter_driver_video.client.move_on_after",
+            side_effect=lambda *args, **kwargs: contextlib.nullcontext(),
+        ),
+        patch("jumpstarter_driver_video.client.sleep_forever", new=raise_keyboard_interrupt),
+        patch("jumpstarter_driver_video.client.webbrowser.open") as mock_open,
+        patch("jumpstarter_driver_video.client.click.echo") as mock_echo,
+    ):
+        run_video_server(client, object(), 0, True)
+
+    runner.setup.assert_awaited_once()
+    site.start.assert_awaited_once()
+    runner.cleanup.assert_awaited_once()
+    mock_open.assert_called_once_with("http://127.0.0.1:59172")
+    mock_echo.assert_any_call("Video stream available at: http://127.0.0.1:59172")
+    mock_echo.assert_any_call("Snapshot endpoint: http://127.0.0.1:59172/snapshot")
+    mock_echo.assert_any_call("Press Ctrl+C to stop.")
+    mock_echo.assert_any_call("\nStopping video server.")
+
+
+def test_run_server_propagates_startup_errors():
+    runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock(), addresses=[])
+    site = SimpleNamespace(start=AsyncMock(side_effect=OSError("port in use")))
+    client = SimpleNamespace(portal=SimpleNamespace(call=lambda fn, *args: anyio.run(fn, *args)))
+
+    with (
+        patch("jumpstarter_driver_video.client.web.AppRunner", return_value=runner),
+        patch("jumpstarter_driver_video.client.web.TCPSite", return_value=site),
+        patch(
+            "jumpstarter_driver_video.client.move_on_after",
+            side_effect=lambda *args, **kwargs: contextlib.nullcontext(),
+        ),
+        patch("jumpstarter_driver_video.client.click.echo") as mock_echo,
+    ):
+        with pytest.raises(OSError, match="port in use"):
+            run_video_server(client, object(), 0, False)
+
+    runner.setup.assert_awaited_once()
+    site.start.assert_awaited_once()
+    runner.cleanup.assert_awaited_once()
+    mock_echo.assert_not_called()
+
+
+def test_run_server_raises_when_no_bound_address_is_reported():
+    runner = SimpleNamespace(setup=AsyncMock(), cleanup=AsyncMock(), addresses=[])
+    site = SimpleNamespace(start=AsyncMock())
+    client = SimpleNamespace(portal=SimpleNamespace(call=lambda fn, *args: anyio.run(fn, *args)))
+
+    with (
+        patch("jumpstarter_driver_video.client.web.AppRunner", return_value=runner),
+        patch("jumpstarter_driver_video.client.web.TCPSite", return_value=site),
+        patch(
+            "jumpstarter_driver_video.client.move_on_after",
+            side_effect=lambda *args, **kwargs: contextlib.nullcontext(),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="without a bound address"):
+            run_video_server(client, object(), 0, False)
+
+    runner.setup.assert_awaited_once()
+    site.start.assert_awaited_once()
+    runner.cleanup.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_proxy_mjpeg_stream_undoes_chunked_transfer_encoding():
+    """Sources like the ESP-IDF http server chunk their MJPEG output; the chunk
+    framing must not reach the client inside the multipart body."""
+    tunnel = _FakeTunnel(
+        [
+            (
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: multipart/x-mixed-replace; boundary=frame\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n"
+                b"9\r\n--frame-1\r\n"
+            ),
+            b"9\r\n--frame-2\r\n",
+            b"0\r\n\r\n",
+        ]
+    )
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+    response = _FakeStreamResponse()
+
+    with patch("jumpstarter_driver_video.client.web.StreamResponse", return_value=response):
+        await proxy_mjpeg_stream(client, object(), "/stream")
+
+    assert response.writes == [b"--frame-1", b"--frame-2"]
+
+
+def test_parse_status_code_extracts_status():
+    assert _parse_status_code(b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n") == 200
+    assert _parse_status_code(b"HTTP/1.1 404 Not Found\r\n") == 404
+    assert _parse_status_code(b"HTTP/1.0 500 Internal Server Error\r\n") == 500
+
+
+def test_parse_status_code_returns_zero_for_invalid_line():
+    assert _parse_status_code(b"garbage\r\n") == 0
+    assert _parse_status_code(b"") == 0
+
+
+@pytest.mark.anyio
+async def test_proxy_returns_502_on_early_disconnect():
+    tunnel = _FakeTunnel([b"HTTP/1.1 200 OK\r\n", anyio.EndOfStream()])
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+
+    with pytest.raises(web.HTTPBadGateway, match="complete headers"):
+        await proxy_mjpeg_stream(client, object(), "/stream")
+
+
+@pytest.mark.anyio
+async def test_proxy_returns_502_on_oversized_headers():
+    huge = b"X-Pad: " + b"A" * (_MAX_HEADER_SIZE + 1) + b"\r\n"
+    tunnel = _FakeTunnel([b"HTTP/1.1 200 OK\r\n", huge])
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+
+    with pytest.raises(web.HTTPBadGateway, match="too large"):
+        await proxy_mjpeg_stream(client, object(), "/stream")
+
+
+@pytest.mark.anyio
+async def test_proxy_returns_502_on_invalid_status_line():
+    tunnel = _FakeTunnel([b"GARBAGE\r\n\r\nbody"])
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+
+    with pytest.raises(web.HTTPBadGateway, match="invalid upstream status"):
+        await proxy_mjpeg_stream(client, object(), "/stream")
+
+
+@pytest.mark.anyio
+async def test_proxy_propagates_upstream_status():
+    tunnel = _FakeTunnel(
+        [
+            b"HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\n\r\nnot here",
+            anyio.EndOfStream(),
+        ]
+    )
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+
+    with patch("jumpstarter_driver_video.client.web.StreamResponse") as mock_sr:
+        mock_response = _FakeStreamResponse()
+        mock_sr.return_value = mock_response
+        await proxy_mjpeg_stream(client, object(), "/stream")
+        mock_sr.assert_called_once_with(status=404)
+
+
+@pytest.mark.anyio
+async def test_proxy_mjpeg_stream_forwards_headers_and_body_chunks():
+    tunnel = _FakeTunnel(
+        [
+            (b"HTTP/1.1 200 OK\r\nContent-Type: multipart/x-mixed-replace; boundary=frame\r\n\r\n--frame-1"),
+            b"--frame-2",
+            anyio.EndOfStream(),
+        ]
+    )
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+    response = _FakeStreamResponse()
+    request = object()
+
+    with patch("jumpstarter_driver_video.client.web.StreamResponse", return_value=response):
+        result = await proxy_mjpeg_stream(client, request, "/stream")
+
+    assert result is response
+    assert tunnel.sent == [b"GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n"]
+    assert response.content_type == "multipart/x-mixed-replace; boundary=frame"
+    assert response.prepared_request is request
+    assert response.writes == [b"--frame-1", b"--frame-2"]
+
+
+@pytest.mark.anyio
+async def test_proxy_returns_502_on_invalid_chunk_size():
+    tunnel = _FakeTunnel(
+        [
+            b"HTTP/1.1 200 OK\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"\r\n"
+            b"NOT_HEX\r\ndata\r\n",
+        ]
+    )
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+    response = _FakeStreamResponse()
+
+    with patch("jumpstarter_driver_video.client.web.StreamResponse", return_value=response):
+        with pytest.raises(web.HTTPBadGateway, match="invalid chunk size"):
+            await proxy_mjpeg_stream(client, object(), "/stream")
+
+
+@pytest.mark.anyio
+async def test_proxy_returns_502_on_oversized_chunk():
+    huge_size = f"{_MAX_CHUNK_SIZE + 1:x}".encode()
+    tunnel = _FakeTunnel(
+        [
+            b"HTTP/1.1 200 OK\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"\r\n"
+            + huge_size + b"\r\n",
+        ]
+    )
+    client = SimpleNamespace(stream_async=lambda method: _FakeStreamContext(tunnel))
+    response = _FakeStreamResponse()
+
+    with patch("jumpstarter_driver_video.client.web.StreamResponse", return_value=response):
+        with pytest.raises(web.HTTPBadGateway, match="chunk too large"):
+            await proxy_mjpeg_stream(client, object(), "/stream")

--- a/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/common.py
+++ b/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/common.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+
+class VideoState(BaseModel):
+    """State common to every video source.
+
+    Source-specific state models extend this, so a client can read the common
+    fields from any video driver while richer sources keep their own detail.
+    """
+
+    online: bool = False
+    """whether the source is currently producing frames"""
+
+    width: int | None = None
+    """frame width in pixels, if known"""
+
+    height: int | None = None
+    """frame height in pixels, if known"""
+
+    fps: float | None = None
+    """frames per second currently captured, if the source reports it"""

--- a/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/driver.py
+++ b/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/driver.py
@@ -1,0 +1,128 @@
+import io
+from abc import ABCMeta, abstractmethod
+from base64 import b64encode
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from aiohttp import ClientSession, MultipartReader
+from anyio import connect_tcp
+from PIL import Image
+
+from .common import VideoState
+from jumpstarter.driver import Driver, export, exportstream
+
+
+class VideoInterface(metaclass=ABCMeta):
+    """Common contract for video source drivers.
+
+    Implementations expose:
+      - ``snapshot``: a single JPEG frame, base64 encoded
+      - ``state``: a :class:`VideoState` (or a subclass carrying more detail)
+      - ``stream_path``: HTTP path serving an MJPEG stream on the ``connect`` stream
+      - ``connect`` (``@exportstream``): a byte stream to an HTTP server that
+        serves MJPEG at ``stream_path``
+    """
+
+    driver_type = "video"
+
+    @classmethod
+    def client(cls) -> str:
+        return "jumpstarter_driver_video.client.VideoClient"
+
+    @abstractmethod
+    async def snapshot(self) -> str: ...
+
+    @abstractmethod
+    def stream_path(self) -> str: ...
+
+    @abstractmethod
+    async def state(self): ...
+
+
+@dataclass(kw_only=True)
+class HttpVideo(VideoInterface, Driver):
+    """Video driver for HTTP/MJPEG camera sources reachable from the exporter.
+
+    Covers cameras that live on the DUT itself, e.g. ESP32 camera firmware
+    serving an MJPEG stream over its network interface, as well as generic
+    IP cameras.
+    """
+
+    url: str
+    snapshot_url: str | None = None
+
+    def __post_init__(self):
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+
+        parsed = urlparse(self.url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"unsupported scheme in stream url: {self.url}")
+        if parsed.hostname is None:
+            raise ValueError(f"missing host in stream url: {self.url}")
+
+    async def _fetch_frame(self) -> bytes:
+        async with ClientSession() as session:
+            if self.snapshot_url is not None:
+                async with session.get(self.snapshot_url) as resp:
+                    resp.raise_for_status()
+                    return await resp.read()
+            # no snapshot endpoint: grab the first frame off the MJPEG stream
+            async with session.get(self.url) as resp:
+                resp.raise_for_status()
+                reader = MultipartReader.from_response(resp)
+                part = await reader.next()
+                if part is None:
+                    raise RuntimeError(f"no frame received from {self.url}")
+                return await part.read()  # type: ignore[union-attr]
+
+    @export
+    async def snapshot(self) -> str:
+        data = await self._fetch_frame()
+        self.logger.debug("snapshot: %d bytes", len(data))
+        return b64encode(data).decode("ascii")
+
+    @export
+    async def state(self) -> VideoState:
+        """Report source state, derived from a frame.
+
+        A plain HTTP camera exposes no status endpoint, so being able to fetch
+        a frame is what "online" means here, and the frame itself carries the
+        resolution. Frame rate is set by the source and is not reported.
+        """
+        try:
+            data = await self._fetch_frame()
+        except Exception as e:
+            self.logger.debug("state: source unreachable: %s", e)
+            return VideoState(online=False)
+        try:
+            with Image.open(io.BytesIO(data)) as img:
+                width, height = img.size
+        except Exception:
+            return VideoState(online=True)
+        return VideoState(online=True, width=width, height=height)
+
+    @export
+    def stream_path(self) -> str:
+        parsed = urlparse(self.url)
+        path = parsed.path or "/"
+        if parsed.query:
+            path += f"?{parsed.query}"
+        return path
+
+    @exportstream
+    @asynccontextmanager
+    async def connect(self):
+        parsed = urlparse(self.url)
+        assert parsed.hostname is not None  # validated in __post_init__
+        if parsed.scheme == "https":
+            port = parsed.port or 443
+            self.logger.debug("streaming video from %s:%d (tls)", parsed.hostname, port)
+            stream = await connect_tcp(parsed.hostname, port, tls=True)
+        else:
+            port = parsed.port or 80
+            self.logger.debug("streaming video from %s:%d", parsed.hostname, port)
+            stream = await connect_tcp(parsed.hostname, port)
+        async with stream:
+            yield stream

--- a/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/driver_test.py
+++ b/python/packages/jumpstarter-driver-video/jumpstarter_driver_video/driver_test.py
@@ -1,0 +1,178 @@
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from jumpstarter_driver_video.driver import HttpVideo
+
+from jumpstarter.common.utils import serve
+
+
+def _jpeg_bytes(color: str) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+FRAME_A = _jpeg_bytes("red")
+FRAME_B = _jpeg_bytes("blue")
+BOUNDARY = "frameboundary"
+
+
+class FakeCameraHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/snapshot.jpg":
+            self.send_response(200)
+            self.send_header("Content-Type", "image/jpeg")
+            self.send_header("Content-Length", str(len(FRAME_A)))
+            self.end_headers()
+            self.wfile.write(FRAME_A)
+        elif self.path == "/stream":
+            self.send_response(200)
+            self.send_header("Content-Type", f"multipart/x-mixed-replace; boundary={BOUNDARY}")
+            self.end_headers()
+            for frame in (FRAME_A, FRAME_B):
+                self.wfile.write(f"--{BOUNDARY}\r\n".encode())
+                self.wfile.write(b"Content-Type: image/jpeg\r\n")
+                self.wfile.write(f"Content-Length: {len(frame)}\r\n\r\n".encode())
+                self.wfile.write(frame)
+                self.wfile.write(b"\r\n")
+            self.wfile.write(f"--{BOUNDARY}--\r\n".encode())
+        else:
+            self.send_error(404)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def fake_camera():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FakeCameraHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+def test_snapshot_via_snapshot_url(fake_camera):
+    instance = HttpVideo(url=f"{fake_camera}/stream", snapshot_url=f"{fake_camera}/snapshot.jpg")
+
+    with serve(instance) as client:
+        assert client.snapshot_bytes() == FRAME_A
+        assert client.snapshot().size == (8, 8)
+
+
+def test_snapshot_from_mjpeg_stream(fake_camera):
+    instance = HttpVideo(url=f"{fake_camera}/stream")
+
+    with serve(instance) as client:
+        assert client.snapshot_bytes() == FRAME_A
+
+
+def test_stream_path(fake_camera):
+    instance = HttpVideo(url=f"{fake_camera}/stream")
+
+    with serve(instance) as client:
+        assert client.stream_path() == "/stream"
+
+
+def test_stream_tunnel(fake_camera):
+    instance = HttpVideo(url=f"{fake_camera}/stream")
+
+    async def read_stream(client, path):
+        async with client.stream_async("connect") as tunnel:
+            await tunnel.send(f"GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode("ascii"))
+            buf = b""
+            while FRAME_B not in buf:
+                buf += await tunnel.receive()
+            return buf
+
+    with serve(instance) as client:
+        buf = client.portal.call(read_stream, client, client.stream_path())
+        assert b"multipart/x-mixed-replace" in buf
+        assert FRAME_A in buf
+
+
+def test_state_reports_online_and_resolution(fake_camera):
+    instance = HttpVideo(url=f"{fake_camera}/stream", snapshot_url=f"{fake_camera}/snapshot.jpg")
+
+    with serve(instance) as client:
+        state = client.state()
+        assert state.online is True
+        assert (state.width, state.height) == (8, 8)
+
+
+def test_state_reports_offline_when_source_unreachable():
+    # nothing is listening on this port
+    instance = HttpVideo(url="http://127.0.0.1:1/stream")
+
+    with serve(instance) as client:
+        state = client.state()
+        assert state.online is False
+        assert state.width is None
+
+
+class FakeChunkedCameraHandler(BaseHTTPRequestHandler):
+    """Serves MJPEG with chunked transfer encoding, like ESP-IDF cameras."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        if self.path != "/stream":
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", f"multipart/x-mixed-replace; boundary={BOUNDARY}")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        for frame in (FRAME_A, FRAME_B):
+            part = (
+                f"--{BOUNDARY}\r\n".encode()
+                + b"Content-Type: image/jpeg\r\n"
+                + f"Content-Length: {len(frame)}\r\n\r\n".encode()
+                + frame
+                + b"\r\n"
+            )
+            chunk = f"{len(part):x}\r\n".encode() + part + b"\r\n"
+            self.wfile.write(chunk)
+        self.wfile.write(b"0\r\n\r\n")
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def fake_chunked_camera():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FakeChunkedCameraHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+def test_stream_tunnel_chunked(fake_chunked_camera):
+    """End-to-end: tunnel through an HttpVideo to a chunked MJPEG server."""
+    instance = HttpVideo(url=f"{fake_chunked_camera}/stream")
+
+    async def read_stream(client, path):
+        async with client.stream_async("connect") as tunnel:
+            await tunnel.send(f"GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode("ascii"))
+            buf = b""
+            while FRAME_B not in buf:
+                buf += await tunnel.receive()
+            return buf
+
+    with serve(instance) as client:
+        buf = client.portal.call(read_stream, client, client.stream_path())
+        assert b"multipart/x-mixed-replace" in buf
+        assert FRAME_A in buf
+
+
+@pytest.mark.parametrize("url", ["ftp://camera/stream", "not-a-url"])
+def test_invalid_url_rejected(url):
+    with pytest.raises(ValueError):
+        HttpVideo(url=url)

--- a/python/packages/jumpstarter-driver-video/pyproject.toml
+++ b/python/packages/jumpstarter-driver-video/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "jumpstarter-driver-video"
+dynamic = ["version", "urls"]
+description = "Video source drivers for Jumpstarter: common video interface and HTTP/MJPEG camera support"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "Benny Zlotnik", email = "bzlotnik@protonmail.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "aiohttp>=3.9.0",
+    "anyio>=4.10.0",
+    "click>=8.3.1",
+    "jumpstarter",
+    "pillow>=10.0.0",
+]
+
+[project.entry-points."jumpstarter.drivers"]
+HttpVideo = "jumpstarter_driver_video.driver:HttpVideo"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { 'root' = '../../../'}
+
+[tool.hatch.metadata.hooks.vcs.urls]
+Homepage = "https://jumpstarter.dev"
+source_archive = "https://github.com/jumpstarter-dev/jumpstarter/archive/{commit_hash}.zip"
+
+[tool.pytest.ini_options]
+addopts = "--cov --cov-report=html --cov-report=xml"
+log_cli = true
+log_cli_level = "INFO"
+testpaths = ["jumpstarter_driver_video"]
+
+[build-system]
+requires = ["hatchling", "hatch-vcs", "hatch-pin-jumpstarter"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.pin_jumpstarter]
+name = "pin_jumpstarter"
+
+[dependency-groups]
+dev = [
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.3",
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,6 +49,7 @@ jumpstarter-driver-uds-doip = { workspace = true }
 jumpstarter-driver-iscsi = { workspace = true }
 jumpstarter-driver-mitmproxy = { workspace = true }
 jumpstarter-driver-ustreamer = { workspace = true }
+jumpstarter-driver-video = { workspace = true }
 jumpstarter-driver-yepkit = { workspace = true }
 jumpstarter-driver-vnc = { workspace = true }
 jumpstarter-driver-xcp = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -60,6 +60,7 @@ members = [
     "jumpstarter-driver-uds-can",
     "jumpstarter-driver-uds-doip",
     "jumpstarter-driver-ustreamer",
+    "jumpstarter-driver-video",
     "jumpstarter-driver-vnc",
     "jumpstarter-driver-xcp",
     "jumpstarter-driver-yepkit",
@@ -2062,6 +2063,7 @@ dependencies = [
     { name = "jumpstarter-driver-uds-can" },
     { name = "jumpstarter-driver-uds-doip" },
     { name = "jumpstarter-driver-ustreamer" },
+    { name = "jumpstarter-driver-video" },
     { name = "jumpstarter-driver-vnc" },
     { name = "jumpstarter-driver-yepkit" },
     { name = "jumpstarter-imagehash" },
@@ -2111,6 +2113,7 @@ requires-dist = [
     { name = "jumpstarter-driver-uds-can", editable = "packages/jumpstarter-driver-uds-can" },
     { name = "jumpstarter-driver-uds-doip", editable = "packages/jumpstarter-driver-uds-doip" },
     { name = "jumpstarter-driver-ustreamer", editable = "packages/jumpstarter-driver-ustreamer" },
+    { name = "jumpstarter-driver-video", editable = "packages/jumpstarter-driver-video" },
     { name = "jumpstarter-driver-vnc", editable = "packages/jumpstarter-driver-vnc" },
     { name = "jumpstarter-driver-yepkit", editable = "packages/jumpstarter-driver-yepkit" },
     { name = "jumpstarter-imagehash", editable = "packages/jumpstarter-imagehash" },
@@ -3678,6 +3681,38 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+]
+
+[[package]]
+name = "jumpstarter-driver-video"
+source = { editable = "packages/jumpstarter-driver-video" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "click" },
+    { name = "jumpstarter" },
+    { name = "pillow" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "anyio", specifier = ">=4.10.0" },
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "pillow", specifier = ">=10.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3662,6 +3662,7 @@ name = "jumpstarter-driver-ustreamer"
 source = { editable = "packages/jumpstarter-driver-ustreamer" }
 dependencies = [
     { name = "jumpstarter" },
+    { name = "jumpstarter-driver-video" },
     { name = "pillow" },
 ]
 
@@ -3674,6 +3675,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jumpstarter", editable = "packages/jumpstarter" },
+    { name = "jumpstarter-driver-video", editable = "packages/jumpstarter-driver-video" },
     { name = "pillow", specifier = ">=10.4.0" },
 ]
 


### PR DESCRIPTION
connecting a camera to a device like ESP32, would not show up as a /dev/ on the exporter, so we need to stream over TCP. Rather than copying a lot of code from ustreamer, create a generic video driver to make code sharing easier