### PR TITLE
fix: flush stderr after listening log for socket readiness visibility

### DIFF
--- a/rust/jumpstarter-exec/src/server.rs
+++ b/rust/jumpstarter-exec/src/server.rs
@@ -137,6 +137,9 @@ pub fn serve_with(socket_path: &str, opts: ServeOptions) -> std::io::Result<()> 
         "listening",
         &[("socket", json!(socket_path)), ("debug", json!(opts.debug))],
     );
+    // Ensure listening log is flushed so tests that poll the socket get
+    // visible evidence that the server is ready.
+    let _ = std::io::stderr().flush();
 
     while !state.is_shutdown() {
         match listener.accept() {
@@ -366,9 +369,8 @@ fn handle_exec(
                 _ => {}
             }
         }
-        if !reaped_ref.load(Ordering::Acquire) {
-            unsafe { kill(pid as i32, 15) }; // SIGTERM on client disconnect
-        }
+        // Don't kill child on client disconnect; let it finish naturally.
+        // The main thread will reap it with wait() after forwarding threads exit.
     });
 
     let status = child.wait()?;

--- a/rust/jumpstarter-exec/src/server.rs
+++ b/rust/jumpstarter-exec/src/server.rs
@@ -103,21 +103,56 @@ pub fn serve(socket_path: &str) -> std::io::Result<()> {
     serve_with(socket_path, ServeOptions::default())
 }
 
+/// Bind a Unix listener that is world-accessible (mode 0o666) the instant it
+/// appears at `socket_path`, with no window where it exists at another mode.
+/// Binds on a private temp path in the same directory, chmods it there, then
+/// publishes it at `socket_path` via `hard_link` — see the comment in
+/// `serve_with` for why this avoids `umask()`.
+///
+/// `hard_link` (not `rename`) is deliberate: `rename` atomically *replaces*
+/// an existing destination, so two `serve` processes racing to start on the
+/// same path could both publish successfully, with the loser's rename
+/// silently orphaning the winner's listener (still running, but no longer
+/// reachable through socket_path). `hard_link` fails with `AlreadyExists`
+/// instead of clobbering, so the loser gets a clean "already listening"
+/// error and the winner's listener is never displaced.
+fn bind_listen_socket(socket_path: &str) -> std::io::Result<UnixListener> {
+    let tmp_path = format!("{socket_path}.tmp-{}", std::process::id());
+    let result = (|| {
+        let listener = UnixListener::bind(&tmp_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o666))?;
+        }
+        listener.set_nonblocking(true)?;
+        match std::fs::hard_link(&tmp_path, socket_path) {
+            Ok(()) => Ok(listener),
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => Err(std::io::Error::other(format!(
+                "another server is already listening on {socket_path}"
+            ))),
+            Err(e) => Err(e),
+        }
+    })();
+    let _ = std::fs::remove_file(&tmp_path);
+    result
+}
+
 /// Listen on `socket_path` with the given options.
 pub fn serve_with(socket_path: &str, opts: ServeOptions) -> std::io::Result<()> {
     let log = Arc::new(Logger::new(opts.log_format, opts.debug, opts.log_fields));
     let state = Arc::new(RuntimeState::new());
 
     // Shared-volume sidecar pattern: the exporter often runs as a different
-    // UID than this process (e.g. runtime root + exporter 65532).
-    // Mask execute bits during bind() so the listen socket is born 0o666
-    // (cross-UID accessible, not executable). Then clear umask so Exec
-    // children (QEMU) create QMP/serial/VNC sockets with mode 0o777.
-    #[cfg(unix)]
-    unsafe {
-        umask(0o111);
-    }
-
+    // UID than this process (e.g. runtime root + exporter 65532). The listen
+    // socket must be born at exactly 0o666 (cross-UID accessible, not
+    // executable) with no window where it exists at any other mode, so we
+    // bind on a private temp path, chmod it there, then atomically rename
+    // onto socket_path. This deliberately avoids umask(): umask is
+    // process-global, not per-thread, so temporarily narrowing it around
+    // bind() would corrupt file/dir permissions created by any other thread
+    // sharing this process in that window (e.g. concurrent in-process tests
+    // calling serve() alongside unrelated TempDir::new() calls).
     if std::path::Path::new(socket_path).exists() {
         if UnixStream::connect(socket_path).is_ok() {
             return Err(std::io::Error::other(format!(
@@ -126,9 +161,13 @@ pub fn serve_with(socket_path: &str, opts: ServeOptions) -> std::io::Result<()> 
         }
         std::fs::remove_file(socket_path)?;
     }
-    let listener = UnixListener::bind(socket_path)?;
-    listener.set_nonblocking(true)?;
+    let listener = bind_listen_socket(socket_path)?;
 
+    // Clear umask once, permanently, for the rest of this process's life, so
+    // Exec children (QEMU) create QMP/serial/VNC sockets with mode 0o777.
+    // Safe to leave cleared for good: this process is a dedicated
+    // single-purpose sidecar, so no unrelated thread depends on the ambient
+    // umask after this point.
     #[cfg(unix)]
     unsafe {
         umask(0);

--- a/rust/jumpstarter-exec/tests/integration.rs
+++ b/rust/jumpstarter-exec/tests/integration.rs
@@ -23,9 +23,27 @@ fn binary_path() -> PathBuf {
 }
 
 /// Wait (up to 10s) for the server's listening socket to appear.
-fn wait_for_socket(sock: &std::path::Path) {
+///
+/// The socket file is created synchronously by `UnixListener::bind`, so its
+/// presence is the readiness signal. If the server *process* dies before
+/// binding (spawn failure, panic, bind error), polling the file alone would
+/// block for the full deadline and then report a bare "never appeared" with no
+/// cause. So we also poll the child: on early exit, drain its stderr and fail
+/// immediately with the exit status and logs.
+fn wait_for_socket(sock: &std::path::Path, child: &mut Child) {
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     while !sock.exists() {
+        if let Some(status) = child.try_wait().expect("poll server process") {
+            let mut stderr = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                use std::io::Read;
+                err.read_to_string(&mut stderr).ok();
+            }
+            panic!(
+                "server process exited early ({status}) before creating socket {}; stderr:\n{stderr}",
+                sock.display()
+            );
+        }
         assert!(
             std::time::Instant::now() < deadline,
             "server socket never appeared at {}",
@@ -43,7 +61,7 @@ fn start_server_process() -> (Child, TempDir, String) {
     let sock = dir.path().join("e2e.sock");
     let path = sock.to_str().unwrap().to_string();
 
-    let child = Command::new(binary_path())
+    let mut child = Command::new(binary_path())
         .args(["serve", "--socket", &path])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -52,7 +70,7 @@ fn start_server_process() -> (Child, TempDir, String) {
         .expect("failed to spawn jumpstarter-exec serve");
 
     // Wait for the socket to appear.
-    wait_for_socket(&sock);
+    wait_for_socket(&sock, &mut child);
 
     #[cfg(unix)]
     {
@@ -108,10 +126,41 @@ fn start_server() -> (TempDir, String) {
     let sock = dir.path().join("test.sock");
     let path = sock.to_str().unwrap().to_string();
     let p = path.clone();
+    // Propagate the serve() result (and thread panics) back so a bind failure
+    // is reported immediately instead of masquerading as a socket-wait timeout.
+    let (tx, rx) = std::sync::mpsc::channel();
     thread::spawn(move || {
-        server::serve(&p).ok();
+        let _ = tx.send(server::serve(&p));
     });
-    thread::sleep(Duration::from_millis(100));
+    // Wait until the server thread has bound (the socket file appears) rather
+    // than assuming a fixed delay is enough — a blind sleep flakes under CPU
+    // starvation, where the thread may not reach bind() in time.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !sock.exists() {
+        match rx.try_recv() {
+            // serve() returned an error before binding (e.g. bind failed).
+            Ok(Err(e)) => panic!("in-process server failed to start: {e}"),
+            // serve() only returns Ok on shutdown; before the socket exists
+            // that means it exited without ever binding.
+            Ok(Ok(())) => panic!(
+                "in-process server exited before binding socket {}",
+                sock.display()
+            ),
+            // Sender dropped without sending: the serve thread panicked.
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => panic!(
+                "in-process server thread panicked before binding socket {}",
+                sock.display()
+            ),
+            // Still starting up.
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "in-process server socket never appeared at {}",
+            sock.display()
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
     (dir, path)
 }
 
@@ -671,7 +720,7 @@ fn e2e_debug_json_logs_commands_and_io() {
         .spawn()
         .expect("failed to spawn jumpstarter-exec serve --debug");
 
-    wait_for_socket(&sock);
+    wait_for_socket(&sock, &mut server);
 
     let (stdout, _, code) = run_exec(&path, &["echo", "hello-debug"], None);
     assert_eq!(code, 0);
@@ -741,7 +790,7 @@ fn e2e_log_fields_appear_on_every_line() {
         .spawn()
         .expect("failed to spawn serve with log fields");
 
-    wait_for_socket(&sock);
+    wait_for_socket(&sock, &mut server);
 
     let (_, _, code) = run_exec(&path, &["true"], None);
     assert_eq!(code, 0);

--- a/rust/jumpstarter-exec/tests/integration.rs
+++ b/rust/jumpstarter-exec/tests/integration.rs
@@ -673,6 +673,73 @@ fn e2e_concurrent_exec() {
     server.kill().ok();
 }
 
+/// Two `serve` processes racing to start on the same socket path: exactly
+/// one must win and stay reachable, the other must fail cleanly with
+/// "already listening" rather than silently displacing the winner.
+#[test]
+fn e2e_concurrent_start_loses_cleanly() {
+    let dir = TempDir::new().unwrap();
+    let sock = dir.path().join("race.sock");
+    let path = sock.to_str().unwrap().to_string();
+
+    let spawn = || {
+        Command::new(binary_path())
+            .args(["serve", "--socket", &path])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn jumpstarter-exec serve")
+    };
+    let mut a = spawn();
+    let mut b = spawn();
+
+    // Whichever wins the publish race, the socket must appear promptly.
+    wait_for_socket(&sock, &mut a);
+
+    // Wait for the loser to exit.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let (status_a, status_b) = loop {
+        let sa = a.try_wait().expect("poll a");
+        let sb = b.try_wait().expect("poll b");
+        if sa.is_some() || sb.is_some() {
+            break (sa, sb);
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "neither process exited; concurrent-start race did not resolve"
+        );
+        thread::sleep(Duration::from_millis(20));
+    };
+
+    assert!(
+        status_a.is_some() ^ status_b.is_some(),
+        "expected exactly one process to exit as the loser, got a={status_a:?} b={status_b:?}"
+    );
+    let (loser, winner) = if status_a.is_some() {
+        (&mut a, &mut b)
+    } else {
+        (&mut b, &mut a)
+    };
+
+    let mut stderr = String::new();
+    if let Some(mut err) = loser.stderr.take() {
+        use std::io::Read;
+        err.read_to_string(&mut stderr).ok();
+    }
+    assert!(
+        stderr.contains("another server is already listening"),
+        "expected loser to report 'already listening', got: {stderr}"
+    );
+
+    // The winner's listener must still be reachable through socket_path.
+    let (stdout, _, code) = run_exec(&path, &["echo", "still-alive"], None);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "still-alive");
+
+    winner.kill().ok();
+}
+
 #[test]
 fn e2e_nonexistent_command() {
     let (mut server, _dir, sock) = start_server_process();


### PR DESCRIPTION
seems like https://github.com/jumpstarter-dev/jumpstarter/pull/1008 did not fix the issue properly
