### PR TITLE
fix(grpc): separate DNS resolution timeout from connect timeout

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/common/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/common/grpc.py
@@ -50,6 +50,9 @@ async def _ssl_channel_credentials_insecure(target: str, timeout: float) -> grpc
 
     Tries to connect to all resolved IPs in parallel and returns credentials
     from the first successful connection.
+
+    ``timeout`` applies independently to DNS resolution and connection, so
+    worst-case wall time is approximately ``2 * timeout``.
     """
     try:
         parsed = urlparse(f"//{target}")

--- a/python/packages/jumpstarter/jumpstarter/common/grpc.py
+++ b/python/packages/jumpstarter/jumpstarter/common/grpc.py
@@ -57,24 +57,31 @@ async def _ssl_channel_credentials_insecure(target: str, timeout: float) -> grpc
     except ValueError as e:
         raise ConfigurationError(f"Failed parsing {target}") from e
 
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+
+    # Resolve all IP addresses for the hostname.
+    #
+    # Resolution gets its own budget, separate from the connect budget below. A
+    # slow or rate-limited resolver would otherwise consume the whole timeout and
+    # surface as "Timeout connecting to <host>:<port>" with no per-IP errors,
+    # pointing at the server when the name was never resolved in the first place.
+    loop = asyncio.get_running_loop()
     try:
         with fail_after(timeout):
-            ssl_context = ssl.create_default_context()
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+            addr_info = await loop.getaddrinfo(parsed.hostname, port, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise ConnectionError(f"Failed resolving {parsed.hostname}") from e
+    except TimeoutError as e:
+        raise ConnectionError(f"Timeout resolving {parsed.hostname} after {timeout}s") from e
 
-            # Resolve all IP addresses for the hostname
-            loop = asyncio.get_running_loop()
-            addr_info = await loop.getaddrinfo(
-                parsed.hostname, port, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
-            )
+    # Log resolved IPs
+    resolved_ips = [sockaddr[0] for _, _, _, _, sockaddr in addr_info]
+    logger.debug(f"Resolved {parsed.hostname} to {len(resolved_ips)} IP(s): {', '.join(resolved_ips)}")
 
-            # Log resolved IPs
-            resolved_ips = [sockaddr[0] for _, _, _, _, sockaddr in addr_info]
-            logger.debug(
-                f"Resolved {parsed.hostname} to {len(resolved_ips)} IP(s): {', '.join(resolved_ips)}"
-            )
-
+    try:
+        with fail_after(timeout):
             # Try all IPs in parallel - race for first success
             # Wrap tasks to include IP info with results/exceptions
             async def try_with_ip(ip_address: str):
@@ -121,10 +128,11 @@ async def _ssl_channel_credentials_insecure(target: str, timeout: float) -> grpc
                 for task in tasks:
                     if not task.done():
                         task.cancel()
-    except socket.gaierror as e:
-        raise ConnectionError(f"Failed resolving {parsed.hostname}") from e
     except TimeoutError as e:
-        raise ConnectionError(f"Timeout connecting to {parsed.hostname}:{port}") from e
+        raise ConnectionError(
+            f"Timeout connecting to {parsed.hostname}:{port} after {timeout}s "
+            f"(resolved to {', '.join(resolved_ips)})"
+        ) from e
 
 
 async def ssl_channel_credentials(target: str, tls_config, timeout=5):

--- a/python/packages/jumpstarter/jumpstarter/common/grpc_test.py
+++ b/python/packages/jumpstarter/jumpstarter/common/grpc_test.py
@@ -1,4 +1,11 @@
-from jumpstarter.common.grpc import _override_default_grpc_options
+import asyncio
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from jumpstarter.common.exceptions import ConnectionError
+from jumpstarter.common.grpc import _override_default_grpc_options, _ssl_channel_credentials_insecure
 
 
 def test_default_options_preserve_existing_defaults():
@@ -7,8 +14,101 @@ def test_default_options_preserve_existing_defaults():
     assert options["grpc.keepalive_time_ms"] == 20000
 
 
-
 def test_user_options_override_defaults():
     user_options = {"grpc.keepalive_time_ms": 50000}
     options = dict(_override_default_grpc_options(user_options))
     assert options["grpc.keepalive_time_ms"] == 50000
+
+
+def _addr_info(*ips):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 443)) for ip in ips]
+
+
+class _LoopWithFakeResolver:
+    """Delegates to the real loop, which anyio still needs, and fakes only
+    getaddrinfo."""
+
+    def __init__(self, loop, getaddrinfo):
+        self._loop = loop
+        self.getaddrinfo = getaddrinfo
+
+    def __getattr__(self, name):
+        return getattr(self._loop, name)
+
+
+def _patch_resolver(getaddrinfo):
+    def fake_get_running_loop():
+        return _LoopWithFakeResolver(asyncio.events.get_running_loop(), getaddrinfo)
+
+    return patch("asyncio.get_running_loop", fake_get_running_loop)
+
+
+class TestSslChannelCredentialsInsecure:
+    """Resolution and connection are timed separately, so the error a user
+    sees points at the step that actually stalled."""
+
+    @pytest.mark.asyncio
+    async def test_returns_credentials_from_first_reachable_ip(self):
+        async def getaddrinfo(*_args, **_kwargs):
+            return _addr_info("192.0.2.1", "192.0.2.2")
+
+        async def connect(ip_address, *_args, **_kwargs):
+            if ip_address == "192.0.2.1":
+                raise OSError("connection refused")
+            return b"-----BEGIN CERTIFICATE-----\n"
+
+        with _patch_resolver(getaddrinfo):
+            with patch(
+                "jumpstarter.common.grpc._try_connect_and_extract_cert",
+                connect,
+            ):
+                credentials = await _ssl_channel_credentials_insecure("example.com:443", timeout=5)
+
+        assert credentials is not None
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_names_the_host(self):
+        async def getaddrinfo(*_args, **_kwargs):
+            raise socket.gaierror("Name or service not known")
+
+        with _patch_resolver(getaddrinfo):
+            with pytest.raises(ConnectionError, match="Failed resolving example.com"):
+                await _ssl_channel_credentials_insecure("example.com:443", timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_slow_resolver_is_reported_as_a_resolution_timeout(self):
+        async def getaddrinfo(*_args, **_kwargs):
+            await asyncio.sleep(10)
+
+        with _patch_resolver(getaddrinfo):
+            with pytest.raises(ConnectionError, match="Timeout resolving example.com"):
+                await _ssl_channel_credentials_insecure("example.com:443", timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_reports_the_resolved_ips(self):
+        async def getaddrinfo(*_args, **_kwargs):
+            return _addr_info("192.0.2.1")
+
+        async def never_connects(*_args, **_kwargs):
+            await asyncio.sleep(10)
+
+        with _patch_resolver(getaddrinfo):
+            with patch("jumpstarter.common.grpc._try_connect_and_extract_cert", never_connects):
+                with pytest.raises(
+                    ConnectionError,
+                    match=r"Timeout connecting to example\.com:443.*resolved to 192\.0\.2\.1",
+                ):
+                    await _ssl_channel_credentials_insecure("example.com:443", timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_all_ips_failing_lists_the_errors(self):
+        async def getaddrinfo(*_args, **_kwargs):
+            return _addr_info("192.0.2.1", "192.0.2.2")
+
+        async def refused(*_args, **_kwargs):
+            raise OSError("connection refused")
+
+        with _patch_resolver(getaddrinfo):
+            with patch("jumpstarter.common.grpc._try_connect_and_extract_cert", refused):
+                with pytest.raises(ConnectionError, match="all IPs exhausted"):
+                    await _ssl_channel_credentials_insecure("example.com:443", timeout=5)


### PR DESCRIPTION
fail_after(timeout) wrapped both resolution and connection, so a slow resolver consumed the whole budget and reported "Timeout connecting to <host>:<port>" with an empty cause list - blaming the server for a name that was never resolved.

Give resolution its own budget and its own message, and name the resolved IPs in the connect error.