### PR TITLE
fix: tie readiness probe to leader election in all controllers

### DIFF
--- a/controller/cmd/exporter-set-controller/main.go
+++ b/controller/cmd/exporter-set-controller/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"time"
 
@@ -32,13 +31,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	virtualtargetv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/virtualtarget/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/exporterset"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/exporterset/provisioners/qemu"
+	jmphealthz "github.com/jumpstarter-dev/jumpstarter/controller/internal/healthz"
 )
 
 var (
@@ -145,7 +144,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", leaderElectionCheck(mgr)); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", jmphealthz.LeaderElectionCheck(mgr)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -165,18 +164,5 @@ func selectProvisioner(name string) (exporterset.Provisioner, error) {
 		return qemu.New(version), nil
 	default:
 		return nil, fmt.Errorf("unknown provisioner %q; supported: %s", name, qemu.ProvisionerName)
-	}
-}
-
-// leaderElectionCheck returns a healthz.Checker that reports not-ready until
-// the manager has been elected leader (or leader election is disabled).
-func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
-	return func(_ *http.Request) error {
-		select {
-		case <-mgr.Elected():
-			return nil
-		default:
-			return fmt.Errorf("not yet leader")
-		}
 	}
 }

--- a/controller/cmd/exporter-set-controller/main.go
+++ b/controller/cmd/exporter-set-controller/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
@@ -143,7 +145,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", leaderElectionCheck(mgr)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -163,5 +165,18 @@ func selectProvisioner(name string) (exporterset.Provisioner, error) {
 		return qemu.New(version), nil
 	default:
 		return nil, fmt.Errorf("unknown provisioner %q; supported: %s", name, qemu.ProvisionerName)
+	}
+}
+
+// leaderElectionCheck returns a healthz.Checker that reports not-ready until
+// the manager has been elected leader (or leader election is disabled).
+func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
+	return func(_ *http.Request) error {
+		select {
+		case <-mgr.Elected():
+			return nil
+		default:
+			return fmt.Errorf("not yet leader")
+		}
 	}
 }

--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -21,7 +21,9 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"flag"
+	"fmt"
 	"net"
+	"net/http"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -40,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -324,7 +327,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", leaderElectionCheck(mgr)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -383,4 +386,20 @@ func jwtAuthenticatorsToOIDCConfigs(authenticators []apiserverv1beta1.JWTAuthent
 		})
 	}
 	return configs
+}
+
+// leaderElectionCheck returns a healthz.Checker that reports not-ready until
+// the manager has been elected leader (or leader election is disabled).
+// This ensures that non-leader replicas are removed from Service endpoints,
+// preventing traffic from reaching pods that are not actively reconciling
+// or serving gRPC.
+func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
+	return func(_ *http.Request) error {
+		select {
+		case <-mgr.Elected():
+			return nil
+		default:
+			return fmt.Errorf("not yet leader")
+		}
+	}
 }

--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -21,9 +21,7 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"flag"
-	"fmt"
 	"net"
-	"net/http"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -42,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -51,6 +48,7 @@ import (
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/authorization"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/config"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/controller"
+	jmphealthz "github.com/jumpstarter-dev/jumpstarter/controller/internal/healthz"
 	jmpmetrics "github.com/jumpstarter-dev/jumpstarter/controller/internal/metrics"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/oidc"
 	"github.com/jumpstarter-dev/jumpstarter/controller/internal/service"
@@ -327,7 +325,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", leaderElectionCheck(mgr)); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", jmphealthz.LeaderElectionCheck(mgr)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -386,20 +384,4 @@ func jwtAuthenticatorsToOIDCConfigs(authenticators []apiserverv1beta1.JWTAuthent
 		})
 	}
 	return configs
-}
-
-// leaderElectionCheck returns a healthz.Checker that reports not-ready until
-// the manager has been elected leader (or leader election is disabled).
-// This ensures that non-leader replicas are removed from Service endpoints,
-// preventing traffic from reaching pods that are not actively reconciling
-// or serving gRPC.
-func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
-	return func(_ *http.Request) error {
-		select {
-		case <-mgr.Elected():
-			return nil
-		default:
-			return fmt.Errorf("not yet leader")
-		}
-	}
 }

--- a/controller/deploy/operator/cmd/main.go
+++ b/controller/deploy/operator/cmd/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -35,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -254,7 +257,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", leaderElectionCheck(mgr)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -263,5 +266,18 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+}
+
+// leaderElectionCheck returns a healthz.Checker that reports not-ready until
+// the manager has been elected leader (or leader election is disabled).
+func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
+	return func(_ *http.Request) error {
+		select {
+		case <-mgr.Elected():
+			return nil
+		default:
+			return fmt.Errorf("not yet leader")
+		}
 	}
 }

--- a/controller/deploy/operator/cmd/main.go
+++ b/controller/deploy/operator/cmd/main.go
@@ -19,8 +19,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -37,10 +35,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	jmphealthz "github.com/jumpstarter-dev/jumpstarter/controller/internal/healthz"
 
 	operatorv1alpha1 "github.com/jumpstarter-dev/jumpstarter/controller/deploy/operator/api/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter/controller/deploy/operator/internal/controller/jumpstarter"
@@ -257,7 +256,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", leaderElectionCheck(mgr)); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", jmphealthz.LeaderElectionCheck(mgr)); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
@@ -266,18 +265,5 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
-	}
-}
-
-// leaderElectionCheck returns a healthz.Checker that reports not-ready until
-// the manager has been elected leader (or leader election is disabled).
-func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
-	return func(_ *http.Request) error {
-		select {
-		case <-mgr.Elected():
-			return nil
-		default:
-			return fmt.Errorf("not yet leader")
-		}
 	}
 }

--- a/controller/deploy/operator/internal/controller/jumpstarter/jumpstarter_controller.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/jumpstarter_controller.go
@@ -898,8 +898,12 @@ func (r *JumpstarterReconciler) createControllerDeployment(jumpstarter *operator
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
-					MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+					MaxSurge: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+					// The controller is active/passive: only the leader pod passes
+					// readiness (see leaderElectionCheck), so at most 1 replica will
+					// ever be ready. Allow all standby replicas to be unavailable so
+					// the Deployment can reach the Available condition.
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: max(jumpstarter.Spec.Controller.Replicas-1, 1)},
 				},
 			},
 			Selector: &metav1.LabelSelector{

--- a/controller/hack/deploy_with_operator.sh
+++ b/controller/hack/deploy_with_operator.sh
@@ -213,7 +213,7 @@ ${AUTH_CONFIG}
   controller:
     image: ${IMAGE_REPO}
     imagePullPolicy: IfNotPresent
-    replicas: 1
+    replicas: 2
     resources:
       requests:
         cpu: 100m

--- a/controller/internal/healthz/healthz.go
+++ b/controller/internal/healthz/healthz.go
@@ -1,0 +1,26 @@
+// Package healthz provides custom health check functions for controller-runtime managers.
+package healthz
+
+import (
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// LeaderElectionCheck returns a healthz.Checker that reports not-ready until
+// the manager has been elected leader (or leader election is disabled).
+// This ensures that non-leader replicas are removed from Service endpoints,
+// preventing traffic from reaching pods that are not actively reconciling
+// or serving gRPC.
+func LeaderElectionCheck(mgr manager.Manager) healthz.Checker {
+	return func(_ *http.Request) error {
+		select {
+		case <-mgr.Elected():
+			return nil
+		default:
+			return fmt.Errorf("not yet leader")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Alternative approach to #1002 — instead of polling the Lease object from shell scripts, fix the root cause: controllers report ready before they've won leader election.

Replaces `healthz.Ping` with a leader-election-aware readiness checker for the `/readyz` endpoint in all three controller binaries. The checker uses `mgr.Elected()` (a channel closed when the manager wins leader election, or immediately if leader election is disabled) to gate readiness.

## What this fixes

**1. E2E race condition (the #1002 root cause)**

Pods were reporting ready (passing `/readyz`) before leader election completed (~57s observed in CI). The E2E `wait_for_jumpstarter_resources` uses `kubectl wait --for=condition=available`, which was satisfied immediately — but the controller couldn't reconcile yet. With this change, the existing readiness wait naturally blocks until the leader is elected.

**2. HA traffic routing bug**

With 2+ replicas (the default is 2), the gRPC `ControllerService` (port 8082) only runs on the leader pod — `controller-runtime` defaults `NeedLeaderElection()` to `true`, so `Start()` never executes on standby replicas. But `healthz.Ping` always returned OK, so Kubernetes included **both** pods in Service endpoints. Result: ~50% of gRPC connections hit the non-leader pod and got **connection refused**. Now non-leader pods report not-ready and are removed from endpoints.

## Changes

| File | Change |
|------|--------|
| `controller/cmd/main.go` | Readyz check: `healthz.Ping` → `leaderElectionCheck(mgr)` |
| `controller/cmd/exporter-set-controller/main.go` | Same |
| `controller/deploy/operator/cmd/main.go` | Same |
| `controller/deploy/operator/.../jumpstarter_controller.go` | Controller Deployment `maxUnavailable`: `25%` → `max(replicas-1, 1)` |
| `controller/hack/deploy_with_operator.sh` | E2E controller replicas: 1 → 2 |

The `leaderElectionCheck` helper is a simple non-blocking select on `mgr.Elected()`:

```go
func leaderElectionCheck(mgr manager.Manager) healthz.Checker {
    return func(_ *http.Request) error {
        select {
        case <-mgr.Elected():
            return nil
        default:
            return fmt.Errorf("not yet leader")
        }
    }
}
```

Since the controller is active/passive by design (only the leader runs gRPC and reconciliation), at most 1 replica will ever pass readiness. The operator now sets `maxUnavailable` to `replicas - 1` (minimum 1) so the Deployment reaches `Available` with just the leader pod ready.

## E2E impact

- Controller replicas bumped from 1 to 2 so the HA readiness behavior is exercised in CI
- No changes needed to `wait_for_jumpstarter_resources` — the existing `kubectl wait --for=condition=available` now correctly blocks until leader election completes, since pods won't pass readiness until then
- The dynamic `maxUnavailable` ensures the deployment becomes `Available` once the leader is ready, regardless of how many standby replicas exist

Relates to #1002