### PR TITLE
fix(telemetry): inject authenticated namespace/exporter into log entries

### DIFF
--- a/controller/internal/service/telemetry_service.go
+++ b/controller/internal/service/telemetry_service.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // JEP-0013 limits for extra_fields, mirroring the client-side limits.
@@ -97,9 +98,12 @@ func (s *TelemetryService) PushLogs(ctx context.Context, req *pb.PushLogsRequest
 	}
 	claimedNamespace := parts[1]
 	claimedName := parts[2]
+	if claimedNamespace == "" || claimedName == "" {
+		return nil, status.Errorf(codes.PermissionDenied, "token has incomplete exporter identity")
+	}
 
-	// Use a plain logger — the entry's own component field carries the source identity.
-	logger := ctrl.Log.WithName("telemetry")
+	// Use context-based logger so tests can inject their own via logf.IntoContext.
+	logger := log.FromContext(ctx).WithName("telemetry")
 
 	entries := req.Entries
 	var dropped uint32
@@ -122,13 +126,15 @@ func (s *TelemetryService) PushLogs(ctx context.Context, req *pb.PushLogsRequest
 			continue
 		}
 
+		// Always log the authenticated identity. After the mismatch checks
+		// above, any non-empty entry fields already match the token; using
+		// the token values makes the server the source of truth for Loki
+		// stream labels even when the entry omitted them.
 		kvs := []any{
 			"component", entry.Component,
-			"exporter", entry.Exporter,
+			"exporter", claimedName,
+			"namespace", claimedNamespace,
 			"severity", entry.Severity,
-		}
-		if entry.Namespace != "" {
-			kvs = append(kvs, "namespace", entry.Namespace)
 		}
 		if entry.Timestamp != nil {
 			kvs = append(kvs, "ts", entry.Timestamp.AsTime().Format(time.RFC3339Nano))

--- a/controller/internal/service/telemetry_service_test.go
+++ b/controller/internal/service/telemetry_service_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -26,6 +27,8 @@ import (
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/oidc"
 	pb "github.com/jumpstarter-dev/jumpstarter/controller/internal/protocol/jumpstarter/v1"
 	"google.golang.org/grpc/metadata"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // testSigner returns a deterministic Signer built from a fixed seed for use in tests.
@@ -265,6 +268,40 @@ func TestTelemetryService_PushLogs_RejectsNonExporterToken(t *testing.T) {
 	}
 }
 
+func TestTelemetryService_PushLogs_RejectsEmptyNamespaceInToken(t *testing.T) {
+	signer := testSigner(t)
+	svc := &TelemetryService{BindAddr: ":0", Signer: signer}
+	// Token with empty namespace: exporter::my-exporter:uid1
+	ctx := authedCtx(t, signer, "exporter::my-exporter:uid1")
+
+	_, err := svc.PushLogs(ctx, &pb.PushLogsRequest{Entries: []*pb.LogEntry{
+		{Severity: "info", Message: "test"},
+	}})
+	if err == nil {
+		t.Fatal("expected PushLogs to reject token with empty namespace")
+	}
+	if !strings.Contains(err.Error(), "incomplete exporter identity") {
+		t.Errorf("expected 'incomplete exporter identity' in error, got: %v", err)
+	}
+}
+
+func TestTelemetryService_PushLogs_RejectsEmptyExporterNameInToken(t *testing.T) {
+	signer := testSigner(t)
+	svc := &TelemetryService{BindAddr: ":0", Signer: signer}
+	// Token with empty exporter name: exporter:my-namespace::uid1
+	ctx := authedCtx(t, signer, "exporter:my-namespace::uid1")
+
+	_, err := svc.PushLogs(ctx, &pb.PushLogsRequest{Entries: []*pb.LogEntry{
+		{Severity: "info", Message: "test"},
+	}})
+	if err == nil {
+		t.Fatal("expected PushLogs to reject token with empty exporter name")
+	}
+	if !strings.Contains(err.Error(), "incomplete exporter identity") {
+		t.Errorf("expected 'incomplete exporter identity' in error, got: %v", err)
+	}
+}
+
 func TestTelemetryService_PushLogs_RejectsWrongExporter(t *testing.T) {
 	signer := testSigner(t)
 	svc := &TelemetryService{BindAddr: ":0", Signer: signer}
@@ -325,6 +362,49 @@ func TestTelemetryService_PushLogs_AcceptsMatchingNamespaceAndExporter(t *testin
 	}
 	if resp.Accepted != 1 {
 		t.Errorf("Accepted = %d, want 1", resp.Accepted)
+	}
+}
+
+func TestTelemetryService_PushLogs_InjectsAuthenticatedIdentityWhenOmitted(t *testing.T) {
+	// Exporter and namespace are required Loki stream labels.
+	// When entries omit these fields, the server injects the authenticated
+	// values from the token so that all log entries have proper identity context.
+
+	// Capture log output to verify injected values using context-based logging.
+	var logBuf bytes.Buffer
+	testLogger := zap.New(zap.WriteTo(&logBuf))
+
+	signer := testSigner(t)
+	svc := &TelemetryService{BindAddr: ":0", Signer: signer}
+
+	// Create context with auth token and inject test logger.
+	ctx := authedCtx(t, signer, "exporter:my-namespace:my-exporter:uid1")
+	ctx = logf.IntoContext(ctx, testLogger)
+
+	// Entry with no exporter or namespace — should be accepted and the server
+	// will inject the authenticated values (my-exporter, my-namespace) from the token.
+	entry := &pb.LogEntry{
+		Severity: "info",
+		Message:  "entry without explicit identity",
+	}
+	resp, err := svc.PushLogs(ctx, &pb.PushLogsRequest{Entries: []*pb.LogEntry{entry}})
+	if err != nil {
+		t.Fatalf("PushLogs returned unexpected error: %v", err)
+	}
+	if resp.Accepted != 1 {
+		t.Errorf("Accepted = %d, want 1 (entry should be accepted with injected identity)", resp.Accepted)
+	}
+	if resp.Dropped != 0 {
+		t.Errorf("Dropped = %d, want 0", resp.Dropped)
+	}
+
+	// Verify the injected values appear in log output.
+	logged := logBuf.String()
+	if !strings.Contains(logged, `"exporter":"my-exporter"`) {
+		t.Errorf("expected injected exporter 'my-exporter' in log output, got:\n%s", logged)
+	}
+	if !strings.Contains(logged, `"namespace":"my-namespace"`) {
+		t.Errorf("expected injected namespace 'my-namespace' in log output, got:\n%s", logged)
 	}
 }
 

--- a/python/packages/jumpstarter/jumpstarter/exporter/telemetry_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/telemetry_test.py
@@ -170,7 +170,7 @@ class TestPrepare:
         assert entry.namespace == "my-namespace"
 
     def test_namespace_empty_by_default(self):
-        """When no namespace is passed the field is empty and the Go identity check is skipped."""
+        """When no namespace is passed the field is empty; the telemetry service fills it from the token."""
         handler = make_handler()
         entry = handler.prepare(make_record())
         assert entry.namespace == ""


### PR DESCRIPTION
When exporters push log entries via `PushLogs` without explicit namespace
or exporter fields, the telemetry service now injects the authenticated
values from the token. This ensures all log entries have proper Loki
stream labels as required by JEP-0013.
Previously, entries without these fields would be logged without identity
context, breaking namespace based Loki queries like:
`{namespace="production", exporter="my-exporter"}`
The fix uses the authenticated token subject `(exporter:namespace:name:uid)`
to fill in missing identity fields, while still rejecting entries that
claim a different identity than the token authorizes.