### PR TITLE
feat(cli): add -o json/yaml to jmp auth status

### DIFF
--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/oidc.py
@@ -21,6 +21,7 @@ from anyio.to_thread import run_sync
 warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"authlib\.")
 
 from authlib.integrations.requests_client import OAuth2Session  # noqa: E402
+from joserfc.errors import JoseError  # noqa: E402
 from joserfc.jws import extract_compact  # noqa: E402
 from yarl import URL  # noqa: E402
 
@@ -328,7 +329,7 @@ class Config:
 def decode_jwt(token: str):
     try:
         return json.loads(extract_compact(token.encode()).payload)
-    except (ValueError, KeyError, TypeError) as e:
+    except (ValueError, KeyError, TypeError, JoseError) as e:
         raise ValueError(f"Invalid JWT format: {e}") from e
 
 

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/opt.py
@@ -157,6 +157,16 @@ opt_output_all = click.option(
     help='Output mode. Use "-o name" for shorter output (resource/name).',
 )
 
+DataOutputType = Optional[Literal["json", "yaml"]]
+
+opt_output_json_yaml = click.option(
+    "-o",
+    "--output",
+    type=click.Choice([OutputMode.JSON, OutputMode.YAML]),
+    default=None,
+    help='Output mode. Use "-o json" or "-o yaml" for machine-readable output.',
+)
+
 NameOutputType = Optional[Literal["name"]]
 
 opt_output_name_only = click.option(

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/auth.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/auth.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Literal, Optional
 
 import click
 from jumpstarter_cli_common.blocking import blocking
@@ -11,6 +12,9 @@ from jumpstarter_cli_common.oidc import (
     format_duration,
     get_token_remaining_seconds,
 )
+from jumpstarter_cli_common.opt import DataOutputType, opt_output_json_yaml
+from jumpstarter_cli_common.print import model_print
+from pydantic import BaseModel, ConfigDict, Field
 
 from jumpstarter.config.client import ClientConfigV1Alpha1
 
@@ -18,6 +22,64 @@ from jumpstarter.config.client import ClientConfigV1Alpha1
 @click.group()
 def auth():
     """Authentication and token management commands."""
+
+
+class AuthStatusV1Alpha1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    api_version: Literal["jumpstarter.dev/v1alpha1"] = Field(alias="apiVersion", default="jumpstarter.dev/v1alpha1")
+    kind: Literal["AuthStatus"] = Field(default="AuthStatus")
+
+    status: Literal["valid", "expiring-soon", "expired", "no-expiry", "no-token", "invalid-token"]
+    expires_at: Optional[datetime] = Field(alias="expiresAt", default=None)
+    remaining_seconds: Optional[float] = Field(alias="remainingSeconds", default=None)
+    subject: Optional[str] = None
+    issuer: Optional[str] = None
+    issued_at: Optional[datetime] = Field(alias="issuedAt", default=None)
+    auth_time: Optional[datetime] = Field(alias="authTime", default=None)
+    refresh_token_stored: bool = Field(alias="refreshTokenStored", default=False)
+    error: Optional[str] = None
+
+
+def _timestamp_claim(payload: dict, claim: str) -> Optional[datetime]:
+    value = payload.get(claim)
+    if not isinstance(value, int):
+        return None
+    return datetime.fromtimestamp(value, tz=timezone.utc)
+
+
+def _collect_auth_status(config) -> AuthStatusV1Alpha1:
+    refresh_token_stored = bool(getattr(config, "refresh_token", None))
+
+    token_str = getattr(config, "token", None)
+    if not token_str:
+        return AuthStatusV1Alpha1(status="no-token", refresh_token_stored=refresh_token_stored)
+
+    try:
+        payload = decode_jwt(token_str)
+    except ValueError as e:
+        return AuthStatusV1Alpha1(status="invalid-token", error=str(e), refresh_token_stored=refresh_token_stored)
+
+    remaining = get_token_remaining_seconds(token_str)
+    if remaining is None:
+        status = "no-expiry"
+    elif remaining < 0:
+        status = "expired"
+    elif remaining < TOKEN_EXPIRY_WARNING_SECONDS:
+        status = "expiring-soon"
+    else:
+        status = "valid"
+
+    return AuthStatusV1Alpha1(
+        status=status,
+        expires_at=_timestamp_claim(payload, "exp"),
+        remaining_seconds=remaining,
+        subject=payload.get("sub"),
+        issuer=payload.get("iss"),
+        issued_at=_timestamp_claim(payload, "iat"),
+        auth_time=_timestamp_claim(payload, "auth_time"),
+        refresh_token_stored=refresh_token_stored,
+    )
 
 
 def _print_token_status(remaining: float) -> None:
@@ -68,9 +130,14 @@ def _print_verbose_details(payload: dict, config) -> None:
 
 @auth.command(name="status")
 @click.option("-v", "--verbose", is_flag=True, help="Show additional token details")
+@opt_output_json_yaml
 @opt_config(exporter=False)
-def token_status(config, verbose: bool):
+def token_status(config, verbose: bool, output: DataOutputType):
     """Display token status and expiry information."""
+    if output:
+        model_print(_collect_auth_status(config), output)
+        return
+
     token_str = getattr(config, "token", None)
 
     if not token_str:

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/auth_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/auth_test.py
@@ -83,6 +83,57 @@ class TestAuthStatus:
         assert result.exit_code == 0
         assert "Refresh token stored: yes" in result.output
 
+    def test_status_invalid_token(self):
+        config = _mock_config(token="not-a-jwt")
+        with _patch_config(config):
+            result = self.runner.invoke(auth, ["status"])
+        assert result.exit_code == 0
+        assert "Failed to decode token" in result.output
+
+    def test_status_valid_token_json(self):
+        token = _make_jwt(exp_offset_seconds=7200)
+        config = _mock_config(token=token, refresh_token="fake-refresh")
+        with _patch_config(config):
+            result = self.runner.invoke(auth, ["status", "-o", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["kind"] == "AuthStatus"
+        assert data["status"] == "valid"
+        assert data["subject"] == "test-subject"
+        assert data["issuer"] == "https://localhost:8085"
+        assert data["refreshTokenStored"] is True
+        assert data["remainingSeconds"] > 3600
+        assert data["expiresAt"] is not None
+        assert token not in result.output
+
+    def test_status_expired_token_json(self):
+        token = _make_expired_jwt()
+        config = _mock_config(token=token)
+        with _patch_config(config):
+            result = self.runner.invoke(auth, ["status", "-o", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "expired"
+        assert data["remainingSeconds"] < 0
+
+    def test_status_no_token_json(self):
+        config = _mock_config(token=None)
+        with _patch_config(config):
+            result = self.runner.invoke(auth, ["status", "-o", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "no-token"
+        assert data["expiresAt"] is None
+
+    def test_status_invalid_token_json(self):
+        config = _mock_config(token="not-a-jwt")
+        with _patch_config(config):
+            result = self.runner.invoke(auth, ["status", "-o", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "invalid-token"
+        assert data["error"]
+
 
 class TestAuthRotate:
     def setup_method(self):


### PR DESCRIPTION
`jmp auth status` printed for humans only, so a tool that wants to know whether a token is still valid has to parse prose or make a call and see what happens — and when the token has expired, that call turns into an interactive browser login, which is not something a background process should ever start.

Adds `-o json|yaml`, reporting the status, expiry, remaining seconds, subject and issuer.

Also catches `JoseError` in `decode_jwt`: a malformed token raised `DecodeError` straight past the handler meant to catch it.
