### PR TITLE
fix(e2e): wait for controller leader election before running tests

### DIFF
--- a/controller/hack/utils
+++ b/controller/hack/utils
@@ -236,6 +236,35 @@ wait_for_jumpstarter_resources() {
     --for=condition=ready pod \
     --selector=app=jumpstarter-router-0 \
     --timeout=180s
+
+  # Wait for the controller to acquire its leader lease — without this the
+  # controller pod is "Available" but cannot reconcile, so any operation that
+  # depends on reconciliation (e.g. legacy exporter secret creation) will time
+  # out.
+  #
+  # We check renewTime freshness (within the last 30s) rather than just
+  # holderIdentity presence, because a stale lease from a dead pod retains
+  # its holderIdentity until a new leader overwrites it.
+  echo -e "${GREEN} * Waiting for controller leader election ...${NC}"
+  local le_elapsed=0
+  while [ $le_elapsed -lt 120 ]; do
+    renew_time=$(kubectl get lease a38b78e7.jumpstarter.dev -n "${namespace}" \
+      -o jsonpath='{.spec.renewTime}' 2>/dev/null)
+    if [ -n "$renew_time" ]; then
+      renew_epoch=$(date -d "$renew_time" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "${renew_time%%.*}" +%s 2>/dev/null)
+      now_epoch=$(date +%s)
+      if [ -n "$renew_epoch" ] && [ $((now_epoch - renew_epoch)) -lt 30 ]; then
+        echo -e "${GREEN} * Controller acquired leader lease (renewTime: ${renew_time})${NC}"
+        break
+      fi
+    fi
+    sleep 2
+    le_elapsed=$((le_elapsed + 2))
+  done
+  if [ $le_elapsed -ge 120 ]; then
+    echo -e "${RED}ERROR: Controller did not acquire leader lease within 120s${NC}"
+    exit 1
+  fi
 }
 
 # Wait for gRPC endpoint to be ready

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,8 +28,8 @@ Prereq (all): dex + controller/operator running, namespace `jumpstarter-lab` cre
 | Test Name | Prerequisite | Steps | Pass Check |
 |---|---|---|---|
 | serves landing page | login endpoint up | `curl` login endpoint | body contains "Jumpstarter" and "jmp login" |
-| clients were created | BeforeAll setup | `jmp admin create client` for oidc/sa/legacy variants (in BeforeAll) | `jmp config client list` shows `test-client-legacy` |
-| exporters were created | BeforeAll setup | `jmp admin create exporter` for oidc/sa/legacy, merge driver overlay (in BeforeAll) | `jmp config exporter list` shows `test-exporter-legacy` |
+| can create clients with admin cli | — | `jmp admin create client` for oidc/sa/legacy variants | no error; `jmp config client list` shows `test-client-legacy` |
+| can create exporters with admin cli | — | `jmp admin create exporter` for oidc/sa/legacy, merge driver overlay | no error; `jmp config exporter list` shows `test-exporter-legacy` |
 | can login with oidc test-client-oidc | client created | `jmp login` via dex username/password | no error; client listed |
 | can login with oidc test-client-oidc-provisioning | dex issuer up | `jmp login` with empty `--name` (auto-provision) | client `test-client-oidc-provisioning-example-com` listed |
 | can login with oidc test-client-sa | SA `test-client-sa` exists | create k8s token, `jmp login --connector-id kubernetes` | client `test-client-sa` listed |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,8 +28,8 @@ Prereq (all): dex + controller/operator running, namespace `jumpstarter-lab` cre
 | Test Name | Prerequisite | Steps | Pass Check |
 |---|---|---|---|
 | serves landing page | login endpoint up | `curl` login endpoint | body contains "Jumpstarter" and "jmp login" |
-| can create clients with admin cli | — | `jmp admin create client` for oidc/sa/legacy variants | no error; `jmp config client list` shows `test-client-legacy` |
-| can create exporters with admin cli | — | `jmp admin create exporter` for oidc/sa/legacy, merge driver overlay | no error; `jmp config exporter list` shows `test-exporter-legacy` |
+| clients were created | BeforeAll setup | `jmp admin create client` for oidc/sa/legacy variants (in BeforeAll) | `jmp config client list` shows `test-client-legacy` |
+| exporters were created | BeforeAll setup | `jmp admin create exporter` for oidc/sa/legacy, merge driver overlay (in BeforeAll) | `jmp config exporter list` shows `test-exporter-legacy` |
 | can login with oidc test-client-oidc | client created | `jmp login` via dex username/password | no error; client listed |
 | can login with oidc test-client-oidc-provisioning | dex issuer up | `jmp login` with empty `--name` (auto-provision) | client `test-client-oidc-provisioning-example-com` listed |
 | can login with oidc test-client-sa | SA `test-client-sa` exists | create k8s token, `jmp login --connector-id kubernetes` | client `test-client-sa` listed |

--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -119,13 +119,13 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, ContinueOnFailure, fu
 			MergeExporterConfig(exporterConfigPath, overlayPath)
 		})
 
-		It("clients were created", func() {
+		It("can create clients with admin cli", func() {
 			out, err := Jmp("config", "client", "list", "-o", "yaml")
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("test-client-legacy"))
 		})
 
-		It("exporters were created", func() {
+		It("can create exporters with admin cli", func() {
 			out, err := Jmp("config", "exporter", "list", "-o", "yaml")
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("test-exporter-legacy"))

--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, ContinueOnFailure, fu
 	// Client and Exporter creation
 	// -------------------------------------------------------------------
 	Context("Admin CLI resource creation", func() {
-		It("can create clients with admin cli", func() {
+		BeforeAll(func() {
 			ns := Namespace()
 
 			// Idempotent under flake-retries: a prior failed attempt may have
@@ -93,20 +93,12 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, ContinueOnFailure, fu
 				"--unsafe", "--save")
 			Expect(err).NotTo(HaveOccurred(), out)
 
-			out, err = Jmp("config", "client", "list", "-o", "yaml")
-			Expect(err).NotTo(HaveOccurred(), out)
-			Expect(out).To(ContainSubstring("test-client-legacy"))
-		})
-
-		It("can create exporters with admin cli", func() {
-			ns := Namespace()
-
 			// Idempotent under flake-retries (see client creation above).
 			for _, name := range []string{"test-exporter-oidc", "test-exporter-sa", "test-exporter-legacy"} {
 				EnsureExporterDeleted(ns, name)
 			}
 
-			out, err := Jmp("admin", "create", "exporter", "-n", ns, "test-exporter-oidc",
+			out, err = Jmp("admin", "create", "exporter", "-n", ns, "test-exporter-oidc",
 				"--nointeractive", "--oidc-username", "dex:test-exporter-oidc",
 				"--label", "example.com/board=oidc")
 			Expect(err).NotTo(HaveOccurred(), out)
@@ -125,8 +117,16 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, ContinueOnFailure, fu
 			exporterConfigPath := SystemExporterConfigPath("test-exporter-legacy")
 			overlayPath := filepath.Join(RepoRoot(), "e2e", "exporters", "exporter.yaml")
 			MergeExporterConfig(exporterConfigPath, overlayPath)
+		})
 
-			out, err = Jmp("config", "exporter", "list", "-o", "yaml")
+		It("clients were created", func() {
+			out, err := Jmp("config", "client", "list", "-o", "yaml")
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("test-client-legacy"))
+		})
+
+		It("exporters were created", func() {
+			out, err := Jmp("config", "exporter", "list", "-o", "yaml")
 			Expect(err).NotTo(HaveOccurred(), out)
 			Expect(out).To(ContainSubstring("test-exporter-legacy"))
 		})


### PR DESCRIPTION
The controller pod can be "Available" (passing readiness probes) before it has acquired the leader lease, which means it cannot reconcile CRDs yet. Legacy exporter creation depends on reconciliation to generate a Secret, so it times out when leader election is slow (~57s observed in CI). Combined with ContinueOnFailure, this caused every downstream spec to wait 5 min on kubectl wait before failing and retrying — effectively hanging the job for hours.

Two fixes:
- Poll the controller's Lease object in wait_for_jumpstarter_resources() until holderIdentity is set, proving reconciliation is possible.
- Move client/exporter creation from It blocks into BeforeAll so that a setup failure aborts the Ordered container immediately instead of letting dependent specs time out one by one.