### PR TITLE
fix(cli): send logs to stderr so -o json output stays parseable

### DIFF
--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -53,6 +53,25 @@ def _detach_stdout_handlers(root: logging.Logger) -> None:
             root.removeHandler(handler)
 
 
+class _CliLogHandler(RichHandler):
+    """The handler the CLI installs, tagged so it is only ever added once."""
+
+
+def _ensure_cli_handler(root: logging.Logger) -> None:
+    """Attach the CLI's stderr handler if it is not already there.
+
+    logging.basicConfig would do this, but only when the root logger has no
+    handlers at all. A handler left by whatever embedded the CLI would
+    therefore mean no output on stderr and no log level applied either, which
+    is a confusing way for --log-level to do nothing.
+    """
+    if any(isinstance(handler, _CliLogHandler) for handler in root.handlers):
+        return
+    handler = _CliLogHandler(console=Console(stderr=True), show_path=False)
+    handler.setFormatter(SourcePrefixFormatter())
+    root.addHandler(handler)
+
+
 def _opt_log_level_callback(ctx, param, value):
     traceback.install()
     # there is no way to determine if the command is invoked for jmp run or something else at this
@@ -66,15 +85,10 @@ def _opt_log_level_callback(ctx, param, value):
     else:
         # Logs go to stderr so they never interleave with the machine-readable
         # payload that -o json/yaml writes to stdout.
-        _detach_stdout_handlers(logging.getLogger())
-        handler = RichHandler(console=Console(stderr=True), show_path=False)
-        handler.setFormatter(SourcePrefixFormatter())
-        basicConfig = partial(logging.basicConfig, handlers=[handler])
-
-        if value:
-            basicConfig(level=value.upper())
-        else:
-            basicConfig(level=logging.INFO)
+        root = logging.getLogger()
+        _detach_stdout_handlers(root)
+        _ensure_cli_handler(root)
+        root.setLevel(value.upper() if value else logging.INFO)
 
 
 opt_log_level = click.option(

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -5,6 +5,7 @@ from typing import Literal, Optional
 
 import click
 from rich import traceback
+from rich.console import Console
 from rich.logging import RichHandler
 
 
@@ -39,7 +40,9 @@ def _opt_log_level_callback(ctx, param, value):
         level = logging.getLevelName(value.upper()) if value else logging.INFO
         setup_logging(component="exporter", log_format=_log_format_value, level=level)
     else:
-        handler = RichHandler(show_path=False)
+        # Logs go to stderr so they never interleave with the machine-readable
+        # payload that -o json/yaml writes to stdout.
+        handler = RichHandler(console=Console(stderr=True), show_path=False)
         handler.setFormatter(SourcePrefixFormatter())
         basicConfig = partial(logging.basicConfig, handlers=[handler])
 

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -153,7 +153,8 @@ opt_insecure_tls_config = opt_insecure_tls
 def confirm_insecure_tls(insecure_tls: bool, nointeractive: bool):
     if nointeractive is False and insecure_tls:
         if not click.confirm(
-            "Insecure TLS mode is enabled. Certificate verification will be disabled for HTTPS connections. Continue?"
+            "Insecure TLS mode is enabled. Certificate verification will be"
+            " disabled for HTTPS connections. Continue?"
         ):
             click.echo("Aborting.")
             raise click.Abort()
@@ -211,7 +212,11 @@ opt_nointeractive = click.option(
 
 def _normalize_tokens(items: list[str], normalize_case: bool) -> list[str]:
     """Extract and normalize tokens from comma-separated values."""
-    tokens = (token.strip().lower() if normalize_case else token.strip() for item in items for token in item.split(","))
+    tokens = (
+        token.strip().lower() if normalize_case else token.strip()
+        for item in items
+        for token in item.split(',')
+    )
     return [token for token in tokens if token]
 
 
@@ -226,7 +231,9 @@ def _validate_tokens(tokens: list[str], allowed_values: set[str], ctx, param) ->
     if invalid:
         allowed_list = ", ".join(sorted(allowed_values))
         raise click.BadParameter(
-            f"Invalid value(s) {invalid}. Allowed values are: {allowed_list}", ctx=ctx, param=param
+            f"Invalid value(s) {invalid}. Allowed values are: {allowed_list}",
+            ctx=ctx,
+            param=param
         )
 
 
@@ -235,7 +242,7 @@ def parse_comma_separated(
     param: click.Parameter | None,
     value: str | tuple[str, ...] | None,
     allowed_values: set[str] | None = None,
-    normalize_case: bool = True,
+    normalize_case: bool = True
 ) -> list[str]:
     """Generic comma-separated value parser with validation and normalization.
 
@@ -274,7 +281,10 @@ def parse_comma_separated(
 
 
 def opt_comma_separated(
-    name: str, allowed_values: set[str] | None = None, normalize_case: bool = True, help_text: str | None = None
+    name: str,
+    allowed_values: set[str] | None = None,
+    normalize_case: bool = True,
+    help_text: str | None = None
 ):
     """Create a click option for comma-separated values with optional validation.
 
@@ -299,4 +309,10 @@ def opt_comma_separated(
         else:
             help_text = "Comma-separated values (comma-separated or repeated)"
 
-    return click.option(f"--{name}", f"{name}_options", callback=callback, multiple=True, help=help_text)
+    return click.option(
+        f"--{name}",
+        f"{name}_options",
+        callback=callback,
+        multiple=True,
+        help=help_text
+    )

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -29,6 +29,30 @@ class SourcePrefixFormatter(logging.Formatter):
         return super().format(record)
 
 
+def _handler_stream(handler: logging.Handler):
+    """The stream a handler writes to, or None when it cannot be determined."""
+    stream = getattr(handler, "stream", None)
+    if stream is not None:
+        return stream
+    # RichHandler writes through a Console rather than holding a stream.
+    console = getattr(handler, "console", None)
+    return getattr(console, "file", None)
+
+
+def _detach_stdout_handlers(root: logging.Logger) -> None:
+    """Remove root handlers that write to stdout.
+
+    basicConfig does nothing at all when the root logger already has handlers,
+    so configuring ours is not enough: a handler installed before the CLI ran
+    would keep writing log lines into the payload that -o json/yaml puts on
+    stdout. Only stdout writers are detached — anything else on the root
+    logger belongs to whoever put it there.
+    """
+    for handler in list(root.handlers):
+        if _handler_stream(handler) is sys.stdout:
+            root.removeHandler(handler)
+
+
 def _opt_log_level_callback(ctx, param, value):
     traceback.install()
     # there is no way to determine if the command is invoked for jmp run or something else at this
@@ -42,6 +66,7 @@ def _opt_log_level_callback(ctx, param, value):
     else:
         # Logs go to stderr so they never interleave with the machine-readable
         # payload that -o json/yaml writes to stdout.
+        _detach_stdout_handlers(logging.getLogger())
         handler = RichHandler(console=Console(stderr=True), show_path=False)
         handler.setFormatter(SourcePrefixFormatter())
         basicConfig = partial(logging.basicConfig, handlers=[handler])
@@ -128,8 +153,7 @@ opt_insecure_tls_config = opt_insecure_tls
 def confirm_insecure_tls(insecure_tls: bool, nointeractive: bool):
     if nointeractive is False and insecure_tls:
         if not click.confirm(
-            "Insecure TLS mode is enabled. Certificate verification will be"
-            " disabled for HTTPS connections. Continue?"
+            "Insecure TLS mode is enabled. Certificate verification will be disabled for HTTPS connections. Continue?"
         ):
             click.echo("Aborting.")
             raise click.Abort()
@@ -187,11 +211,7 @@ opt_nointeractive = click.option(
 
 def _normalize_tokens(items: list[str], normalize_case: bool) -> list[str]:
     """Extract and normalize tokens from comma-separated values."""
-    tokens = (
-        token.strip().lower() if normalize_case else token.strip()
-        for item in items
-        for token in item.split(',')
-    )
+    tokens = (token.strip().lower() if normalize_case else token.strip() for item in items for token in item.split(","))
     return [token for token in tokens if token]
 
 
@@ -206,9 +226,7 @@ def _validate_tokens(tokens: list[str], allowed_values: set[str], ctx, param) ->
     if invalid:
         allowed_list = ", ".join(sorted(allowed_values))
         raise click.BadParameter(
-            f"Invalid value(s) {invalid}. Allowed values are: {allowed_list}",
-            ctx=ctx,
-            param=param
+            f"Invalid value(s) {invalid}. Allowed values are: {allowed_list}", ctx=ctx, param=param
         )
 
 
@@ -217,7 +235,7 @@ def parse_comma_separated(
     param: click.Parameter | None,
     value: str | tuple[str, ...] | None,
     allowed_values: set[str] | None = None,
-    normalize_case: bool = True
+    normalize_case: bool = True,
 ) -> list[str]:
     """Generic comma-separated value parser with validation and normalization.
 
@@ -256,10 +274,7 @@ def parse_comma_separated(
 
 
 def opt_comma_separated(
-    name: str,
-    allowed_values: set[str] | None = None,
-    normalize_case: bool = True,
-    help_text: str | None = None
+    name: str, allowed_values: set[str] | None = None, normalize_case: bool = True, help_text: str | None = None
 ):
     """Create a click option for comma-separated values with optional validation.
 
@@ -284,10 +299,4 @@ def opt_comma_separated(
         else:
             help_text = "Comma-separated values (comma-separated or repeated)"
 
-    return click.option(
-        f"--{name}",
-        f"{name}_options",
-        callback=callback,
-        multiple=True,
-        help=help_text
-    )
+    return click.option(f"--{name}", f"{name}_options", callback=callback, multiple=True, help=help_text)

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
@@ -1,6 +1,8 @@
 """Tests for opt.py utilities."""
 
+import io
 import logging
+import sys
 
 import click
 import pytest
@@ -141,7 +143,7 @@ class TestLogHandlerStream:
         """Logs must not corrupt the JSON/YAML payload written to stdout.
 
         `-o json` consumers (IDE integrations, CI) parse stdout; a log line
-        interleaved there makes the output unparseable.
+        interleaved there leaves the output impossible to parse.
         """
         root = logging.getLogger()
         saved_handlers, saved_level = root.handlers[:], root.level
@@ -158,3 +160,46 @@ class TestLogHandlerStream:
 
         assert "Lease acquired" in captured.err
         assert captured.out == ""
+
+    def test_logs_stay_off_stdout_when_a_handler_is_already_installed(self, capsys) -> None:
+        """A root handler installed before the CLI ran must not keep stdout.
+
+        logging.basicConfig does nothing when the root logger already has
+        handlers, so simply configuring a stderr handler is not enough: the
+        pre-existing one would go on writing into the -o json payload.
+        """
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        root.handlers.clear()
+        # Something configured logging before us, pointing at stdout.
+        root.addHandler(logging.StreamHandler(sys.stdout))
+        try:
+            _opt_log_level_callback(None, None, "INFO")
+            logging.getLogger("jumpstarter.client.lease").info("Lease acquired successfully!")
+            for handler in root.handlers:
+                handler.flush()
+            captured = capsys.readouterr()
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+        assert captured.out == ""
+        assert "Lease acquired" in captured.err
+
+    def test_unrelated_handlers_are_left_alone(self) -> None:
+        """Only stdout writers are detached; other handlers are not ours to remove.
+
+        pytest's own caplog handler lives on the root logger, and so may a
+        file handler the user configured.
+        """
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        root.handlers.clear()
+        elsewhere = logging.StreamHandler(io.StringIO())
+        root.addHandler(elsewhere)
+        try:
+            _opt_log_level_callback(None, None, "INFO")
+            assert elsewhere in root.handlers
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
@@ -7,6 +7,8 @@ import sys
 import click
 import pytest
 from click.testing import CliRunner
+from rich.console import Console
+from rich.logging import RichHandler
 
 from jumpstarter_cli_common.opt import (
     SourcePrefixFormatter,
@@ -199,6 +201,27 @@ class TestLogHandlerStream:
         root.addHandler(elsewhere)
         try:
             _opt_log_level_callback(None, None, "INFO")
+            assert elsewhere in root.handlers
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+    def test_a_rich_handler_on_stdout_is_detached_too(self) -> None:
+        """RichHandler holds a Console, not a stream, and still writes somewhere.
+
+        The CLI installs one itself, so a second one left pointing at stdout
+        would be the easiest way to reintroduce the corruption.
+        """
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        root.handlers.clear()
+        on_stdout = RichHandler(console=Console(file=sys.stdout))
+        elsewhere = RichHandler(console=Console(file=io.StringIO()))
+        root.addHandler(on_stdout)
+        root.addHandler(elsewhere)
+        try:
+            _opt_log_level_callback(None, None, "INFO")
+            assert on_stdout not in root.handlers
             assert elsewhere in root.handlers
         finally:
             root.handlers[:] = saved_handlers

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
@@ -226,3 +226,47 @@ class TestLogHandlerStream:
         finally:
             root.handlers[:] = saved_handlers
             root.setLevel(saved_level)
+
+    def test_a_surviving_handler_does_not_suppress_the_cli_handler(self, capsys) -> None:
+        """A handler the CLI leaves alone must not cost it its own output.
+
+        basicConfig does nothing when the root logger already has handlers, so
+        relying on it meant an unrelated file handler silenced the CLI's stderr
+        output and left --log-level with no effect at all.
+        """
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        root.handlers.clear()
+        kept = logging.StreamHandler(io.StringIO())
+        root.addHandler(kept)
+        try:
+            _opt_log_level_callback(None, None, "DEBUG")
+            # The handler that was there is still there...
+            assert kept in root.handlers
+            # ...and so is ours, with the level actually applied.
+            assert root.level == logging.DEBUG
+            logging.getLogger("jumpstarter.client.lease").debug("a debug line")
+            for handler in root.handlers:
+                handler.flush()
+            captured = capsys.readouterr()
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+        assert "a debug line" in captured.err
+        assert captured.out == ""
+
+    def test_the_cli_handler_is_not_added_twice(self) -> None:
+        """The callback is eager and can run more than once in one process."""
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        root.handlers.clear()
+        try:
+            _opt_log_level_callback(None, None, "INFO")
+            _opt_log_level_callback(None, None, "DEBUG")
+            assert len(root.handlers) == 1
+            # The second invocation still applies its level.
+            assert root.level == logging.DEBUG
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt_test.py
@@ -6,7 +6,12 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from jumpstarter_cli_common.opt import SourcePrefixFormatter, opt_insecure_tls, validate_name
+from jumpstarter_cli_common.opt import (
+    SourcePrefixFormatter,
+    _opt_log_level_callback,
+    opt_insecure_tls,
+    validate_name,
+)
 
 
 class TestSourcePrefixFormatter:
@@ -129,3 +134,27 @@ class TestValidateName:
 
     def test_accepts_valid_name(self) -> None:
         validate_name("my-resource")
+
+
+class TestLogHandlerStream:
+    def test_logs_go_to_stderr_not_stdout(self, capsys) -> None:
+        """Logs must not corrupt the JSON/YAML payload written to stdout.
+
+        `-o json` consumers (IDE integrations, CI) parse stdout; a log line
+        interleaved there makes the output unparseable.
+        """
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        root.handlers.clear()
+        try:
+            _opt_log_level_callback(None, None, "INFO")
+            logging.getLogger("jumpstarter.client.lease").info("Lease acquired successfully!")
+            for handler in root.handlers:
+                handler.flush()
+            captured = capsys.readouterr()
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+        assert "Lease acquired" in captured.err
+        assert captured.out == ""


### PR DESCRIPTION
`RichHandler` was writing log lines to stdout, so any command asked for `-o json` could return something that does not parse. Anything consuming the CLI's machine-readable output hits this the first time a command logs.

Logs now go to stderr, where the CLI's warnings already go. The CLI attaches its own handler rather than relying on `basicConfig`, which does nothing when the root logger already has one — an embedding application or an imported library that configures logging first would otherwise keep stdout as the destination. Includes regression tests asserting stdout stays empty while a command logs, including with a handler already installed.
