### PR TITLE
fix: OCI creds weren't properly passed to exporter

### DIFF
--- a/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/client.py
+++ b/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/client.py
@@ -23,8 +23,13 @@ class QemuFlasherClient(FlasherClient):
         compression: Compression | None = None,
     ):
         if isinstance(path, str) and path.startswith("oci://"):
+            from jumpstarter.common.oci import resolve_oci_credentials
+
+            creds = resolve_oci_credentials(path)
             returncode = 0
-            for stdout, stderr, code in self.streamingcall("flash_oci", path, target):
+            for stdout, stderr, code in self.streamingcall(
+                "flash_oci", path, target, creds.username, creds.plain_password
+            ):
                 if stdout:
                     print(stdout, end="", flush=True)
                 if stderr:

--- a/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/client_test.py
+++ b/python/packages/jumpstarter-driver-qemu/jumpstarter_driver_qemu/client_test.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from jumpstarter_driver_qemu.driver import Qemu
+
+from jumpstarter.common.oci import OciCredentials
+from jumpstarter.common.utils import serve
+
+
+@pytest.fixture
+def qemu_client():
+    """Serve a QEMU driver and yield the composite client for client-side tests."""
+    with serve(Qemu()) as client:
+        yield client
+
+
+def test_flash_oci_forwards_authenticated_credentials(qemu_client):
+    """The client must resolve OCI creds locally and forward them to the exporter's
+       flash_oci call.
+    """
+    creds = OciCredentials(username="myuser", password=SecretStr("mypass"))
+    with patch("jumpstarter.common.oci.resolve_oci_credentials", return_value=creds):
+        with patch.object(qemu_client.flasher, "streamingcall", return_value=iter([])) as mock_sc:
+            qemu_client.flasher.flash("oci://quay.io/private/image:tag")
+
+    mock_sc.assert_called_once()
+    args = mock_sc.call_args.args
+    assert args[0] == "flash_oci"
+    assert args[1] == "oci://quay.io/private/image:tag"
+    # flash_oci signature: (oci_url, partition, oci_username, oci_password)
+    assert args[3] == "myuser"
+    assert args[4] == "mypass"
+
+
+def test_flash_oci_forwards_none_when_unauthenticated(qemu_client):
+    """Without client-side creds, forward None/None so the exporter falls back
+    to its own env/auth-file resolution (backward compatible)."""
+    with patch("jumpstarter.common.oci.resolve_oci_credentials", return_value=OciCredentials()):
+        with patch.object(qemu_client.flasher, "streamingcall", return_value=iter([])) as mock_sc:
+            qemu_client.flasher.flash("oci://quay.io/public/image:tag")
+
+    mock_sc.assert_called_once()
+    args = mock_sc.call_args.args
+    assert args[0] == "flash_oci"
+    assert args[3] is None
+    assert args[4] is None


### PR DESCRIPTION
When a qemu client set OCI creds they weren't passed to the driver, leading to authentication failure.

Properly resolve and pass them onto the driver