### PR TITLE
feat: add support for `jmp get lease`

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get.py
@@ -80,6 +80,7 @@ def get_exporters(
 
 @get.command(name="leases")
 @opt_config(exporter=False)
+@click.argument("name", required=False, default=None)
 @opt_selector
 @opt_output_all
 @click.option("-a", "--all", "show_all", is_flag=True, default=False, help="Include expired leases")
@@ -101,10 +102,18 @@ def get_leases(
     all_clients: bool,
     tag_filter: str | None,
     page_size: int,
+    name: str | None = None,
 ):
     """
     Display one or many leases
     """
+
+    if name:
+        if selector or tag_filter:
+            raise click.UsageError("NAME cannot be combined with --selector or --tag-filter")
+        lease = config.get_lease(name=name)
+        model_print(lease, output)
+        return
 
     leases = config.list_leases(
         filter=selector, only_active=not show_all, tag_filter=tag_filter, page_size=page_size
@@ -112,15 +121,5 @@ def get_leases(
 
     if not all_clients:
         leases = leases.filter_by_client(config.metadata.name)
-
-    for lease in leases.leases:
-        for label_key, message in lease.deprecated_labels.items():
-            warning = f"selector label '{label_key}' on lease '{lease.name}' is deprecated"
-            if message:
-                warning += f": {message}"
-            click.echo(
-                click.style("Warning: ", fg="yellow") + warning,
-                err=True,
-            )
 
     model_print(leases, output)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/get_test.py
@@ -526,84 +526,6 @@ class TestGetLeasesLogic:
         assert len(leases_from_server.leases) == 0
 
 
-class TestGetLeasesDeprecatedLabelsWarning:
-    def _make_lease(self, name="test-lease", deprecated_labels=None):
-        return Lease(
-            namespace="default",
-            name=name,
-            selector="legacy-board=rpi4",
-            exporter_name=None,
-            duration=timedelta(minutes=30),
-            effective_duration=None,
-            begin_time=None,
-            client="test-client",
-            exporter="test-exporter",
-            conditions=[],
-            effective_begin_time=None,
-            effective_end_time=None,
-            deprecated_labels=deprecated_labels or {},
-        )
-
-    def _make_config(self, leases):
-        config = Mock()
-        config.metadata = type("Metadata", (), {"name": "test-client"})()
-        config.list_leases = Mock(return_value=LeaseList(leases=leases, next_page_token=None))
-        return config
-
-    def test_deprecated_labels_emit_warnings_with_message(self):
-        from unittest.mock import patch
-
-        lease = self._make_lease(deprecated_labels={"legacy-board": "Use board instead"})
-        config = self._make_config([lease])
-
-        with patch("jumpstarter_cli.get.model_print"), patch("jumpstarter_cli.get.click") as mock_click:
-            mock_click.style.side_effect = lambda text, **kwargs: text
-            _unwrapped_get_leases(
-                config=config, selector=None, output=None, show_all=False, all_clients=False, tag_filter=None,
-                page_size=100,
-            )
-
-        mock_click.echo.assert_called_once()
-        warning_msg = mock_click.echo.call_args[0][0]
-        assert "legacy-board" in warning_msg
-        assert "test-lease" in warning_msg
-        assert "deprecated" in warning_msg
-        assert "Use board instead" in warning_msg
-
-    def test_deprecated_labels_emit_warnings_without_message(self):
-        from unittest.mock import patch
-
-        lease = self._make_lease(deprecated_labels={"legacy-board": ""})
-        config = self._make_config([lease])
-
-        with patch("jumpstarter_cli.get.model_print"), patch("jumpstarter_cli.get.click") as mock_click:
-            mock_click.style.side_effect = lambda text, **kwargs: text
-            _unwrapped_get_leases(
-                config=config, selector=None, output=None, show_all=False, all_clients=False, tag_filter=None,
-                page_size=100,
-            )
-
-        mock_click.echo.assert_called_once()
-        warning_msg = mock_click.echo.call_args[0][0]
-        assert "legacy-board" in warning_msg
-        assert "deprecated" in warning_msg
-        assert "Use board instead" not in warning_msg
-
-    def test_no_warnings_when_no_deprecated_labels(self):
-        from unittest.mock import patch
-
-        lease = self._make_lease()
-        config = self._make_config([lease])
-
-        with patch("jumpstarter_cli.get.model_print"), patch("jumpstarter_cli.get.click") as mock_click:
-            _unwrapped_get_leases(
-                config=config, selector=None, output=None, show_all=False, all_clients=False, tag_filter=None,
-                page_size=100,
-            )
-
-        mock_click.echo.assert_not_called()
-
-
 class TestGetLeasesShortFlags:
     def test_get_leases_accepts_short_a_flag(self):
         from .get import get_leases
@@ -612,6 +534,12 @@ class TestGetLeasesShortFlags:
             param for param in get_leases.params if param.name == "show_all"
         )
         assert "-a" in all_option.opts
+
+    def test_get_leases_accepts_optional_name_argument(self):
+        from .get import get_leases
+
+        name_arg = next(param for param in get_leases.params if param.name == "name")
+        assert name_arg.required is False
 
 
 _unwrapped_get_leases = get_leases.callback.__wrapped__.__wrapped__
@@ -709,3 +637,86 @@ class TestGetLeasesClientFiltering:
         printed_leases = mock_print.call_args[0][0]
         assert len(printed_leases.leases) == 2
         config.list_leases.assert_called_once_with(filter=None, only_active=False, tag_filter=None, page_size=100)
+
+
+class TestGetLeaseByName:
+    def _make_lease(self, name, client="my-client"):
+        return Lease(
+            namespace="default",
+            name=name,
+            selector="board-type=qc8775",
+            exporter_name=None,
+            duration=timedelta(minutes=30),
+            effective_duration=None,
+            begin_time=None,
+            client=client,
+            exporter="qti-snapdragon-ride4-sa8775p-03",
+            conditions=[],
+            effective_begin_time=None,
+            effective_end_time=None,
+        )
+
+    def _make_config(self, lease):
+        config = Mock()
+        config.metadata = type("Metadata", (), {"name": "my-client"})()
+        config.get_lease = Mock(return_value=lease)
+        config.list_leases = Mock()
+        return config
+
+    def test_get_lease_by_name_calls_get_lease(self):
+        from unittest.mock import patch
+
+        lease = self._make_lease("01a0153c-277c-7992-9476-8ff0f68ba6f8")
+        config = self._make_config(lease)
+
+        with patch("jumpstarter_cli.get.model_print") as mock_print:
+            _unwrapped_get_leases(
+                config=config, selector=None, output="yaml", show_all=False, all_clients=False,
+                tag_filter=None, page_size=100, name=lease.name,
+            )
+
+        config.get_lease.assert_called_once_with(name=lease.name)
+        config.list_leases.assert_not_called()
+        printed = mock_print.call_args[0][0]
+        assert printed is lease
+        assert printed.exporter == "qti-snapdragon-ride4-sa8775p-03"
+
+    def test_get_lease_by_name_shows_other_clients_lease(self):
+        from unittest.mock import patch
+
+        lease = self._make_lease("other-lease", client="other-client")
+        config = self._make_config(lease)
+
+        with patch("jumpstarter_cli.get.model_print") as mock_print:
+            _unwrapped_get_leases(
+                config=config, selector=None, output=None, show_all=False, all_clients=False,
+                tag_filter=None, page_size=100, name=lease.name,
+            )
+
+        printed = mock_print.call_args[0][0]
+        assert printed.client == "other-client"
+        config.list_leases.assert_not_called()
+
+    def test_get_lease_by_name_rejects_selector(self):
+        config = self._make_config(self._make_lease("lease-1"))
+
+        with pytest.raises(click.UsageError, match="NAME cannot be combined"):
+            _unwrapped_get_leases(
+                config=config, selector="board-type=qc8775", output=None, show_all=False,
+                all_clients=False, tag_filter=None, page_size=100, name="lease-1",
+            )
+
+        config.get_lease.assert_not_called()
+        config.list_leases.assert_not_called()
+
+    def test_get_lease_by_name_rejects_tag_filter(self):
+        config = self._make_config(self._make_lease("lease-1"))
+
+        with pytest.raises(click.UsageError, match="NAME cannot be combined"):
+            _unwrapped_get_leases(
+                config=config, selector=None, output=None, show_all=False,
+                all_clients=False, tag_filter="build=1234", page_size=100, name="lease-1",
+            )
+
+        config.get_lease.assert_not_called()
+        config.list_leases.assert_not_called()

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -290,6 +290,17 @@ class ClientConfigV1Alpha1(BaseSettings):
 
     @_blocking_compat
     @_handle_connection_error
+    async def get_lease(
+        self,
+        name: str,
+    ):
+        svc = ClientService(channel=await self.channel(), namespace=self.metadata.namespace)
+        return await svc.GetLease(
+            name=name,
+        )
+
+    @_blocking_compat
+    @_handle_connection_error
     async def list_leases(
         self,
         filter: str | None = None,

--- a/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -451,6 +451,28 @@ async def test_create_lease_passes_exporter_name():
 
 
 @pytest.mark.asyncio
+async def test_get_lease_calls_get_lease():
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+    mock_service = Mock()
+    mock_service.GetLease = AsyncMock(return_value="lease")
+
+    with (
+        patch("jumpstarter.config.client.ClientConfigV1Alpha1.channel", AsyncMock(return_value=Mock())),
+        patch("jumpstarter.config.client.ClientService", return_value=mock_service),
+    ):
+        result = await config.get_lease(name="01a0153c-277c-7992-9476-8ff0f68ba6f8")
+
+    assert result == "lease"
+    mock_service.GetLease.assert_awaited_once_with(name="01a0153c-277c-7992-9476-8ff0f68ba6f8")
+
+
+@pytest.mark.asyncio
 async def test_list_leases_paginates():
     from jumpstarter.client.grpc import Lease, LeaseList
 


### PR DESCRIPTION
Support getting information for a single list. This would make it simpler to fetch information about a list, rather then fetching a list and filtering.