### PR TITLE
chore(operator): bump VERSION to 0.9.0 for final release

### DIFF
--- a/controller/deploy/operator/Makefile
+++ b/controller/deploy/operator/Makefile
@@ -3,13 +3,13 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.9.0-rc.2
+VERSION ?= 0.9.0
 
 # REPLACES defines the previous operator version this release replaces in the OLM upgrade graph.
 # Used to generate the release-config.yaml for FBC auto-release.
 # Set to empty for the first release in a channel.
 # See: https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_autorelease/
-REPLACES ?= jumpstarter-operator.v0.9.0-rc.1
+REPLACES ?= jumpstarter-operator.v0.9.0-rc.2
 
 # FBC_CHANNELS defines the FBC catalog channels for this release.
 FBC_CHANNELS ?= alpha


### PR DESCRIPTION
## Summary
Bumps operator Makefile VERSION from `0.9.0-rc.2` to `0.9.0` and REPLACES to `jumpstarter-operator.v0.9.0-rc.2` ahead of the v0.9.0 final tag.

## Test plan
- [ ] Merge via merge queue
- [ ] Tag v0.9.0 after merge