### PR TITLE
perf(ci): use host-compiled Go for e2e image builds on cache miss

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -83,12 +83,12 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: /tmp/controller-image.tar
-          key: controller-image-${{ matrix.arch }}-${{ hashFiles('controller/Makefile', 'controller/Containerfile', 'controller/go.mod', 'controller/go.sum', 'controller/cmd/**', 'controller/api/**', 'controller/internal/**') }}
+          key: controller-image-${{ matrix.arch }}-${{ hashFiles('.go-version', 'controller/Makefile', 'controller/Containerfile', 'controller/Containerfile.prebuilt', 'controller/go.mod', 'controller/go.sum', 'controller/cmd/**', 'controller/api/**', 'controller/internal/**') }}
 
       - name: Build controller image
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          make -C controller docker-build
+          make -C controller docker-build-ci
           docker save quay.io/jumpstarter-dev/jumpstarter-controller:latest -o /tmp/controller-image.tar
 
       - name: Upload controller image
@@ -125,12 +125,12 @@ jobs:
           path: |
             /tmp/operator-image.tar
             /tmp/operator-install.yaml
-          key: operator-image-${{ matrix.arch }}-${{ hashFiles('controller/Makefile', 'controller/Containerfile.operator', 'controller/go.mod', 'controller/go.sum', 'controller/deploy/operator/**', 'controller/api/**', 'controller/internal/**') }}
+          key: operator-image-${{ matrix.arch }}-${{ hashFiles('.go-version', 'controller/Makefile', 'controller/Containerfile.operator', 'controller/Containerfile.prebuilt', 'controller/go.mod', 'controller/go.sum', 'controller/deploy/operator/**', 'controller/api/**', 'controller/internal/**') }}
 
       - name: Build operator image and installer manifest
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          make -C controller/deploy/operator docker-build build-installer VERSION=latest
+          make -C controller/deploy/operator docker-build-ci build-installer VERSION=latest
           docker save quay.io/jumpstarter-dev/jumpstarter-operator:latest -o /tmp/operator-image.tar
           cp controller/deploy/operator/dist/install.yaml /tmp/operator-install.yaml
 
@@ -168,12 +168,12 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: /tmp/exporterset-controller-image.tar
-          key: exporterset-controller-image-${{ matrix.arch }}-${{ hashFiles('controller/Makefile', 'controller/Containerfile.exporter-set-controller', 'controller/go.mod', 'controller/go.sum', 'controller/cmd/exporter-set-controller/**', 'controller/api/**', 'controller/internal/**') }}
+          key: exporterset-controller-image-${{ matrix.arch }}-${{ hashFiles('.go-version', 'controller/Makefile', 'controller/Containerfile.exporter-set-controller', 'controller/Containerfile.prebuilt', 'controller/go.mod', 'controller/go.sum', 'controller/cmd/exporter-set-controller/**', 'controller/api/**', 'controller/internal/**') }}
 
       - name: Build exporterset-controller image
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          make -C controller docker-build-exporter-set-controller
+          make -C controller docker-build-exporter-set-controller-ci
           docker save quay.io/jumpstarter-dev/jumpstarter-exporterset-controller:latest -o /tmp/exporterset-controller-image.tar
 
       - name: Upload exporterset-controller image

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -152,6 +152,12 @@ docker-build-ci: ## Build docker images from pre-compiled host binaries (fast CI
 	$(CONTAINER_TOOL) build --build-arg BIN=manager -t $(IMG) -f Containerfile.prebuilt bin/ci-stage/controller
 	$(CONTAINER_TOOL) build --build-arg BIN=exporter-set-controller -t $(EXPORTER_SET_CONTROLLER_IMG) -f Containerfile.prebuilt bin/ci-stage/esc
 
+.PHONY: docker-build-exporter-set-controller-ci
+docker-build-exporter-set-controller-ci: ## CI-optimized: host-compiled ESC binary, no multi-stage build.
+	rm -rf bin/ci-stage/esc && mkdir -p bin/ci-stage/esc
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -ldflags "$(LDFLAGS)" -o bin/ci-stage/esc/exporter-set-controller cmd/exporter-set-controller/main.go
+	$(CONTAINER_TOOL) build --build-arg BIN=exporter-set-controller -t $(EXPORTER_SET_CONTROLLER_IMG) -f Containerfile.prebuilt bin/ci-stage/esc
+
 .PHONY: docker-build-exporter-set-controller
 docker-build-exporter-set-controller: ## Build docker image for the exporter-set-controller.
 	$(CONTAINER_TOOL) build \


### PR DESCRIPTION
Switch the e2e workflow's controller, operator, and exporterset-controller build jobs from multi-stage docker-build (pulls ~1.5GB go-toolset image) to the CI-optimized path that compiles on the runner with cached Go modules and packages into minimal ubi-micro containers.

Add docker-build-exporter-set-controller-ci as a standalone target so the e2e workflow can build the ESC image independently (docker-build-ci builds controller + ESC together, but e2e needs them in separate parallel jobs). Update cache keys to include Containerfile.prebuilt.