### PR TITLE
feat(cli): add -o json/yaml/name to jmp driver list

### DIFF
--- a/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver.py
+++ b/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver.py
@@ -1,29 +1,59 @@
 from importlib.metadata import entry_points
 
 import click
-from rich.console import Console
-from rich.table import Table
+from jumpstarter_cli_common.opt import OutputType, opt_output_all
+from jumpstarter_cli_common.print import model_print
+from pydantic import BaseModel
 
 
-@click.command("list")
-def list_drivers():
-    drivers = list(entry_points(group="jumpstarter.drivers"))
-    if not drivers:
-        click.echo("No drivers found.")
-    else:
-        table = Table(
-            box=None,
-            header_style=None,
-            pad_edge=False,
-        )
+class DriverEntry(BaseModel):
+    name: str
+    type: str
+    package: str | None = None
+    version: str | None = None
 
+    def rich_add_rows(self, table):
+        table.add_row(self.name, self.type)
+
+    def rich_add_names(self, names):
+        names.append(self.name)
+
+
+class DriverEntryList(BaseModel):
+    drivers: list[DriverEntry]
+
+    @classmethod
+    def rich_add_columns(cls, table):
         table.add_column("NAME", no_wrap=True)
         table.add_column("TYPE")
 
-        for driver in drivers:
-            table.add_row(
-                driver.name,
-                driver.value.replace(":", "."),
-            )
+    def rich_add_rows(self, table):
+        for entry in self.drivers:
+            entry.rich_add_rows(table)
 
-        Console().print(table)
+    def rich_add_names(self, names):
+        for entry in self.drivers:
+            entry.rich_add_names(names)
+
+
+@click.command("list")
+@opt_output_all
+def list_drivers(output: OutputType):
+    """List drivers installed in the current environment"""
+    drivers = []
+    for entry_point in entry_points(group="jumpstarter.drivers"):
+        dist = entry_point.dist
+        drivers.append(
+            DriverEntry(
+                name=entry_point.name,
+                type=entry_point.value.replace(":", "."),
+                package=dist.name if dist else None,
+                version=dist.version if dist else None,
+            )
+        )
+
+    if not drivers and output is None:
+        click.echo("No drivers found.")
+        return
+
+    model_print(DriverEntryList(drivers=drivers), output)

--- a/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver_test.py
+++ b/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver_test.py
@@ -1,40 +1,99 @@
 import json
+from dataclasses import dataclass
+from unittest.mock import patch
 
+import pytest
+import yaml
 from click.testing import CliRunner
 
 from . import driver
 
 
-def test_list_drivers():
-    runner = CliRunner()
+@dataclass
+class FakeDist:
+    name: str
+    version: str
 
-    result = runner.invoke(
-        driver,
-        ["list"],
-    )
+
+@dataclass
+class FakeEntryPoint:
+    """Stands in for an installed driver's entry point.
+
+    The tests patch these in rather than reading the environment: which drivers
+    happen to be installed is not something a CLI test should depend on, and an
+    environment with none exercises nothing at all.
+    """
+
+    name: str
+    value: str
+    dist: FakeDist | None
+
+
+ENTRY_POINTS = [
+    FakeEntryPoint(
+        name="power",
+        value="jumpstarter_driver_power.driver:MockPower",
+        dist=FakeDist(name="jumpstarter-driver-power", version="1.2.3"),
+    ),
+    # A driver whose distribution cannot be resolved: package and version are
+    # unknown, and the row still has to render.
+    FakeEntryPoint(name="orphan", value="somewhere.driver:Orphan", dist=None),
+]
+
+
+@pytest.fixture
+def installed_drivers():
+    with patch("jumpstarter_cli_driver.driver.entry_points", return_value=ENTRY_POINTS):
+        yield
+
+
+def test_list_drivers_table(installed_drivers):
+    result = CliRunner().invoke(driver, ["list"])
     assert result.exit_code == 0
+    # The name and the dotted type, one row each.
+    assert "power" in result.output
+    assert "jumpstarter_driver_power.driver.MockPower" in result.output
+    assert "orphan" in result.output
 
 
-def test_list_drivers_json():
-    runner = CliRunner()
-
-    result = runner.invoke(
-        driver,
-        ["list", "-o", "json"],
-    )
+def test_list_drivers_json(installed_drivers):
+    result = CliRunner().invoke(driver, ["list", "-o", "json"])
     assert result.exit_code == 0
-    data = json.loads(result.output)
-    assert "drivers" in data
-    for entry in data["drivers"]:
-        assert entry["name"]
-        assert entry["type"]
+    entries = json.loads(result.output)["drivers"]
+    assert entries[0] == {
+        "name": "power",
+        "type": "jumpstarter_driver_power.driver.MockPower",
+        "package": "jumpstarter-driver-power",
+        "version": "1.2.3",
+    }
+    # An unresolvable distribution reports null rather than guessing.
+    assert entries[1]["package"] is None
+    assert entries[1]["version"] is None
 
 
-def test_list_drivers_name():
-    runner = CliRunner()
-
-    result = runner.invoke(
-        driver,
-        ["list", "-o", "name"],
-    )
+def test_list_drivers_yaml(installed_drivers):
+    result = CliRunner().invoke(driver, ["list", "-o", "yaml"])
     assert result.exit_code == 0
+    entries = yaml.safe_load(result.output)["drivers"]
+    assert [entry["name"] for entry in entries] == ["power", "orphan"]
+
+
+def test_list_drivers_name(installed_drivers):
+    result = CliRunner().invoke(driver, ["list", "-o", "name"])
+    assert result.exit_code == 0
+    assert result.output.split() == ["power", "orphan"]
+
+
+def test_list_drivers_says_so_when_there_are_none():
+    with patch("jumpstarter_cli_driver.driver.entry_points", return_value=[]):
+        result = CliRunner().invoke(driver, ["list"])
+    assert result.exit_code == 0
+    assert "No drivers found." in result.output
+
+
+def test_list_drivers_empty_json_is_still_valid_json():
+    """A consumer parsing the output must not have to special-case "none"."""
+    with patch("jumpstarter_cli_driver.driver.entry_points", return_value=[]):
+        result = CliRunner().invoke(driver, ["list", "-o", "json"])
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"drivers": []}

--- a/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver_test.py
+++ b/python/packages/jumpstarter-cli-driver/jumpstarter_cli_driver/driver_test.py
@@ -1,3 +1,5 @@
+import json
+
 from click.testing import CliRunner
 
 from . import driver
@@ -9,5 +11,30 @@ def test_list_drivers():
     result = runner.invoke(
         driver,
         ["list"],
+    )
+    assert result.exit_code == 0
+
+
+def test_list_drivers_json():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        driver,
+        ["list", "-o", "json"],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "drivers" in data
+    for entry in data["drivers"]:
+        assert entry["name"]
+        assert entry["type"]
+
+
+def test_list_drivers_name():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        driver,
+        ["list", "-o", "name"],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
`jmp driver list` printed a table only, so anything wanting to know which drivers are installed in an environment had to scrape it.

Adds the usual `-o json|yaml|name` modes, reporting each driver's name, type, package and version.
