### PR TITLE
fix(client): preserve exporter fields when merging leases

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -28,7 +28,7 @@ from .env import JMP_DIAL_TIMEOUT, JMP_LEASE, JMP_RETRY_TIMEOUT
 from .grpc import call_credentials
 from .shell import ShellConfigV1Alpha1
 from .tls import TLSConfigV1Alpha1
-from jumpstarter.client.grpc import ClientService, Exporter
+from jumpstarter.client.grpc import ClientService
 from jumpstarter.common.exceptions import (
     ConfigurationError,
     ConnectionError,
@@ -236,20 +236,11 @@ class ClientConfigV1Alpha1(BaseSettings):
                     if latest_condition.type == "Ready" and latest_condition.status == "True":
                         lease_map[lease.exporter] = lease
 
-        exporters_with_leases = []
-        for exporter in result.exporters:
-            lease = lease_map.get(exporter.name)
-            exporter_with_lease = Exporter(
-                namespace=exporter.namespace,
-                name=exporter.name,
-                labels=exporter.labels,
-                online=exporter.online,
-                enabled=exporter.enabled,
-                lease=lease,
-            )
-            exporters_with_leases.append(exporter_with_lease)
         result.include_leases = True
-        result.exporters = exporters_with_leases
+        result.exporters = [
+            exporter.model_copy(update={"lease": lease_map.get(exporter.name)})
+            for exporter in result.exporters
+        ]
         return result
 
     @_blocking_compat

--- a/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -726,6 +726,7 @@ async def test_list_exporters_with_leases_preserves_exporter_fields():
     assert leased.status == ExporterStatus.LEASE_READY
     assert leased.enabled is True
     assert leased.online is True
+    assert leased.labels == {"env": "test"}
     assert leased.deprecated_labels == {"old": "label"}
     assert offline.lease is None
     assert offline.status == ExporterStatus.OFFLINE

--- a/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import yaml
+from jumpstarter_protocol import kubernetes_pb2
 from pydantic import ValidationError
 
 from jumpstarter.common.exceptions import FileNotFoundError
@@ -659,3 +660,77 @@ def test_client_config_list_redacts_credentials_by_default():
     dumped = configs.model_dump(mode="json", by_alias=True)
     assert dumped["items"][0]["token"] == "secret-token"
     assert dumped["items"][0]["refresh_token"] == "secret-refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_list_exporters_with_leases_preserves_exporter_fields():
+    from jumpstarter.client.grpc import Exporter, ExporterList, Lease, LeaseList
+    from jumpstarter.common.enums import ExporterStatus
+
+    exp = Exporter(
+        namespace="default",
+        name="exporter-a",
+        labels={"env": "test"},
+        online=True,
+        status=ExporterStatus.LEASE_READY,
+        enabled=True,
+        deprecated_labels={"old": "label"},
+        lease=None,
+    )
+    unleased = Exporter(
+        namespace="default",
+        name="exporter-b",
+        labels={},
+        online=False,
+        status=ExporterStatus.OFFLINE,
+        enabled=False,
+        lease=None,
+    )
+    condition = kubernetes_pb2.Condition(type="Ready", status="True")
+    lease = Lease(
+        namespace="default",
+        name="lease-a",
+        selector="env=test",
+        duration=timedelta(hours=1),
+        client="c",
+        exporter="exporter-a",
+        effective_begin_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        conditions=[condition],
+    )
+
+    exporter_page = ExporterList(exporters=[exp, unleased], next_page_token="")
+    lease_page = LeaseList(leases=[lease], next_page_token="")
+
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+
+    mock_service = Mock()
+    mock_service.ListExporters = AsyncMock(return_value=exporter_page)
+    mock_service.ListLeases = AsyncMock(return_value=lease_page)
+
+    with (
+        patch("jumpstarter.config.client.ClientConfigV1Alpha1.channel", AsyncMock(return_value=Mock())),
+        patch("jumpstarter.config.client.ClientService", return_value=mock_service),
+    ):
+        result = await config.list_exporters(
+            filter=None, include_leases=True, include_online=True, include_status=True
+        )
+
+    leased, offline = result.exporters
+    assert leased.lease is not None and leased.lease.name == "lease-a"
+    assert leased.status == ExporterStatus.LEASE_READY
+    assert leased.enabled is True
+    assert leased.online is True
+    assert leased.deprecated_labels == {"old": "label"}
+    assert offline.lease is None
+    assert offline.status == ExporterStatus.OFFLINE
+    assert offline.enabled is False
+
+    dumped = result.model_dump(mode="json")["exporters"][0]
+    assert dumped["status"] is not None
+    assert dumped["lease"]["name"] == "lease-a"


### PR DESCRIPTION
`list_exporters(include_leases=True)` rebuilt each exporter in order to attach its lease, and the constructor call omitted `status` and `deprecated_labels`. `jmp get exporters --with leases,status` therefore reported a null status for every exporter, while `--with status` alone reported it correctly.

Attaches the lease with `model_copy` instead, leaving the rest of the exporter intact.
