### PR TITLE
fix: gate lease slot release on session teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,10 @@ help:
 	@echo ""
 	@echo "End-to-end testing:"
 	@echo "  make e2e-setup             - Setup e2e test environment (one-time)"
-	@echo "  make e2e-run               - Run full e2e suite (includes ExporterSet QEMU)"
+	@echo "  make e2e-run               - Run e2e suite (excludes lease-churn; includes ExporterSet QEMU)"
 	@echo "  make e2e                   - Same as e2e-run"
 	@echo "  make e2e-exporterset-qemu  - Run ExporterSet QEMU e2e only"
+	@echo "  make e2e-lease-churn       - Run core e2e including lease-churn cycles"
 	@echo "  make e2e-full              - Full setup + run (for CI or first time)"
 	@echo "  make e2e-clean             - Clean up e2e test environment (delete cluster, certs, etc.)"
 	@echo ""
@@ -193,17 +194,24 @@ e2e-setup:
 	@echo "Setting up e2e test environment..."
 	@bash e2e/setup-e2e.sh
 
-# Run e2e tests
+# Run e2e tests (excludes lease-churn; override with GINKGO_LABEL_FILTER)
 .PHONY: e2e-run
 e2e-run:
 	@echo "Running e2e tests..."
-	@bash e2e/run-e2e.sh
+	@GINKGO_LABEL_FILTER="$(or $(GINKGO_LABEL_FILTER),!lease-churn)" bash e2e/run-e2e.sh
 
 # Focused local run of ExporterSet QEMU e2e (also covered by make e2e-run / CI).
 .PHONY: e2e-exporterset-qemu
 e2e-exporterset-qemu:
 	@echo "Running ExporterSet QEMU e2e tests..."
 	@GINKGO_LABEL_FILTER=exporterset-qemu bash e2e/run-e2e.sh
+
+# Core lane including the lease-churn cycle spec (create/release ×20).
+# Needs the Ordered core setup specs, so this is `core` not `lease-churn` alone.
+.PHONY: e2e-lease-churn
+e2e-lease-churn:
+	@echo "Running core e2e tests including lease-churn..."
+	@GINKGO_LABEL_FILTER=core bash e2e/run-e2e.sh
 
 # Prints a lane-grouped index of all e2e specs (group + name + labels + source),
 # generated via `ginkgo --dry-run`. Use it to check e2e/README.md's lane/test/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,8 +48,9 @@ Prereq (all): dex + controller/operator running, namespace `jumpstarter-lab` cre
 | legacy client config contains CA certificate and works with secure TLS | exporters running | inspect `test-client-legacy.yaml` `tls.ca`; run `jmp get exporters` without `JUMPSTARTER_GRPC_INSECURE` | CA present; command succeeds over real TLS |
 | can operate on leases | exporters running | create lease, list leases/exporters, test label-selector filters (`=`, `!`, multi-expr), delete all | selector filtering returns correct/empty results |
 | can create a lease with context metadata | exporters running | `create lease --context k=v` x2, fetch yaml | CRD-persisted context keys/values present in output |
-| paginated lease listing returns all leases | exporters running | create 10 leases, `get leases --page-size 5 -o name` | exactly 10 lines returned across pages |
+| paginated lease listing returns all leases | exporters running | create 10 unmatched leases labeled `pagination=true`, `get leases --all --selector pagination=true --page-size 5 -o name` | exactly 10 lines returned across pages (ended/unsatisfiable included) |
 | paginated exporter listing returns all exporters | exporters running | create 10 exporters w/ shared label, list with `--page-size 5` | exactly 10 names returned |
+| cycles leases on one exporter without sticking at LeaseReady | exporters running; `lease-churn` (excluded from `make e2e-run` / CI) | create+delete lease on `test-exporter-oidc` ×20, wait `Available\|` after each release | exporter returns to `Available\|` after every cycle |
 | lease listing shows expires at and remaining columns | exporters running | create lease, `get leases` with wide COLUMNS | output has "EXPIRES AT" and "REMAINING" |
 | can transfer lease to another client | exporters running | create lease, wait Ready, `update lease --to-client test-client-legacy` | updated lease yaml shows new client |
 | can lease and connect to exporters | exporters running | `jmp shell --selector ... j power on` for oidc/sa/legacy/provisioning clients | all shells succeed |
@@ -229,14 +230,21 @@ venv/binary isn't found.
 
 - **Lanes = Ginkgo `Label(...)`** on each top-level `Describe`; selected via
   `GINKGO_LABEL_FILTER` / `--label-filter` (see `e2e/run-e2e.sh` header comment).
-  CI's `e2e-tests` job effectively runs the full suite (including
-  `exporterset-qemu`); `e2e-compat-old-controller`/`e2e-compat-old-client` jobs run
+  CI's `e2e-tests` job runs `make e2e-run`, which defaults to
+  `--label-filter '!lease-churn'` (still includes `exporterset-qemu`).
+  `e2e-compat-old-controller`/`e2e-compat-old-client` jobs run
   only on merge-queue/dispatch via `compat/run.sh`. PRs run amd64 only;
   merge-queue and `workflow_dispatch` also run arm64.
 - **`operator-only`** is a secondary label on 2 individual `It`s inside the `core`
   lane (`can login with simplified login` and `legacy client config contains CA
   certificate and works with secure TLS`) — excluded when running against a
   plain controller (non-operator) deployment via `--label-filter "!operator-only"`.
+- **`lease-churn`** is a secondary label on `cycles leases on one exporter without
+  sticking at LeaseReady` inside `core`. It is excluded from `make e2e-run` / CI
+  (`!lease-churn`). Run it with `make e2e-lease-churn` (`GINKGO_LABEL_FILTER=core`),
+  which still runs the Ordered core setup specs. It cannot be `Serial`: Ginkgo
+  rejects that decorator on an `It` inside a non-Serial Ordered container; the
+  parent Ordered suite already sequences it against other core lease specs.
 - Failure log dumping is lane-specific infrastructure (for example: core and
   exit-on-lease-end dump exporter + controller logs; exporterset-qemu dumps
   exporterset/QEMU pod logs).

--- a/e2e/run-e2e.sh
+++ b/e2e/run-e2e.sh
@@ -5,12 +5,13 @@
 # The tests are implemented using Go + Ginkgo. By default the full suite runs,
 # including ExporterSet QEMU (label exporterset-qemu). Label filters select
 # subsets:
-#   --label-filter "core"                 - run core tests only
+#   --label-filter "core"                 - run core tests only (includes lease-churn)
 #   --label-filter "hooks"                - run hooks tests only
 #   --label-filter "direct-listener"      - run direct-listener tests only
 #   --label-filter "exporterset-qemu"     - ExporterSet QEMU only (needs qemu images)
 #   --label-filter "!exporterset-qemu"   - skip ExporterSet QEMU
 #   --label-filter "!operator-only"       - skip operator-specific tests
+#   --label-filter "!lease-churn"         - skip assigned-lease cycle spec (default for make e2e-run / CI)
 #
 # Override with GINKGO_LABEL_FILTER for focused local runs.
 
@@ -66,7 +67,7 @@ run_tests() {
     export JUMPSTARTER_GRPC_INSECURE=1
 
     log_info "Running ginkgo e2e tests..."
-    run_ginkgo "$SCRIPT_DIR/test" "${GINKGO_LABEL_FILTER:-}"
+    run_ginkgo "$SCRIPT_DIR/test" "${GINKGO_LABEL_FILTER:-!lease-churn}"
 }
 
 # Full setup and run (for CI or first-time use)

--- a/e2e/test/e2e_test.go
+++ b/e2e/test/e2e_test.go
@@ -342,11 +342,11 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, ContinueOnFailure, fu
 			token := MustRunCmd("bash", "-c", fmt.Sprintf("echo '%s' | base64 -d", tokenB64))
 
 			env := map[string]string{
-				"JMP_NAMESPACE":    ns,
+				"JMP_NAMESPACE":     ns,
 				"JMP_DRIVERS_ALLOW": "*",
-				"JMP_NAME":         "test-client-legacy",
-				"JMP_ENDPOINT":     endpoint,
-				"JMP_TOKEN":        token,
+				"JMP_NAME":          "test-client-legacy",
+				"JMP_ENDPOINT":      endpoint,
+				"JMP_TOKEN":         token,
 			}
 			out, err := RunCmdWithEnv(env, "jmp", "shell",
 				"--selector", "example.com/board=oidc", "j", "power", "on")
@@ -453,6 +453,11 @@ var _ = Describe("Core E2E Tests", Label("core"), Ordered, ContinueOnFailure, fu
 
 			// As with the exporter pagination spec, the leases are fixtures for
 			// the client's pagination, so create them in a single apply.
+			// Spec selector must not match a live exporter: assigning and then
+			// delete --all of 10 overlapping leases races session teardown and
+			// can stick the exporter at LeaseReady. Unmatched leases become
+			// Unsatisfiable/Ended; jmp get leases hides those unless --all.
+			// metadata.labels is what --selector filters on the server.
 			var manifest strings.Builder
 			for i := 1; i <= 10; i++ {
 				fmt.Fprintf(&manifest, `---
@@ -460,24 +465,28 @@ apiVersion: jumpstarter.dev/v1alpha1
 kind: Lease
 metadata:
   name: pagination-lease-%d
+  labels:
+    pagination: "true"
 spec:
   clientRef:
     name: test-client-oidc
   duration: 24h
   selector:
     matchLabels:
-      example.com/board: oidc
+      pagination: "true"
 `, i)
 			}
 			MustKubectlApply(manifest.String())
+			DeferCleanup(func() {
+				MustKubectl("-n", Namespace(), "delete", "leases.jumpstarter.dev",
+					"-l", "pagination=true")
+			})
 
 			out, err := Jmp("get", "leases", "--client", "test-client-oidc",
-				"--page-size", "5", "-o", "name")
+				"--all", "--selector", "pagination=true", "--page-size", "5", "-o", "name")
 			Expect(err).NotTo(HaveOccurred(), out)
 			lines := strings.Split(strings.TrimSpace(out), "\n")
 			Expect(lines).To(HaveLen(10))
-
-			MustJmp("delete", "leases", "--client", "test-client-oidc", "--all")
 		})
 
 		It("paginated exporter listing returns all exporters", func() {
@@ -509,6 +518,47 @@ spec:
 
 			MustKubectl("-n", Namespace(), "delete", "exporters.jumpstarter.dev",
 				"-l", "pagination=true", "--wait=false")
+		})
+
+		// Opt-in: Label("lease-churn") is excluded from make e2e-run / CI
+		// (GINKGO_LABEL_FILTER=!lease-churn). Run with make e2e-lease-churn.
+		// Lives in this Ordered container so it cannot overlap other core
+		// lease specs; Ginkgo forbids Serial on an It here (the outer
+		// Ordered is not Serial). Wait for Available| after each assigned
+		// release; do not delete with --wait=false.
+		It("cycles leases on one exporter without sticking at LeaseReady", Label("lease-churn"), func() {
+			WaitForExporters("test-exporter-oidc", "test-exporter-sa", "test-exporter-legacy")
+			ns := Namespace()
+			exporterRef := "exporters.jumpstarter.dev/test-exporter-oidc"
+
+			// ContinueOnFailure on the parent Ordered container means a failed
+			// assertion below stops this spec but lets later specs keep running.
+			// Register cleanup up front so a lease created in a cycle that then
+			// fails its assertion cannot bleed into those specs.
+			DeferCleanup(func() {
+				MustJmp("delete", "leases", "--client", "test-client-oidc", "--all")
+			})
+
+			for i := 1; i <= 20; i++ {
+				leaseName := strings.TrimSpace(MustJmp("create", "lease",
+					"--client", "test-client-oidc", "--selector", "example.com/board=oidc",
+					"--duration", "1d", "-o", "name"))
+				Expect(leaseName).NotTo(BeEmpty(), "cycle %d: create lease returned no name", i)
+
+				// Prove the lease actually attached to this exporter: the
+				// leaseRef.name half of exporterState (after the |) must equal the
+				// lease we just created, not merely differ from Available|.
+				Eventually(func() string {
+					return exporterState(ns, exporterRef)
+				}, defaultWaitTimeout, exporterPollPeriod).Should(HaveSuffix("|"+leaseName),
+					"cycle %d: lease %s did not assign", i, leaseName)
+
+				MustJmp("delete", "leases", "--client", "test-client-oidc", "--all")
+				Eventually(func() string {
+					return exporterState(ns, exporterRef)
+				}, defaultWaitTimeout, exporterPollPeriod).Should(Equal(exporterFree),
+					"cycle %d: exporter stuck after release (want Available|)", i)
+			}
 		})
 
 		It("lease listing shows expires at and remaining columns", func() {

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -51,6 +52,12 @@ _RPC_MAX_RETRIES = 20
 _RPC_BACKOFF_BASE = 1.0
 _RPC_BACKOFF_CAP = 30.0
 _RPC_TIMEOUT = 30
+
+# How long after a lease ends to wait for handle_lease's LeaseFinished before
+# warning. The loop waits for LeaseFinished indefinitely (it is a real
+# happens-before edge, not a timer), so this only logs — it never releases the
+# slot — keeping a wedged teardown diagnosable without reintroducing a timeout.
+_LEASE_FINISHED_WATCHDOG = 30.0
 
 # Status codes indicating old controller without exporter auth on ReleaseLease
 _RELEASE_LEASE_UNSUPPORTED_CODES = frozenset({
@@ -160,6 +167,19 @@ def shutdown_runtime_sidecar(
 class LeaseState(Enum):
     IDLE = "idle"
     LEASED = "leased"
+
+
+@dataclass
+class LeaseFinished:
+    """Control-plane message: a handle_lease task has fully torn down its lease.
+
+    Sent by handle_lease's finally after session_for_lease has exited (gRPC
+    graceful stop included), so receiving it means the transport is gone. The
+    control-plane loop is the sole writer of _lease_context; handle_lease hands
+    the slot back with this message instead of clearing it from its own task.
+    """
+
+    lease_ctx: LeaseContext
 
 
 async def _standalone_shutdown_waiter():
@@ -305,18 +325,21 @@ class Exporter(AsyncContextManagerMixin, Metadata):
     """
 
     _last_completed_lease: str | None = field(init=False, default=None)
-    """Name of the most recently completed lease, used to filter trailing
-    status ticks after handle_lease's finally has cleaned up."""
+    """Name of the most recently completed lease. Set by the control-plane loop
+    when it processes LeaseFinished; suppresses trailing leased=true ticks for a
+    lease that has already torn down."""
 
     _pending_lease_status: jumpstarter_pb2.StatusResponse | None = field(init=False, default=None)
-    """Stashed status from a lease reassignment, replayed after handle_lease's
-    finally clears _lease_context so the new lease can be acquired."""
+    """Stashed status from a lease reassignment, replayed by the control-plane
+    loop when it processes LeaseFinished (after the old slot is released) so the
+    new lease can be acquired."""
 
-    _status_replay_tx: MemoryObjectSendStream[jumpstarter_pb2.StatusResponse] | None = field(
+    _control_tx: "MemoryObjectSendStream[jumpstarter_pb2.StatusResponse | LeaseFinished] | None" = field(
         init=False, default=None
     )
-    """Send side of the status channel, used to replay _pending_lease_status
-    back into the status loop after a lease transition."""
+    """Send side of the control-plane channel. handle_lease posts LeaseFinished
+    here to hand its slot back to the loop, and the loop replays
+    _pending_lease_status through it after a lease transition."""
     _lease_context: LeaseContext | None = field(init=False, default=None)
     """Encapsulates all resources associated with the current lease.
 
@@ -1191,44 +1214,31 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                     await listen_tx.aclose()
                     await listen_rx.aclose()
         finally:
-            # Unblock _on_lease_released even if we no longer own _lease_context
-            # (it may already have snapshot-cleared the exporter field and be
-            # waiting on after_lease_hook_done).
+            # Hand the slot back to the control-plane loop, the sole writer of
+            # _lease_context. This task only sets events on its own LeaseContext
+            # and posts one message; it never clears the slot or replays status
+            # itself, so there is no second writer to race.
             with CancelScope(shield=True):
                 if not lease_scope.before_lease_hook.is_set():
                     lease_scope.before_lease_hook.set()
                 if not lease_scope.after_lease_hook_done.is_set():
                     lease_scope.after_lease_hook_done.set()
-                # Fallback ownership cleanup when _on_lease_released did not run
-                # (cancellation / handle_lease finishing before leased=False).
-                if self._lease_context is lease_scope:
-                    session_was_created = lease_scope.session is not None
-                    if session_was_created:
-                        # Brief delay to ensure session is fully closed before next lease.
-                        # Prevents SSL corruption from overlapping connections.
-                        await sleep(0.2)
-                    self._last_completed_lease = lease_scope.lease_name
-                    self._lease_context = None
-                    if self.exit_on_lease_end:
-                        self._stop_requested = True
-                    clear_log_context()
-                    set_log_context(exporter=self.name)
-                    logger.debug("Ready for next lease")
-                # Replay a stashed reassignment status regardless of who cleared
-                # _lease_context. On the reassign-then-leased=False ordering,
-                # _on_lease_released may clear the field before we reach this finally;
-                # gating the replay on ownership above would drop the pending lease.
-                pending = self._pending_lease_status
-                if pending is not None:
-                    self._pending_lease_status = None
-                    if self._status_replay_tx is not None:
-                        try:
-                            await self._status_replay_tx.send(pending)
-                        except (anyio.ClosedResourceError, anyio.EndOfStream):
-                            logger.debug(
-                                "Status channel closed, skipping replay for %s",
-                                pending.lease_name,
-                            )
+                # session_for_lease has fully exited by now (gRPC graceful stop
+                # included), so LeaseFinished is the "transport is gone" signal
+                # the loop waits for before releasing the slot. Sent on every
+                # exit path: normal leased=false, reassignment, stale lease, and
+                # cancellation — so the loop always gets its finalize trigger.
+                # send_nowait, not send: this runs shielded during shutdown, and
+                # a blocking send with the loop already gone would hang the task
+                # group forever. The channel is unbounded, so this never blocks.
+                if self._control_tx is not None:
+                    try:
+                        self._control_tx.send_nowait(LeaseFinished(lease_scope))
+                    except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                        logger.debug(
+                            "Control channel closed, slot release for lease %s skipped",
+                            lease_scope.lease_name,
+                        )
 
     async def serve(self):
         """Serve the exporter, handling leases until stopped."""
@@ -1237,7 +1247,17 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         set_log_context(exporter=self.name)
         async with self.session():
             pass
-        status_tx, status_rx = create_memory_object_stream[jumpstarter_pb2.StatusResponse](max_buffer_size=5)
+        # Unbounded on purpose. The control-plane loop is the sole receiver AND,
+        # when it replays a stashed reassignment, a producer. With a bounded
+        # buffer, anyio hands a freed slot straight to a blocked sender on
+        # receive(), so a full buffer plus the loop's own send would deadlock the
+        # consumer, and handle_lease's shielded LeaseFinished send could hang
+        # shutdown. Producers are bounded (live leases + one RPC stream), so an
+        # unbounded buffer costs nothing and removes both hangs. Sends use
+        # send_nowait, which never blocks against math.inf.
+        status_tx, status_rx = create_memory_object_stream[jumpstarter_pb2.StatusResponse | LeaseFinished](
+            max_buffer_size=math.inf
+        )
         try:
             await self._run_control_plane(status_tx, status_rx)
         finally:
@@ -1261,13 +1281,13 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
     async def _run_control_plane(
         self,
-        status_tx: MemoryObjectSendStream[jumpstarter_pb2.StatusResponse],
-        status_rx: MemoryObjectReceiveStream[jumpstarter_pb2.StatusResponse],
+        status_tx: MemoryObjectSendStream[jumpstarter_pb2.StatusResponse | LeaseFinished],
+        status_rx: MemoryObjectReceiveStream[jumpstarter_pb2.StatusResponse | LeaseFinished],
     ) -> None:
         """Start control-plane streams and process status updates."""
         async with create_task_group() as tg:
             self._tg = tg
-            self._status_replay_tx = status_tx
+            self._control_tx = status_tx
             self._status_rpc_event = Event()
             self._pending_status_request = None
             self._status_drain_active = True
@@ -1280,8 +1300,15 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 self._status_stream_factory(),
                 status_tx,
             )
-            async for status in status_rx:
-                if await self._apply_status(status, tg):
+            # One loop, one writer of _lease_context. Status ticks come from the
+            # controller RPC; LeaseFinished comes from handle_lease when it has
+            # torn a lease down. Both are handled here, sequentially.
+            async for message in status_rx:
+                if isinstance(message, LeaseFinished):
+                    if await self._on_lease_finished(message.lease_ctx):
+                        break
+                    continue
+                if await self._apply_status(message, tg):
                     break
 
     async def _apply_status(
@@ -1309,9 +1336,10 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             ):
                 # Controller reassigned the exporter to a different lease.
                 # Stash the new status and signal the old lease to tear down.
-                # handle_lease's finally block replays the stashed status
-                # after clearing _lease_context. The controller won't
-                # re-send it because proto.Equal suppresses duplicates.
+                # The loop replays the stashed status from _on_lease_finished,
+                # once LeaseFinished for the old lease has released the slot. The
+                # controller won't re-send it because proto.Equal suppresses
+                # duplicates.
                 self._pending_lease_status = status
                 if not self._lease_context.lease_ended.is_set():
                     logger.warning(
@@ -1320,11 +1348,17 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                         status.lease_name,
                     )
                     self._lease_context.lease_ended.set()
+                    tg.start_soon(self._lease_finished_watchdog, self._lease_context)
                 return False
 
             self._on_lease_update(status)
         else:
-            await self._on_lease_released(previous_state)
+            await self._on_lease_released(previous_state, tg)
+            if self._lease_context is not None:
+                # A lease is tearing down. The slot is released, and the stop
+                # decision made, when LeaseFinished arrives (_on_lease_finished),
+                # so exit_on_lease_end keeps the runtime up until the hook is done.
+                return False
 
         return self._check_stop_requested() if not current_leased else False
 
@@ -1371,20 +1405,74 @@ class Exporter(AsyncContextManagerMixin, Metadata):
                 set_log_context(client=status.client_name)
         logger.info("Currently leased by %s under %s", status.client_name, status.lease_name)
 
-    async def _on_lease_released(self, previous_state: LeaseState) -> None:
-        """Handle not-leased status: signal handle_lease on transition, check exit_on_lease_end.
+    async def _on_lease_finished(self, lease_ctx: LeaseContext) -> bool:
+        """Release a finished lease's slot. Runs only in the control-plane loop.
 
-        Primary cleanup path: signals lease_ended, waits (shielded) for the
-        afterLease hook, then clears _lease_context. _lease_context is kept set
-        for the whole hook so _report_status still reaches the client session
-        (it gates the session update on _lease_context). The status loop is
-        sequential, so no other ticks are processed while we wait. A brief
-        settle delay runs before clearing so the next lease can't grab this
-        slot before handle_lease finishes tearing down the session.
+        handle_lease posts LeaseFinished from its finally, after session_for_lease
+        has exited (gRPC graceful stop included). Receiving it *is* the
+        "transport is gone" happens-before edge, so there is no timing-based
+        settle to guess at — the old 0.2s sleep it replaced never actually
+        covered that teardown.
 
-        handle_lease's outer finally is the fallback when this path never
-        runs (e.g. task cancellation, or handle_lease finishing before the
-        controller sends leased=False).
+        No ownership re-check is needed: the loop is the sole writer of
+        _lease_context, and it only acquires a replacement by replaying a stashed
+        reassignment at the end of this handler. So when LeaseFinished arrives,
+        the slot is still this lease.
+
+        Returns True if the loop should stop (exit_on_lease_end / requested stop).
+        """
+        if self._lease_context is not lease_ctx:
+            # Defensive: with the loop as sole writer, only reacquiring a
+            # replacement after releasing the slot, this should not happen —
+            # LeaseFinished for a lease that still owns the slot is the only
+            # reachable case. Kept as a guard so a future second writer can't
+            # silently wipe an unrelated lease.
+            logger.debug("Lease %s not the current slot owner, ignoring LeaseFinished", lease_ctx.lease_name)
+            return self._check_stop_requested()
+
+        self._last_completed_lease = lease_ctx.lease_name
+        self._lease_context = None
+        if self.exit_on_lease_end:
+            # _on_lease_released sets this on the leased=false tick; setting it
+            # here too covers exit paths that never saw that tick (cancellation,
+            # stale lease, handle_lease finishing first).
+            self._stop_requested = True
+        # structlog contextvars live in this (loop) task, so clearing here is
+        # what actually drops the lease's log fields — a clear in handle_lease's
+        # task would not reach the loop.
+        clear_log_context()
+        set_log_context(exporter=self.name)
+        logger.debug("Ready for next lease")
+
+        # Now that the slot is free, replay a stashed reassignment so the loop
+        # acquires the new lease on the next iteration.
+        pending = self._pending_lease_status
+        if pending is not None:
+            self._pending_lease_status = None
+            if self._control_tx is not None:
+                try:
+                    # send_nowait, not send: this is the loop sending into the
+                    # channel it is the sole receiver of. A blocking send here
+                    # would deadlock — nothing else drains it. The channel is
+                    # unbounded, so this always succeeds unless it is closed.
+                    self._control_tx.send_nowait(pending)
+                except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                    logger.debug("Control channel closed, skipping replay for %s", pending.lease_name)
+
+        return self._check_stop_requested()
+
+    async def _on_lease_released(self, previous_state: LeaseState, tg: TaskGroup) -> None:
+        """Handle a not-leased status tick: signal the lease to tear down.
+
+        This does not block or clear _lease_context. It only sets lease_ended,
+        which handle_lease is waiting on to run the afterLease hook and tear the
+        session down. handle_lease then posts LeaseFinished, and the loop
+        releases the slot in _on_lease_finished. Keeping the slot set until then
+        is what lets _report_status still reach the client session while the
+        afterLease hook runs (it gates its session update on _lease_context).
+
+        Not blocking here is the point: the loop stays responsive during Ending,
+        and slot release happens on the LeaseFinished message, not inline.
         """
         logger.info("Currently not leased")
 
@@ -1393,33 +1481,38 @@ class Exporter(AsyncContextManagerMixin, Metadata):
             if self.exit_on_lease_end:
                 # Refuse new leases immediately, but keep the runtime up until
                 # afterLease finishes — shutdown SIGTERMs Exec children (QEMU)
-                # that hooks may still be talking to.
+                # that hooks may still be talking to. The loop breaks only once
+                # LeaseFinished arrives (see _on_lease_finished), so the hook has
+                # completed by the time serve()'s finally runs the shutdown.
                 self._stop_requested = True
 
-            logger.info("Lease ended, signaling handle_lease to run afterLease hook")
-            lease_ctx.lease_ended.set()
+            if not lease_ctx.lease_ended.is_set():
+                logger.info("Lease ended, signaling handle_lease to run afterLease hook")
+                lease_ctx.lease_ended.set()
+                # Diagnostic only: the loop waits for LeaseFinished with no
+                # timeout, so a wedged handle_lease would park the exporter in
+                # Ending forever (still reporting leased). Warn if that happens;
+                # never release the slot on a timer.
+                tg.start_soon(self._lease_finished_watchdog, lease_ctx)
 
-            # Keep _lease_context set while the afterLease hook runs. _report_status
-            # gates its session/client update on _lease_context, so clearing it here
-            # would silently drop status updates the hook emits (they would reach the
-            # controller RPC but never the client). Clear only after the hook is done.
-            with CancelScope(shield=True):
-                await lease_ctx.after_lease_hook_done.wait()
-            logger.info("afterLease hook completed")
+    async def _lease_finished_watchdog(self, lease_ctx: LeaseContext) -> None:
+        """Warn if a lease stays in Ending too long waiting for LeaseFinished.
 
-            if lease_ctx.session is not None:
-                # Brief delay to ensure session is fully closed before next lease.
-                # Prevents SSL corruption from overlapping connections.
-                await sleep(0.2)
-
-            self._last_completed_lease = lease_ctx.lease_name
-            self._lease_context = None
-            clear_log_context()
-            set_log_context(exporter=self.name)
-            # exit_on_lease_end shutdown runs once, in serve()'s finally, after
-            # the control-plane loop unwinds. _stop_requested (set above) is
-            # what drives that unwind, so the hook is already done by the time
-            # it fires there — no need to call shutdown_runtime_sidecar here too.
+        Spawned when lease_ended is set. The loop releases the slot only on
+        LeaseFinished, with no timeout — the right behavior, since it is a real
+        happens-before edge rather than a guess. But a handle_lease that never
+        posts (e.g. wedged teardown) would leave the exporter reporting leased
+        while serving nothing, invisible from outside. This logs once so the
+        stall is diagnosable; it never touches _lease_context.
+        """
+        await anyio.sleep(_LEASE_FINISHED_WATCHDOG)
+        if self._lease_context is lease_ctx:
+            logger.warning(
+                "Lease %s ended %ss ago but handle_lease has not posted LeaseFinished; "
+                "exporter is stuck in Ending and still reporting leased",
+                lease_ctx.lease_name,
+                _LEASE_FINISHED_WATCHDOG,
+            )
 
     def _check_stop_requested(self) -> bool:
         """Check if stop was requested and initiate shutdown. Returns True to break the status loop."""

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -21,6 +21,7 @@ from jumpstarter.exporter.exporter import (
     _RPC_BACKOFF_CAP,
     _RPC_MAX_RETRIES,
     _RPC_TIMEOUT,
+    LeaseFinished,
     LeaseState,
 )
 from jumpstarter.exporter.lease_context import LeaseContext
@@ -65,7 +66,7 @@ def _make_base_exporter(**overrides):
         "labels": {"jumpstarter.dev/name": "test-exporter"},
         "_last_completed_lease": None,
         "_pending_lease_status": None,
-        "_status_replay_tx": None,
+        "_control_tx": None,
         "_status_drain_active": False,
         "_pending_status_request": None,
         "_status_rpc_event": Event(),
@@ -1303,9 +1304,11 @@ class TestApplyStatus:
             await exporter._apply_status(status, tg)
             tg.cancel_scope.cancel()
 
+        # _on_lease_released only signals teardown; the loop keeps the slot
+        # until handle_lease posts LeaseFinished (_on_lease_finished clears it).
         assert lease_ctx.lease_ended.is_set()
-        assert exporter._lease_context is None
-        assert exporter._last_completed_lease == "ending-lease"
+        assert exporter._lease_context is lease_ctx
+        assert exporter._last_completed_lease is None
 
     async def test_trailing_tick_for_completed_lease_ignored(self):
         """After handle_lease completes, a trailing leased=true tick for the same lease is skipped."""
@@ -1485,93 +1488,156 @@ class TestHandleLeaseConnections:
         assert lease_ctx.before_lease_hook.is_set()
         exporter._cleanup_after_lease.assert_awaited_once()
 
-    async def test_handle_lease_finally_clears_lease_context(self):
-        """handle_lease finally block clears _lease_context when it matches lease_scope."""
+    async def test_handle_lease_finally_posts_lease_finished(self):
+        """handle_lease's finally posts LeaseFinished and leaves the slot alone.
 
+        The control-plane loop is the sole writer of _lease_context; handle_lease
+        hands the slot back via the message rather than clearing it itself."""
         lease_ctx = make_lease_context(lease_name="cleanup-lease")
         exporter = make_exporter(lease_ctx)
-        exporter.labels = {"jumpstarter.dev/name": "test-exporter"}
-
         exporter._skip_stale_lease = AsyncMock(return_value=True)
+        status_tx, status_rx = create_memory_object_stream(max_buffer_size=1)
+        exporter._control_tx = status_tx
 
         async with create_task_group() as tg:
             await exporter.handle_lease("cleanup-lease", tg, lease_ctx)
 
-        assert exporter._lease_context is None
-        assert exporter._last_completed_lease == "cleanup-lease"
+        msg = status_rx.receive_nowait()
+        assert isinstance(msg, LeaseFinished)
+        assert msg.lease_ctx is lease_ctx
+        assert exporter._lease_context is lease_ctx  # handle_lease never clears it
         assert lease_ctx.after_lease_hook_done.is_set()
-
-    async def test_handle_lease_finally_sets_stop_when_exit_on_lease_end(self):
-        """Fallback cleanup must set _stop_requested when handle_lease finishes
-        before the controller's leased=False tick reaches _on_lease_released."""
-        lease_ctx = make_lease_context(lease_name="exit-lease")
-        exporter = make_exporter(lease_ctx)
-        exporter.exit_on_lease_end = True
-        exporter._skip_stale_lease = AsyncMock(return_value=True)
-
-        async with create_task_group() as tg:
-            await exporter.handle_lease("exit-lease", tg, lease_ctx)
-
-        assert exporter._stop_requested is True
-
-    async def test_handle_lease_finally_skips_replay_when_status_channel_closed(self):
-        """Shutdown may close the status stream before replay; that must not
-        leak ClosedResourceError out of handle_lease's finally."""
-        lease_ctx = make_lease_context(lease_name="replay-lease")
-        exporter = make_exporter(lease_ctx)
-        pending = MagicMock()
-        pending.lease_name = "lease-B"
-        exporter._pending_lease_status = pending
-        status_tx, status_rx = create_memory_object_stream(max_buffer_size=1)
-        await status_tx.aclose()
-        exporter._status_replay_tx = status_tx
-        exporter._skip_stale_lease = AsyncMock(return_value=True)
-
-        async with create_task_group() as tg:
-            await exporter.handle_lease("replay-lease", tg, lease_ctx)
-
-        assert exporter._pending_lease_status is None
-        assert exporter._lease_context is None
-        await status_rx.aclose()
-
-    async def test_handle_lease_finally_replays_pending_when_context_already_cleared(self):
-        """Reassign-then-leased=False ordering: _on_lease_released can clear
-        _lease_context before handle_lease reaches its finally. The stashed
-        reassignment status must still be replayed so lease B is acquired,
-        even though the ownership guard (_lease_context is lease_scope) is False."""
-        lease_ctx = make_lease_context(lease_name="lease-A")
-        exporter = make_exporter(lease_ctx)
-        # Simulate _on_lease_released having already taken ownership and cleared it.
-        exporter._lease_context = None
-        pending = MagicMock()
-        pending.lease_name = "lease-B"
-        exporter._pending_lease_status = pending
-        status_tx, status_rx = create_memory_object_stream(max_buffer_size=1)
-        exporter._status_replay_tx = status_tx
-        exporter._skip_stale_lease = AsyncMock(return_value=True)
-
-        async with create_task_group() as tg:
-            await exporter.handle_lease("lease-A", tg, lease_ctx)
-
-        assert status_rx.receive_nowait() is pending
-        assert exporter._pending_lease_status is None
         await status_tx.aclose()
         await status_rx.aclose()
 
-    async def test_handle_lease_finally_clears_context_when_cancelled_during_settle(self):
-        """Cancellation during the SSL settle sleep must still clear _lease_context."""
-        lease_ctx = make_lease_context(lease_name="cancel-settle")
+    async def test_handle_lease_posts_lease_finished_even_when_cancelled(self):
+        """The finally is shielded, so cancellation still posts LeaseFinished —
+        the loop's finalize trigger is never lost."""
+        lease_ctx = make_lease_context(lease_name="cancel-lease")
         exporter = make_exporter(lease_ctx)
         exporter._skip_stale_lease = AsyncMock(return_value=True)
+        status_tx, status_rx = create_memory_object_stream(max_buffer_size=1)
+        exporter._control_tx = status_tx
 
         with fail_after(5):
             async with create_task_group() as tg:
-                tg.start_soon(exporter.handle_lease, "cancel-settle", tg, lease_ctx)
+                tg.start_soon(exporter.handle_lease, "cancel-lease", tg, lease_ctx)
                 await anyio.sleep(0)
                 tg.cancel_scope.cancel()
 
+        msg = status_rx.receive_nowait()
+        assert isinstance(msg, LeaseFinished)
+        assert msg.lease_ctx is lease_ctx
+        await status_tx.aclose()
+        await status_rx.aclose()
+
+    async def test_on_lease_finished_clears_slot(self):
+        """The loop's LeaseFinished handler releases the slot and records the
+        completed lease name."""
+        owner_ctx = make_lease_context(lease_name="lease-A")
+        exporter = make_exporter(owner_ctx)
+
+        stop = await exporter._on_lease_finished(owner_ctx)
+
+        assert stop is False
         assert exporter._lease_context is None
-        assert exporter._last_completed_lease == "cancel-settle"
+        assert exporter._last_completed_lease == "lease-A"
+
+    async def test_on_lease_finished_noop_when_slot_not_owned(self, caplog):
+        """LeaseFinished for a context that no longer owns the slot is a no-op.
+
+        Because the loop is the only writer, this only happens for a lease that
+        never took the slot; it must not wipe whoever owns it now, and it must
+        not warn — there is no race to report."""
+        ctx_a = make_lease_context(lease_name="lease-A")
+        ctx_b = make_lease_context(lease_name="lease-B")
+        exporter = make_exporter(ctx_b)
+        with caplog.at_level(logging.WARNING, logger="jumpstarter.exporter.exporter"):
+            stop = await exporter._on_lease_finished(ctx_a)
+        assert stop is False
+        assert exporter._lease_context is ctx_b
+        assert exporter._last_completed_lease is None
+        assert caplog.text == ""
+
+    async def test_on_lease_finished_sets_stop_when_exit_on_lease_end(self):
+        """Fallback: if the leased=false tick never reached _on_lease_released
+        (cancellation / stale lease), the loop still sets _stop_requested when it
+        releases the slot."""
+        lease_ctx = make_lease_context(lease_name="exit-lease")
+        exporter = make_exporter(lease_ctx)
+        exporter.exit_on_lease_end = True
+
+        stop = await exporter._on_lease_finished(lease_ctx)
+
+        assert stop is True
+        assert exporter._stop_requested is True
+        assert exporter._lease_context is None
+
+    async def test_on_lease_finished_replays_pending_reassignment(self):
+        """After releasing the slot, the loop replays a stashed reassignment so
+        the next lease is acquired on the following iteration."""
+        lease_ctx = make_lease_context(lease_name="lease-A")
+        exporter = make_exporter(lease_ctx)
+        pending = MagicMock()
+        pending.lease_name = "lease-B"
+        exporter._pending_lease_status = pending
+        status_tx, status_rx = create_memory_object_stream(max_buffer_size=1)
+        exporter._control_tx = status_tx
+
+        await exporter._on_lease_finished(lease_ctx)
+
+        assert status_rx.receive_nowait() is pending
+        assert exporter._pending_lease_status is None
+        assert exporter._lease_context is None
+        await status_tx.aclose()
+        await status_rx.aclose()
+
+    async def test_on_lease_finished_ignores_closed_control_channel(self):
+        """Shutdown may close the control channel before the replay send; that
+        must not leak ClosedResourceError out of the loop."""
+        lease_ctx = make_lease_context(lease_name="lease-A")
+        exporter = make_exporter(lease_ctx)
+        pending = MagicMock()
+        pending.lease_name = "lease-B"
+        exporter._pending_lease_status = pending
+        status_tx, status_rx = create_memory_object_stream(max_buffer_size=1)
+        await status_tx.aclose()
+        exporter._control_tx = status_tx
+
+        await exporter._on_lease_finished(lease_ctx)  # must not raise
+
+        assert exporter._pending_lease_status is None
+        assert exporter._lease_context is None
+        await status_rx.aclose()
+
+    async def test_completed_lease_suppresses_trailing_status(self):
+        """Once the loop has finalized a lease, a trailing leased=true tick for
+        the same name is dropped instead of spawning a dead handle_lease."""
+        lease_ctx = make_lease_context(lease_name="lease-A")
+        exporter = make_exporter(lease_ctx)
+        await exporter._on_lease_finished(lease_ctx)
+        assert exporter._last_completed_lease == "lease-A"
+
+        spawned = []
+
+        async def fake_handle_lease(lease_name, tg, lease_scope):
+            spawned.append(lease_name)
+
+        exporter.handle_lease = fake_handle_lease
+        exporter._started = True
+
+        status = MagicMock()
+        status.leased = True
+        status.lease_name = "lease-A"
+        status.client_name = "test-client"
+        status.context = {}
+
+        async with create_task_group() as tg:
+            await exporter._apply_status(status, tg)
+            tg.cancel_scope.cancel()
+
+        assert spawned == []
+        assert exporter._lease_context is None
 
     async def test_handle_lease_closes_listen_streams_when_stale_during_setup(self):
         """Stale-lease return during session setup must close the Listen streams."""
@@ -1674,10 +1740,19 @@ def _wire_status_stream(exporter, statuses, sent: Event | None = None):
 
 
 def _wire_handle_lease(exporter):
-    """Replace handle_lease with a minimal mock that satisfies lifecycle events."""
+    """Replace handle_lease with a minimal mock that satisfies lifecycle events.
+
+    Mirrors the real ordering: afterLease hook completes, session teardown
+    finishes, then handle_lease's finally posts LeaseFinished so the
+    control-plane loop releases the slot."""
+    from jumpstarter.exporter.exporter import LeaseFinished
+
     async def fake_handle_lease(lease_name, tg, lease_ctx):
         await lease_ctx.lease_ended.wait()
         lease_ctx.after_lease_hook_done.set()
+        await anyio.sleep(0)
+        if exporter._control_tx is not None:
+            await exporter._control_tx.send(LeaseFinished(lease_ctx))
 
     exporter.handle_lease = fake_handle_lease
 
@@ -1878,29 +1953,23 @@ class TestShutdownRuntimeSidecar:
             assert shutdown_runtime_sidecar(binary=str(binary)) is False
 
 
-class TestOnLeaseReleasedClearsContext:
-    """_on_lease_released keeps _lease_context set while the afterLease hook
-    runs (so _report_status still reaches the client session) and clears it
-    afterwards, so the next status tick sees IDLE and a new lease is acquired."""
+class TestOnLeaseReleased:
+    """_on_lease_released reacts to a leased=false tick without touching the
+    slot: it flags lease_ended (and, under exit_on_lease_end, _stop_requested)
+    and returns immediately. The slot is released later by the loop when the
+    matching LeaseFinished arrives — see the TestHandleLeaseFinally /
+    _on_lease_finished tests for the release half of the handshake."""
 
-    async def test_context_kept_until_after_lease_hook_completes(self):
-        """_report_status gates the session/client update on _lease_context, so
-        the field must stay set while the afterLease hook runs — otherwise hook
-        status updates reach the controller RPC but never the client. It is
-        cleared only once the hook signals after_lease_hook_done."""
+    async def test_signals_lease_ended_without_clearing_slot(self):
+        """A leased=false tick flags the lease as ended so handle_lease can run
+        its afterLease hook, but must NOT clear _lease_context. The loop keeps
+        the slot (so _report_status still reaches the client session during the
+        hook) until handle_lease posts LeaseFinished."""
         exporter = _make_serve_exporter()
         lease_ctx = make_lease_context(lease_name="lease-A")
         exporter._lease_context = lease_ctx
         exporter._started = True
 
-        context_set_during_hook = []
-
-        async def finish_hook():
-            # Stands in for the afterLease hook body: _lease_context must still
-            # point at this lease so _report_status can reach the session.
-            context_set_during_hook.append(exporter._lease_context is lease_ctx)
-            lease_ctx.after_lease_hook_done.set()
-
         status = MagicMock()
         status.leased = False
         status.lease_name = ""
@@ -1908,39 +1977,41 @@ class TestOnLeaseReleasedClearsContext:
         status.context = {}
 
         async with create_task_group() as tg:
-            tg.start_soon(finish_hook)
-            await exporter._apply_status(status, tg)
+            result = await exporter._apply_status(status, tg)
             tg.cancel_scope.cancel()
 
-        assert context_set_during_hook == [True]
-        assert exporter._lease_context is None
-        assert exporter._last_completed_lease == "lease-A"
-
-    async def test_clears_context_and_sets_last_completed(self):
-        exporter = _make_serve_exporter()
-        lease_ctx = make_lease_context(lease_name="lease-A")
-        lease_ctx.after_lease_hook_done.set()
-        exporter._lease_context = lease_ctx
-
-        status = MagicMock()
-        status.leased = False
-        status.lease_name = ""
-        status.client_name = ""
-        status.context = {}
-
-        async with create_task_group() as tg:
-            await exporter._apply_status(status, tg)
-            tg.cancel_scope.cancel()
-
-        assert exporter._lease_context is None
-        assert exporter._last_completed_lease == "lease-A"
+        assert result is False  # loop keeps running until LeaseFinished arrives
         assert lease_ctx.lease_ended.is_set()
+        assert exporter._lease_context is lease_ctx
+        assert exporter._last_completed_lease is None
 
-    async def test_on_lease_released_delegates_shutdown_to_serve(self):
-        """exit_on_lease_end sets _stop_requested immediately but does not call
-        shutdown_runtime_sidecar itself; serve()'s finally is the single
-        authoritative call site, reached only after this coroutine returns
-        (which requires the afterLease hook to have completed)."""
+    async def test_exit_on_lease_end_sets_stop_immediately(self):
+        """Refuse new leases the moment the lease ends — do not wait for the
+        afterLease hook or session teardown. The slot is still held until
+        LeaseFinished so serve()'s shutdown runs only after the hook completes."""
+        exporter = _make_serve_exporter(exit_on_lease_end=True)
+        lease_ctx = make_lease_context(lease_name="ending-lease")
+        exporter._lease_context = lease_ctx
+        exporter._started = True
+
+        status = MagicMock()
+        status.leased = False
+        status.lease_name = ""
+        status.client_name = ""
+        status.context = {}
+
+        async with create_task_group() as tg:
+            result = await exporter._apply_status(status, tg)
+            tg.cancel_scope.cancel()
+
+        assert exporter._stop_requested is True
+        assert result is False  # do not break the loop before LeaseFinished
+        assert exporter._lease_context is lease_ctx
+
+    async def test_does_not_call_shutdown_itself(self):
+        """exit_on_lease_end flips _stop_requested but must not call
+        shutdown_runtime_sidecar; serve()'s finally is the single authoritative
+        call site, reached only after handle_lease's afterLease hook completes."""
         exporter = _make_serve_exporter(exit_on_lease_end=True)
         lease_ctx = make_lease_context(lease_name="ending-lease")
         exporter._lease_context = lease_ctx
@@ -1955,20 +2026,84 @@ class TestOnLeaseReleasedClearsContext:
         shutdown_calls = []
 
         def tracking_shutdown(*_args, **_kwargs):
-            shutdown_calls.append(lease_ctx.after_lease_hook_done.is_set())
-
-        async def finish_hook():
-            await anyio.sleep(0.05)
-            lease_ctx.after_lease_hook_done.set()
+            shutdown_calls.append(True)
 
         with patch("jumpstarter.exporter.exporter.shutdown_runtime_sidecar", tracking_shutdown):
             async with create_task_group() as tg:
-                tg.start_soon(finish_hook)
                 await exporter._apply_status(status, tg)
                 tg.cancel_scope.cancel()
 
         assert shutdown_calls == []
         assert exporter._stop_requested is True
+
+    async def test_spawns_watchdog_on_lease_end(self):
+        """A leased=false tick starts the LeaseFinished watchdog so a wedged
+        teardown is eventually logged."""
+        exporter = _make_serve_exporter()
+        lease_ctx = make_lease_context(lease_name="lease-A")
+        exporter._lease_context = lease_ctx
+        exporter._started = True
+
+        spawned = []
+
+        async def tracking_watchdog(ctx):
+            spawned.append(ctx)
+
+        exporter._lease_finished_watchdog = tracking_watchdog
+
+        status = MagicMock()
+        status.leased = False
+        status.lease_name = ""
+        status.client_name = ""
+        status.context = {}
+
+        async with create_task_group() as tg:
+            await exporter._apply_status(status, tg)
+            await anyio.sleep(0)
+            tg.cancel_scope.cancel()
+
+        assert spawned == [lease_ctx]
+
+
+class TestLeaseFinishedWatchdog:
+    """The watchdog only logs a stuck Ending state; it never releases the slot,
+    so the loop's no-timeout wait for LeaseFinished stays a real happens-before
+    edge rather than a disguised timer."""
+
+    async def test_warns_when_teardown_stalls(self, caplog):
+        """If LeaseFinished never arrives, the watchdog logs once and leaves the
+        slot untouched."""
+        exporter = _make_serve_exporter()
+        lease_ctx = make_lease_context(lease_name="wedged")
+        exporter._lease_context = lease_ctx
+
+        with (
+            caplog.at_level(logging.WARNING, logger="jumpstarter.exporter.exporter"),
+            patch("jumpstarter.exporter.exporter._LEASE_FINISHED_WATCHDOG", 0.01),
+        ):
+            await exporter._lease_finished_watchdog(lease_ctx)
+
+        assert "stuck in Ending" in caplog.text
+        assert "wedged" in caplog.text
+        assert exporter._lease_context is lease_ctx  # never released by the watchdog
+
+    async def test_silent_after_lease_finished(self, caplog):
+        """Once _on_lease_finished has released the slot, the watchdog stays
+        quiet when it wakes."""
+        exporter = _make_serve_exporter()
+        lease_ctx = make_lease_context(lease_name="clean")
+        exporter._lease_context = lease_ctx
+
+        with (
+            caplog.at_level(logging.WARNING, logger="jumpstarter.exporter.exporter"),
+            patch("jumpstarter.exporter.exporter._LEASE_FINISHED_WATCHDOG", 0.05),
+        ):
+            async with create_task_group() as tg:
+                tg.start_soon(exporter._lease_finished_watchdog, lease_ctx)
+                await exporter._on_lease_finished(lease_ctx)
+
+        assert exporter._lease_context is None
+        assert caplog.text == ""
 
 
 class TestContextPropagation:


### PR DESCRIPTION
#948 moved `await sleep(0.2)`
1. _on_lease_released finishes its own sleep, clears, returns
2. status loop acquires lease-B
3. A’s finally wakes and sets _lease_context = None
4. B’s handle_lease is now running with IDLE state: LeaseReady, empty leaseRef. 

This PR switches to a single control-plane writer for the lease's slot:
<img width="1472" height="920" alt="image" src="https://github.com/user-attachments/assets/44a38800-69df-45c5-a340-e9c7c597cb4a" />


fixes https://github.com/jumpstarter-dev/jumpstarter/issues/1024