### PR TITLE
cli: add --allow-disabled flag to jmp shell

### DIFF
--- a/controller/internal/controller/lease_controller.go
+++ b/controller/internal/controller/lease_controller.go
@@ -277,7 +277,7 @@ func (r *LeaseReconciler) reconcileStatusExporterRef(
 					"ExporterDisabled",
 					"Requested exporter %s is disabled. "+
 						"To lease a disabled exporter, set spec.allowDisabled: true on the Lease, "+
-						"or use --allow-disabled with jmp create lease",
+						"or use --allow-disabled with jmp create lease or jmp shell",
 					exporter.Name,
 				)
 				return nil

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/common.py
@@ -173,6 +173,13 @@ opt_dial_timeout = partial(
     ),
 )
 
+opt_allow_disabled = click.option(
+    "--allow-disabled",
+    is_flag=True,
+    default=False,
+    help="Allow leasing a disabled exporter (only effective with --name/-n)",
+)
+
 opt_begin_time = click.option(
     "--begin-time",
     "begin_time",

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/create.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/create.py
@@ -7,7 +7,7 @@ from jumpstarter_cli_common.exceptions import handle_exceptions_with_reauthentic
 from jumpstarter_cli_common.opt import OutputType, opt_output_all
 from jumpstarter_cli_common.print import model_print
 
-from .common import opt_begin_time, opt_duration_partial, opt_exporter_name, opt_selector
+from .common import opt_allow_disabled, opt_begin_time, opt_duration_partial, opt_exporter_name, opt_selector
 from .login import relogin_client
 
 
@@ -60,12 +60,7 @@ def create():
     multiple=True,
     help="Tag to set on the lease (key=value format, can be specified multiple times)",
 )
-@click.option(
-    "--allow-disabled",
-    is_flag=True,
-    default=False,
-    help="Allow leasing a disabled exporter (only effective with --name/-n)",
-)
+@opt_allow_disabled
 @click.option(
     "--context",
     "context_entries",

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -480,7 +480,7 @@ async def _run_shell_with_lease_async(lease, exporter_logs, config, command, can
 
 async def _shell_with_signal_handling(  # noqa: C901
     config, selector, exporter_name, lease_name, duration, exporter_logs, command, acquisition_timeout,
-    retry_timeout=None, dial_timeout=None,
+    retry_timeout=None, dial_timeout=None, allow_disabled=False,
 ):
     """Handle lease acquisition and shell execution with signal handling."""
     exit_code = 0
@@ -508,6 +508,7 @@ async def _shell_with_signal_handling(  # noqa: C901
                         async with config.lease_async(
                             selector, exporter_name, lease_name, duration, portal, acquisition_timeout,
                             retry_timeout=retry_timeout, dial_timeout=dial_timeout,
+                            allow_disabled=allow_disabled,
                         ) as lease:
                             lease_used = lease
 
@@ -699,6 +700,12 @@ async def _shell_direct_async(
 @opt_exporter_name
 @opt_duration_partial(default=timedelta(minutes=30), show_default="00:30:00")
 @click.option("--exporter-logs", is_flag=True, help="Enable exporter log streaming")
+@click.option(
+    "--allow-disabled",
+    is_flag=True,
+    default=False,
+    help="Allow leasing a disabled exporter (only effective with --name/-n)",
+)
 @opt_acquisition_timeout()
 @opt_retry_timeout()
 @opt_dial_timeout()
@@ -731,6 +738,7 @@ def shell(
     exporter_name,
     duration,
     exporter_logs,
+    allow_disabled,
     acquisition_timeout,
     retry_timeout,
     dial_timeout,
@@ -784,6 +792,7 @@ def shell(
                 acquisition_timeout,
                 retry_timeout,
                 dial_timeout,
+                allow_disabled,
             )
             sys.exit(exit_code)
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -26,6 +26,7 @@ from jumpstarter_cli_common.signal import signal_handler
 
 from .common import (
     opt_acquisition_timeout,
+    opt_allow_disabled,
     opt_dial_timeout,
     opt_duration_partial,
     opt_exporter_name,
@@ -700,12 +701,7 @@ async def _shell_direct_async(
 @opt_exporter_name
 @opt_duration_partial(default=timedelta(minutes=30), show_default="00:30:00")
 @click.option("--exporter-logs", is_flag=True, help="Enable exporter log streaming")
-@click.option(
-    "--allow-disabled",
-    is_flag=True,
-    default=False,
-    help="Allow leasing a disabled exporter (only effective with --name/-n)",
-)
+@opt_allow_disabled
 @opt_acquisition_timeout()
 @opt_retry_timeout()
 @opt_dial_timeout()

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -68,7 +68,7 @@ class _DummyConfig:
     @asynccontextmanager
     async def lease_async(
         self, selector, exporter_name, lease_name, duration, portal,
-        acquisition_timeout, retry_timeout=None, dial_timeout=None,
+        acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
     ):
         self.captured = (selector, exporter_name, lease_name, duration, acquisition_timeout)
         m = Mock()
@@ -113,7 +113,7 @@ async def test_shell_warns_when_expired_token_prevents_cleanup_on_normal_exit():
     @asynccontextmanager
     async def lease_async(
         selector, exporter_name, lease_name, duration, portal,
-        acquisition_timeout, retry_timeout=None, dial_timeout=None,
+        acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
     ):
         yield lease
 
@@ -160,6 +160,7 @@ def test_shell_requires_selector_or_name_when_no_leases():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -182,6 +183,7 @@ def test_shell_allows_existing_lease_name_without_selector_or_name():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -208,6 +210,7 @@ def test_shell_auto_connects_single_lease():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -237,6 +240,7 @@ def test_shell_no_leases_shows_guidance():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -279,6 +283,7 @@ def test_shell_multi_lease_no_tty_error():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -316,6 +321,7 @@ def test_shell_no_own_leases_among_others():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -339,6 +345,7 @@ def test_shell_allows_env_lease_without_selector_or_name():
             exporter_name=None,
             duration=timedelta(minutes=1),
             exporter_logs=False,
+            allow_disabled=False,
             acquisition_timeout=None,
             retry_timeout=None,
             dial_timeout=None,
@@ -1061,7 +1068,7 @@ class TestShellWithSignalHandlingExceptionGroup:
         @asynccontextmanager
         async def lease_async(
             selector, exporter_name, lease_name, duration, portal,
-            acquisition_timeout, retry_timeout=None, dial_timeout=None,
+            acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
         ):
             yield lease
 
@@ -1144,7 +1151,7 @@ class TestRetryLoopTimeout:
         @asynccontextmanager
         async def lease_async(
             selector, exporter_name, lease_name, duration, portal,
-            acquisition_timeout, retry_timeout=None, dial_timeout=None,
+            acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
         ):
             yield lease
 
@@ -1188,7 +1195,7 @@ class TestRetryLoopTimeout:
         @asynccontextmanager
         async def lease_async(
             selector, exporter_name, lease_name, duration, portal,
-            acquisition_timeout, retry_timeout=None, dial_timeout=None,
+            acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
         ):
             yield lease
 
@@ -1230,7 +1237,7 @@ class TestRetryLoopTimeout:
         @asynccontextmanager
         async def lease_async(
             selector, exporter_name, lease_name, duration, portal,
-            acquisition_timeout, retry_timeout=None, dial_timeout=None,
+            acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
         ):
             yield lease
 
@@ -1273,7 +1280,7 @@ class TestRetryLoopLeaseExpired:
         @asynccontextmanager
         async def lease_async(
             selector, exporter_name, lease_name, duration, portal,
-            acquisition_timeout, retry_timeout=None, dial_timeout=None,
+            acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
         ):
             yield lease
 
@@ -1310,7 +1317,7 @@ class TestRetryLoopLeaseExpired:
         @asynccontextmanager
         async def lease_async(
             selector, exporter_name, lease_name, duration, portal,
-            acquisition_timeout, retry_timeout=None, dial_timeout=None,
+            acquisition_timeout, retry_timeout=None, dial_timeout=None, **kwargs,
         ):
             yield lease
 

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -91,6 +91,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
     tls_config: TLSConfigV1Alpha1 = field(default_factory=TLSConfigV1Alpha1)
     grpc_options: dict[str, Any] = field(default_factory=dict)
     client_name: str | None = None  # Name of the current client, used for ownership validation
+    allow_disabled: bool = False  # Allow leasing a disabled exporter (only effective with exporter_name)
     acquisition_timeout: int = field(default=7200)  # Timeout in seconds for lease acquisition, polled in 5s intervals
     dial_timeout: float = field(default=60.0)  # Timeout in seconds for Dial retry loop when exporter not ready
     retry_timeout: float = field(default=300.0)  # Retry timeout for unreachable exporter (0 to disable)
@@ -128,6 +129,7 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
                 duration=self.duration,
                 lease_id=self.name,
                 tags=self.tags or None,
+                allow_disabled=self.allow_disabled,
             )
             self.name = lease.name
             for label_key, message in lease.deprecated_labels.items():

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -331,6 +331,7 @@ class ClientConfigV1Alpha1(BaseSettings):
         acquisition_timeout: timedelta | None = None,
         retry_timeout: timedelta | None = None,
         dial_timeout: timedelta | None = None,
+        allow_disabled: bool = False,
     ):
         from jumpstarter.client import Lease
 
@@ -369,6 +370,7 @@ class ClientConfigV1Alpha1(BaseSettings):
                 tls_config=self.tls,
                 grpc_options=self.grpcOptions,
                 client_name=self.metadata.name,
+                allow_disabled=allow_disabled,
                 acquisition_timeout=acquisition_timeout_seconds,
                 dial_timeout=dial_timeout_seconds,
                 retry_timeout=retry_timeout_seconds,


### PR DESCRIPTION
## Summary

Add the `--allow-disabled` flag to `jmp shell` so admins can directly connect to disabled exporters for testing/maintenance, without the workaround of first creating a lease via `jmp create lease --allow-disabled`.

## Problem

The `jmp create lease` command supports `--allow-disabled` to lease a disabled exporter, but `jmp shell` does not. This forces admins into a two-step workaround:

```bash
# Current workaround (cumbersome)
JMP_LEASE=$(jmp create lease --allow-disabled -n my-exporter --duration 1h --output name)
jmp shell --lease "$JMP_LEASE"
```

## Solution

Add the `--allow-disabled` flag to `jmp shell` and thread it through:

1. **`shell.py`** - New `--allow-disabled` CLI option, passed to `_shell_with_signal_handling()`
2. **`config/client.py`** - New `allow_disabled` parameter on `lease_async()`
3. **`client/lease.py`** - New `allow_disabled` field on `Lease` dataclass, passed to `CreateLease()`

After this change:
```bash
# Direct usage
jmp shell --allow-disabled -n my-exporter
```

Consistent with the existing flag on `jmp create lease`, this is only effective when targeting a specific exporter by name (`-n`).

Fixes #1015
Jira: PITCREW-523