### PR TITLE
fix(cli): redact credentials in jmp config client list output

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_client.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_client.py
@@ -144,9 +144,16 @@ def delete_client_config(name: str, output: PathOutputType):
 
 @config_client.command("list", short_help="List available client configurations.")
 @opt_output_all
+@click.option(
+    "--show-credentials",
+    is_flag=True,
+    default=False,
+    help="Include tokens in json/yaml output instead of redacting them.",
+)
 @handle_exceptions
-def list_client_configs(output: OutputType):
+def list_client_configs(output: OutputType, show_credentials: bool):
     configs = ClientConfigV1Alpha1.list()
+    configs.include_credentials = show_credentials
 
     model_print(configs, output)
 

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/config_client_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/config_client_test.py
@@ -88,3 +88,38 @@ def test_create_client_config_insecure_tls_abort(tmp_path):
     )
     assert result.exit_code != 0
     assert not out.exists()
+
+
+def _patch_client_list():
+    from unittest.mock import patch
+
+    from jumpstarter.config.client import ClientConfigListV1Alpha1
+    from jumpstarter.config.common import ObjectMeta
+
+    config = ClientConfigV1Alpha1(
+        alias=CLIENT_ALIAS,
+        metadata=ObjectMeta(namespace=CLIENT_NAMESPACE, name=CLIENT_NAME),
+        endpoint=CLIENT_ENDPOINT,
+        token="secret-token",
+        refresh_token="secret-refresh-token",
+    )
+    configs = ClientConfigListV1Alpha1(current_config=CLIENT_ALIAS, items=[config])
+    return patch.object(ClientConfigV1Alpha1, "list", return_value=configs)
+
+
+def test_list_client_configs_redacts_credentials():
+    runner = CliRunner()
+    with _patch_client_list():
+        result = runner.invoke(config_client, ["list", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    assert CLIENT_ALIAS in result.output
+    assert "secret-token" not in result.output
+    assert "secret-refresh-token" not in result.output
+
+
+def test_list_client_configs_show_credentials():
+    runner = CliRunner()
+    with _patch_client_list():
+        result = runner.invoke(config_client, ["list", "-o", "json", "--show-credentials"])
+    assert result.exit_code == 0, result.output
+    assert "secret-token" in result.output

--- a/python/packages/jumpstarter/jumpstarter/config/client.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client.py
@@ -536,11 +536,23 @@ class ClientConfigListV1Alpha1(BaseModel):
     items: list[ClientConfigV1Alpha1]
     kind: Literal["ClientConfigList"] = Field(default="ClientConfigList")
 
+    include_credentials: bool = Field(default=False, exclude=True)
+
+    def _redact_credentials(self, kwargs: dict) -> dict:
+        if not self.include_credentials and "exclude" not in kwargs:
+            kwargs["exclude"] = {"items": {"__all__": {"token", "refresh_token"}}}
+        return kwargs
+
+    def model_dump(self, **kwargs):
+        return super().model_dump(**self._redact_credentials(kwargs))
+
+    def model_dump_json(self, **kwargs):
+        return super().model_dump_json(**self._redact_credentials(kwargs))
+
     def dump_json(self):
         return self.model_dump_json(
             indent=4,
             by_alias=True,
-            exclude={"items": {"__all__": {"refresh_token"}}},
         )
 
     def dump_yaml(self):
@@ -548,7 +560,6 @@ class ClientConfigListV1Alpha1(BaseModel):
             self.model_dump(
                 mode="json",
                 by_alias=True,
-                exclude={"items": {"__all__": {"refresh_token"}}},
             ),
             indent=2,
         )

--- a/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
+++ b/python/packages/jumpstarter/jumpstarter/config/client_config_test.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from jumpstarter.common.exceptions import FileNotFoundError
 from jumpstarter.config.client import (
+    ClientConfigListV1Alpha1,
     ClientConfigV1Alpha1,
     ClientConfigV1Alpha1Drivers,
     ClientConfigV1Alpha1Lease,
@@ -634,3 +635,27 @@ async def test_list_exporters_with_leases_propagates_page_size():
 
     lease_calls = mock_service.ListLeases.call_args_list
     assert lease_calls[0].kwargs["page_size"] == 50
+
+
+def test_client_config_list_redacts_credentials_by_default():
+    config = ClientConfigV1Alpha1(
+        alias="testclient",
+        metadata=ObjectMeta(namespace="default", name="testclient"),
+        endpoint="jumpstarter.my-lab.com:1443",
+        token="secret-token",
+        refresh_token="secret-refresh-token",
+        drivers=ClientConfigV1Alpha1Drivers(allow=["jumpstarter.drivers.*"], unsafe=False),
+    )
+    configs = ClientConfigListV1Alpha1(current_config="testclient", items=[config])
+
+    dumped = configs.model_dump(mode="json", by_alias=True)
+    assert "token" not in dumped["items"][0]
+    assert "refresh_token" not in dumped["items"][0]
+    assert "secret-token" not in configs.model_dump_json()
+    assert "secret-token" not in configs.dump_json()
+    assert "secret-token" not in configs.dump_yaml()
+
+    configs.include_credentials = True
+    dumped = configs.model_dump(mode="json", by_alias=True)
+    assert dumped["items"][0]["token"] == "secret-token"
+    assert dumped["items"][0]["refresh_token"] == "secret-refresh-token"


### PR DESCRIPTION
`jmp config client list -o json|yaml` printed each client's token verbatim, so anything that captures that output captures the credentials with it: a terminal scrollback, a CI log, a tool listing the configured clients.

Tokens are redacted by default. The config files themselves are unchanged; this is only about what the command prints.
