### PR TITLE
feat(cli): add jmp describe for exporters, leases, and clients

### DIFF
--- a/docs/source/getting-started/guides/examples/testing.md
+++ b/docs/source/getting-started/guides/examples/testing.md
@@ -277,7 +277,10 @@ hardware-test:
 **Lease acquisition times out**
 : Verify that an {term}`exporter` matching your `selector` labels is running and
   registered with the {term}`controller`. Check available {term}`exporter`s with
-  `jmp get exporters`.
+  `jmp get exporters`, and `jmp describe exporter <name>` for one exporter's
+  labels and the {term}`lease` currently holding it. If the {term}`lease` was
+  created but never became ready, `jmp describe lease <name>` reports its
+  conditions.
 
 **`client` fixture setup fails**
 : Confirm that `jumpstarter-testing` is installed, and either: `JUMPSTARTER_HOST`

--- a/docs/source/getting-started/guides/setup/distributed-mode.md
+++ b/docs/source/getting-started/guides/setup/distributed-mode.md
@@ -89,6 +89,78 @@ development purposes, and saves the configuration locally in
 $ jmp admin create client hello --save --unsafe --insecure-tls
 ```
 
+### Inspect Exporters and Leases
+
+List the {term}`exporter`s your client can reach, to find one to select:
+
+```console
+$ jmp get exporters
+NAME                 LABELS
+example-distributed  foo=bar
+```
+
+`jmp describe` shows one resource in full, including the labels you select on
+and the {term}`lease` holding it, if any:
+
+```console
+$ jmp describe exporter example-distributed
+Name:       example-distributed
+Namespace:  jumpstarter-lab
+Labels:
+  foo=bar
+Online:   yes
+Status:   AVAILABLE
+Enabled:  yes
+Lease:  <none>
+```
+
+Describing a {term}`lease` reports its conditions, which is the quickest way to
+see why one is still waiting:
+
+```console
+$ jmp describe lease 01a05822-e378-71cc-a98c-a216ad4a9432
+Name:                  01a05822-e378-71cc-a98c-a216ad4a9432
+Namespace:             jumpstarter-lab
+Selector:              foo=bar
+Exporter:              example-distributed
+Client:                hello
+Status:                In-Use
+Duration:              0:05:00
+Effective Begin Time:  2026-08-31 10:04:36 EDT
+Effective End Time:    <none>
+Tags:  <none>
+Context:  <none>
+Conditions:
+  Type   Status  Reason  Message                                       Last Transition Time
+  ----   ------  ------  -------                                       --------------------
+  Ready  True    Ready   An exporter has been acquired for the client  2026-08-31 14:04:36 UTC
+```
+
+Describing a client reads the local configuration rather than the cluster, so it
+works without a connection and reports whether the client's token is still valid:
+
+```console
+$ jmp describe client hello
+Alias:      hello
+Path:       /home/user/.config/jumpstarter/clients/hello.yaml
+Current:    yes
+Name:       hello
+Namespace:  jumpstarter-lab
+Endpoint:   grpc.jumpstarter.example.com:443
+TLS:
+  CA:        configured
+  Insecure:  yes
+Drivers:
+  Allow:   <none>
+  Unsafe:  yes
+Token:
+  Expiry:  2027-08-30 02:00:56 UTC
+  Status:  valid (8723h 53m remaining)
+Refresh Token Stored:  no
+```
+
+Add `-o json` or `-o yaml` to any of these for machine-readable output.
+
 ### Spawn an Exporter Shell
 
 Interact with your distributed {term}`exporter` using the {term}`exporter shell` functionality

--- a/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/alias.py
+++ b/python/packages/jumpstarter-cli-common/jumpstarter_cli_common/alias.py
@@ -19,6 +19,7 @@ class AliasedGroup(click.Group):
         "move": ["mv"],
         "config": ["conf"],
         "delete": ["del", "d"],
+        "describe": ["desc"],
         "shell": ["sh", "s"],
         "exporter": ["exporters", "e"],
         "exporters": ["exporter"],

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/describe.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/describe.py
@@ -1,0 +1,281 @@
+from datetime import datetime, timezone
+
+import click
+from jumpstarter_cli_common.alias import AliasedGroup
+from jumpstarter_cli_common.config import opt_config
+from jumpstarter_cli_common.exceptions import handle_exceptions, handle_exceptions_with_reauthentication
+from jumpstarter_cli_common.oidc import decode_jwt, format_duration, get_token_remaining_seconds
+from jumpstarter_cli_common.opt import OutputMode, OutputType
+from jumpstarter_cli_common.print import model_print
+from pydantic import BaseModel, ConfigDict, Field
+
+from .login import relogin_client
+from jumpstarter.config.client import ClientConfigV1Alpha1
+from jumpstarter.config.user import UserConfigV1Alpha1
+
+opt_output = click.option(
+    "-o",
+    "--output",
+    type=click.Choice([OutputMode.JSON, OutputMode.YAML]),
+    default=None,
+    help="Output mode. Defaults to a human-readable description.",
+)
+
+
+def _format_value(value) -> str:
+    if value is None or value == "":
+        return "<none>"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M:%S %Z").strip()
+    return str(value)
+
+
+def _print_fields(fields: list[tuple[str, object]], indent: int = 0) -> None:
+    width = max(len(label) for label, _ in fields) + 1
+    prefix = " " * indent
+    for label, value in fields:
+        click.echo(f"{prefix}{label + ':':<{width}}  {_format_value(value)}")
+
+
+def _print_mapping(label: str, mapping: dict[str, str], indent: int = 0) -> None:
+    prefix = " " * indent
+    if not mapping:
+        click.echo(f"{prefix}{label}:  <none>")
+        return
+    click.echo(f"{prefix}{label}:")
+    for key, value in sorted(mapping.items()):
+        click.echo(f"{prefix}  {key}={value}")
+
+
+def _condition_time(condition) -> datetime | None:
+    if condition.HasField("lastTransitionTime"):
+        time = condition.lastTransitionTime
+        return datetime.fromtimestamp(time.seconds + time.nanos / 1e9, tz=timezone.utc)
+    return None
+
+
+def _print_conditions(conditions) -> None:
+    if not conditions:
+        click.echo("Conditions:  <none>")
+        return
+    click.echo("Conditions:")
+    headers = ["Type", "Status", "Reason", "Message", "Last Transition Time"]
+    rows = [
+        [
+            _format_value(condition.type),
+            _format_value(condition.status),
+            _format_value(condition.reason),
+            _format_value(condition.message),
+            _format_value(_condition_time(condition)),
+        ]
+        for condition in conditions
+    ]
+    widths = [max([len(header)] + [len(row[i]) for row in rows]) for i, header in enumerate(headers)]
+    dashes = ["-" * len(header) for header in headers]
+    for cells in [headers, dashes, *rows]:
+        click.echo("  " + "  ".join(cell.ljust(width) for cell, width in zip(cells, widths, strict=True)).rstrip())
+
+
+@click.group(cls=AliasedGroup)
+def describe():
+    """
+    Show detailed information about a specific resource
+    """
+
+
+@describe.command(name="exporter")
+@opt_config(exporter=False)
+@click.argument("name")
+@opt_output
+@handle_exceptions_with_reauthentication(relogin_client)
+def describe_exporter(config, name: str, output: OutputType):
+    """
+    Show details of a specific exporter
+    """
+
+    exporter = config.get_exporter(name)
+
+    if output:
+        model_print(exporter, output)
+        return
+
+    _print_fields(
+        [
+            ("Name", exporter.name),
+            ("Namespace", exporter.namespace),
+        ]
+    )
+    _print_mapping("Labels", exporter.labels)
+    if exporter.deprecated_labels:
+        _print_mapping("Deprecated Labels", exporter.deprecated_labels)
+    _print_fields(
+        [
+            ("Online", exporter.online),
+            ("Status", str(exporter.status) if exporter.status else "UNKNOWN"),
+            ("Enabled", exporter.enabled),
+        ]
+    )
+    if exporter.lease:
+        lease = exporter.lease
+        click.echo("Lease:")
+        _print_fields(
+            [
+                ("Name", lease.name),
+                ("Client", lease.client),
+                ("Status", lease.get_status()),
+                ("Begin Time", lease.effective_begin_time or lease.begin_time),
+                ("End Time", lease.effective_end_time),
+                ("Duration", lease.duration),
+            ],
+            indent=2,
+        )
+    else:
+        click.echo("Lease:  <none>")
+
+
+@describe.command(name="lease")
+@opt_config(exporter=False)
+@click.argument("name")
+@opt_output
+@handle_exceptions_with_reauthentication(relogin_client)
+def describe_lease(config, name: str, output: OutputType):
+    """
+    Show details of a specific lease
+    """
+
+    lease = config.get_lease(name=name)
+
+    if output:
+        model_print(lease, output)
+        return
+
+    _print_fields(
+        [
+            ("Name", lease.name),
+            ("Namespace", lease.namespace),
+            ("Selector", lease.selector),
+            ("Exporter", lease.exporter),
+            ("Client", lease.client),
+            ("Status", lease.get_status()),
+            ("Duration", lease.duration),
+            ("Effective Begin Time", lease.effective_begin_time),
+            ("Effective End Time", lease.effective_end_time),
+        ]
+    )
+    _print_mapping("Tags", lease.tags)
+    _print_mapping("Context", lease.context)
+    _print_conditions(lease.conditions)
+
+
+class ClientDescription(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    alias: str
+    path: str | None
+    current: bool
+    name: str | None
+    namespace: str | None
+    endpoint: str | None
+    tls_ca_configured: bool = Field(alias="tlsCaConfigured")
+    tls_insecure: bool = Field(alias="tlsInsecure")
+    drivers_allow: list[str] = Field(alias="driversAllow")
+    drivers_unsafe: bool = Field(alias="driversUnsafe")
+    token_expiry: datetime | None = Field(alias="tokenExpiry")
+    token_status: str = Field(alias="tokenStatus")
+    refresh_token_stored: bool = Field(alias="refreshTokenStored")
+
+
+def _token_details(token: str | None) -> tuple[datetime | None, str]:
+    if not token:
+        return None, "no token"
+    try:
+        payload = decode_jwt(token)
+    except Exception:
+        return None, "malformed"
+    exp = payload.get("exp")
+    remaining = get_token_remaining_seconds(token)
+    if exp is None or remaining is None:
+        return None, "no expiry claim"
+    expiry = datetime.fromtimestamp(exp, tz=timezone.utc)
+    if remaining < 0:
+        return expiry, f"expired ({format_duration(remaining)} ago)"
+    return expiry, f"valid ({format_duration(remaining)} remaining)"
+
+
+@describe.command(name="client")
+@click.argument("alias", required=False, default=None)
+@opt_output
+@handle_exceptions
+def describe_client(alias: str | None, output: OutputType):
+    """
+    Show details of a client config
+    """
+
+    if alias is not None:
+        config = ClientConfigV1Alpha1.load(alias)
+    else:
+        config = UserConfigV1Alpha1.load_or_create().config.current_client
+        if config is None:
+            raise click.ClickException("no client alias specified and no default client is set")
+
+    current_alias = ClientConfigV1Alpha1.list().current_config
+
+    token_expiry, token_status = _token_details(config.token)
+
+    description = ClientDescription(
+        alias=config.alias,
+        path=str(config.path) if config.path else None,
+        current=current_alias is not None and config.alias == current_alias,
+        name=config.metadata.name,
+        namespace=config.metadata.namespace,
+        endpoint=config.endpoint,
+        tls_ca_configured=bool(config.tls.ca),
+        tls_insecure=config.tls.insecure,
+        drivers_allow=config.drivers.allow,
+        drivers_unsafe=config.drivers.unsafe,
+        token_expiry=token_expiry,
+        token_status=token_status,
+        refresh_token_stored=bool(config.refresh_token),
+    )
+
+    if output:
+        model_print(description, output)
+        return
+
+    _print_fields(
+        [
+            ("Alias", description.alias),
+            ("Path", description.path),
+            ("Current", description.current),
+            ("Name", description.name),
+            ("Namespace", description.namespace),
+            ("Endpoint", description.endpoint),
+        ]
+    )
+    click.echo("TLS:")
+    _print_fields(
+        [
+            ("CA", "configured" if description.tls_ca_configured else None),
+            ("Insecure", description.tls_insecure),
+        ],
+        indent=2,
+    )
+    click.echo("Drivers:")
+    _print_fields(
+        [
+            ("Allow", ", ".join(description.drivers_allow) if description.drivers_allow else None),
+            ("Unsafe", description.drivers_unsafe),
+        ],
+        indent=2,
+    )
+    click.echo("Token:")
+    _print_fields(
+        [
+            ("Expiry", description.token_expiry),
+            ("Status", description.token_status),
+        ],
+        indent=2,
+    )
+    _print_fields([("Refresh Token Stored", description.refresh_token_stored)])

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/describe.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/describe.py
@@ -85,6 +85,19 @@ def describe():
     """
 
 
+def _holding_lease(config, exporter: str):
+    """The lease currently holding an exporter, if any.
+
+    GetExporter answers with the exporter on its own, so the lease has to be
+    looked up separately — without it, describing a busy exporter could not say
+    who has it, which is the main reason to ask.
+    """
+    for lease in config.list_leases(only_active=True).leases:
+        if lease.exporter == exporter:
+            return lease
+    return None
+
+
 @describe.command(name="exporter")
 @opt_config(exporter=False)
 @click.argument("name")
@@ -96,6 +109,7 @@ def describe_exporter(config, name: str, output: OutputType):
     """
 
     exporter = config.get_exporter(name)
+    exporter = exporter.model_copy(update={"lease": _holding_lease(config, name)})
 
     if output:
         model_print(exporter, output)

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/describe_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/describe_test.py
@@ -1,0 +1,342 @@
+import base64
+import json
+import time
+from contextlib import ExitStack
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from jumpstarter_protocol import kubernetes_pb2
+
+from jumpstarter_cli.describe import describe
+
+from jumpstarter.client.grpc import Exporter, Lease
+from jumpstarter.common import ExporterStatus
+from jumpstarter.common.exceptions import ConnectionError
+
+CLIENT_TOKEN_PLACEHOLDER = "not-a-real-token"
+
+
+def _make_jwt(exp_offset_seconds=3600, include_exp=True):
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none", "typ": "JWT"}).encode()).rstrip(b"=").decode()
+    payload_data = {
+        "sub": "test-subject",
+        "iss": "https://localhost:8085",
+        "iat": int(time.time()),
+    }
+    if include_exp:
+        payload_data["exp"] = int(time.time()) + exp_offset_seconds
+    payload = base64.urlsafe_b64encode(json.dumps(payload_data).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.fake-signature"
+
+
+def _make_condition(type="Ready", status="True", reason="Ready", message="lease is ready"):
+    condition = kubernetes_pb2.Condition(type=type, status=status, reason=reason, message=message)
+    condition.lastTransitionTime.seconds = int(datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc).timestamp())
+    return condition
+
+
+def _make_lease(name="lease-1", conditions=None, **kwargs):
+    return Lease(
+        namespace="default",
+        name=name,
+        selector="board=rpi4",
+        duration=timedelta(minutes=30),
+        client="my-client",
+        exporter="exporter-1",
+        conditions=conditions if conditions is not None else [_make_condition()],
+        effective_begin_time=datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+        tags={"build": "1234"},
+        context={"purpose": "ci"},
+        **kwargs,
+    )
+
+
+def _make_exporter(lease=None):
+    return Exporter(
+        namespace="default",
+        name="exporter-1",
+        labels={"board": "rpi4", "env": "test"},
+        online=True,
+        status=ExporterStatus.AVAILABLE,
+        enabled=True,
+        lease=lease,
+    )
+
+
+def _patch_remote_config(config):
+    mock_cls = MagicMock()
+    mock_cls.load.return_value = config
+    return patch("jumpstarter_cli_common.config.ClientConfigV1Alpha1", mock_cls)
+
+
+def _make_client_config(alias="test-client", token=None, refresh_token=None):
+    config = MagicMock()
+    config.alias = alias
+    config.path = Path(f"/home/user/.config/jumpstarter/clients/{alias}.yaml")
+    config.metadata.name = "my-client"
+    config.metadata.namespace = "default"
+    config.endpoint = "grpc.example.com:443"
+    config.token = token
+    config.refresh_token = refresh_token
+    config.tls.ca = ""
+    config.tls.insecure = False
+    config.drivers.allow = ["jumpstarter_driver_power"]
+    config.drivers.unsafe = False
+    return config
+
+
+def _patch_client_configs(config, current_alias=None, default_client=None):
+    client_cls = MagicMock()
+    client_cls.load.return_value = config
+    client_cls.list.return_value = MagicMock(current_config=current_alias)
+    user_cls = MagicMock()
+    user_cls.load_or_create.return_value.config.current_client = default_client
+    stack = ExitStack()
+    stack.enter_context(patch("jumpstarter_cli.describe.ClientConfigV1Alpha1", client_cls))
+    stack.enter_context(patch("jumpstarter_cli.describe.UserConfigV1Alpha1", user_cls))
+    return stack
+
+
+class TestDescribeExporter:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_pretty_output(self):
+        config = MagicMock()
+        config.get_exporter.return_value = _make_exporter()
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Name:" in result.output
+        assert "exporter-1" in result.output
+        assert "Namespace:" in result.output
+        assert "board=rpi4" in result.output
+        assert "env=test" in result.output
+        assert "Online:" in result.output
+        assert "AVAILABLE" in result.output
+        assert "Enabled:" in result.output
+        assert "Lease:  <none>" in result.output
+        config.get_exporter.assert_called_once_with("exporter-1")
+
+    def test_pretty_output_with_lease(self):
+        config = MagicMock()
+        config.get_exporter.return_value = _make_exporter(lease=_make_lease())
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Lease:" in result.output
+        assert "lease-1" in result.output
+        assert "my-client" in result.output
+        assert "In-Use" in result.output
+        assert "0:30:00" in result.output
+
+    def test_pretty_output_deprecated_labels(self):
+        exporter = _make_exporter()
+        exporter.deprecated_labels = {"old-key": "Use new-key instead"}
+        config = MagicMock()
+        config.get_exporter.return_value = exporter
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Deprecated Labels:" in result.output
+        assert "old-key=Use new-key instead" in result.output
+
+    def test_json_output(self):
+        config = MagicMock()
+        config.get_exporter.return_value = _make_exporter()
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test", "-o", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["name"] == "exporter-1"
+        assert data["namespace"] == "default"
+        assert data["labels"] == {"board": "rpi4", "env": "test"}
+        assert data["online"] is True
+
+    def test_unknown_name(self):
+        config = MagicMock()
+        config.get_exporter.side_effect = ConnectionError("exporter 'missing' not found")
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["exporter", "missing", "--client", "test"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestDescribeLease:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_pretty_output(self):
+        config = MagicMock()
+        config.get_lease.return_value = _make_lease()
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["lease", "lease-1", "--client", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Name:" in result.output
+        assert "lease-1" in result.output
+        assert "Selector:" in result.output
+        assert "board=rpi4" in result.output
+        assert "exporter-1" in result.output
+        assert "my-client" in result.output
+        assert "In-Use" in result.output
+        assert "0:30:00" in result.output
+        assert "Effective Begin Time:" in result.output
+        assert "build=1234" in result.output
+        assert "purpose=ci" in result.output
+        assert "Conditions:" in result.output
+        assert "Ready" in result.output
+        assert "lease is ready" in result.output
+        config.get_lease.assert_called_once_with(name="lease-1")
+
+    def test_pretty_output_no_conditions(self):
+        config = MagicMock()
+        config.get_lease.return_value = _make_lease(conditions=[])
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["lease", "lease-1", "--client", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Conditions:  <none>" in result.output
+        assert "Unknown" in result.output
+
+    def test_json_output(self):
+        config = MagicMock()
+        config.get_lease.return_value = _make_lease()
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["lease", "lease-1", "--client", "test", "-o", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["name"] == "lease-1"
+        assert data["selector"] == "board=rpi4"
+        assert data["client"] == "my-client"
+        assert data["exporter"] == "exporter-1"
+        assert data["conditions"][0]["type"] == "Ready"
+
+    def test_unknown_name(self):
+        config = MagicMock()
+        config.get_lease.side_effect = ConnectionError("lease 'missing' not found")
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["lease", "missing", "--client", "test"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestDescribeClient:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_pretty_output(self):
+        token = _make_jwt(exp_offset_seconds=7200)
+        config = _make_client_config(token=token, refresh_token="fake-refresh")
+        with _patch_client_configs(config, current_alias="test-client"):
+            result = self.runner.invoke(describe, ["client", "test-client"])
+        assert result.exit_code == 0, result.output
+        assert "Alias:" in result.output
+        assert "test-client" in result.output
+        assert "Current:" in result.output
+        assert "my-client" in result.output
+        assert "grpc.example.com:443" in result.output
+        assert "jumpstarter_driver_power" in result.output
+        assert "valid" in result.output
+        assert "Refresh Token Stored:" in result.output
+        assert token not in result.output
+        assert "fake-refresh" not in result.output
+
+    def test_pretty_output_not_current(self):
+        config = _make_client_config()
+        with _patch_client_configs(config, current_alias="other-client"):
+            result = self.runner.invoke(describe, ["client", "test-client"])
+        assert result.exit_code == 0, result.output
+        assert "Current:" in result.output
+        assert "no" in result.output
+
+    def test_default_client(self):
+        config = _make_client_config()
+        with _patch_client_configs(config, current_alias="test-client", default_client=config):
+            result = self.runner.invoke(describe, ["client"])
+        assert result.exit_code == 0, result.output
+        assert "test-client" in result.output
+        assert "yes" in result.output
+
+    def test_no_default_client(self):
+        config = _make_client_config()
+        with _patch_client_configs(config, default_client=None):
+            result = self.runner.invoke(describe, ["client"])
+        assert result.exit_code != 0
+        assert "no default client" in result.output
+
+    def test_json_output_never_contains_token(self):
+        token = _make_jwt(exp_offset_seconds=7200)
+        config = _make_client_config(token=token, refresh_token="fake-refresh")
+        with _patch_client_configs(config, current_alias="test-client"):
+            result = self.runner.invoke(describe, ["client", "test-client", "-o", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["alias"] == "test-client"
+        assert data["current"] is True
+        assert data["endpoint"] == "grpc.example.com:443"
+        assert data["tokenExpiry"] is not None
+        assert data["tokenStatus"].startswith("valid")
+        assert data["refreshTokenStored"] is True
+        assert token not in result.output
+        assert "fake-refresh" not in result.output
+
+    def test_yaml_output_never_contains_token(self):
+        token = _make_jwt(exp_offset_seconds=7200)
+        config = _make_client_config(token=token, refresh_token="fake-refresh")
+        with _patch_client_configs(config, current_alias="test-client"):
+            result = self.runner.invoke(describe, ["client", "test-client", "-o", "yaml"])
+        assert result.exit_code == 0, result.output
+        assert token not in result.output
+        assert "fake-refresh" not in result.output
+        assert "tokenStatus" in result.output
+
+    def test_no_token(self):
+        config = _make_client_config(token=None)
+        with _patch_client_configs(config):
+            result = self.runner.invoke(describe, ["client", "test-client"])
+        assert result.exit_code == 0, result.output
+        assert "no token" in result.output
+
+    def test_malformed_token(self):
+        config = _make_client_config(token=CLIENT_TOKEN_PLACEHOLDER)
+        with _patch_client_configs(config):
+            result = self.runner.invoke(describe, ["client", "test-client"])
+        assert result.exit_code == 0, result.output
+        assert "malformed" in result.output
+        assert "Traceback" not in result.output
+
+    def test_malformed_token_json(self):
+        config = _make_client_config(token=CLIENT_TOKEN_PLACEHOLDER)
+        with _patch_client_configs(config):
+            result = self.runner.invoke(describe, ["client", "test-client", "-o", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["tokenStatus"] == "malformed"
+        assert data["tokenExpiry"] is None
+
+    def test_token_without_exp_claim(self):
+        config = _make_client_config(token=_make_jwt(include_exp=False))
+        with _patch_client_configs(config):
+            result = self.runner.invoke(describe, ["client", "test-client"])
+        assert result.exit_code == 0, result.output
+        assert "no expiry claim" in result.output
+
+    def test_expired_token(self):
+        config = _make_client_config(token=_make_jwt(exp_offset_seconds=-3600))
+        with _patch_client_configs(config):
+            result = self.runner.invoke(describe, ["client", "test-client"])
+        assert result.exit_code == 0, result.output
+        assert "expired" in result.output
+
+
+class TestDescribeGroup:
+    def test_subcommands_registered(self):
+        assert set(describe.commands) == {"exporter", "lease", "client"}
+
+    def test_desc_alias(self):
+        from jumpstarter_cli.jmp import jmp
+
+        ctx = MagicMock()
+        ctx.fail = MagicMock()
+        assert jmp.get_command(ctx, "desc") is describe

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/describe_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/describe_test.py
@@ -11,7 +11,7 @@ from jumpstarter_protocol import kubernetes_pb2
 
 from jumpstarter_cli.describe import describe
 
-from jumpstarter.client.grpc import Exporter, Lease
+from jumpstarter.client.grpc import Exporter, Lease, LeaseList
 from jumpstarter.common import ExporterStatus
 from jumpstarter.common.exceptions import ConnectionError
 
@@ -37,14 +37,14 @@ def _make_condition(type="Ready", status="True", reason="Ready", message="lease 
     return condition
 
 
-def _make_lease(name="lease-1", conditions=None, **kwargs):
+def _make_lease(name="lease-1", conditions=None, exporter="exporter-1", **kwargs):
     return Lease(
         namespace="default",
         name=name,
         selector="board=rpi4",
         duration=timedelta(minutes=30),
         client="my-client",
-        exporter="exporter-1",
+        exporter=exporter,
         conditions=conditions if conditions is not None else [_make_condition()],
         effective_begin_time=datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
         tags={"build": "1234"},
@@ -63,6 +63,18 @@ def _make_exporter(lease=None):
         enabled=True,
         lease=lease,
     )
+
+
+def _exporter_config(exporter=None, leases=()):
+    """A client config that answers the way the real one does.
+
+    GetExporter never carries a lease, so a test that hangs one on the exporter
+    is testing something the server cannot do.
+    """
+    config = MagicMock()
+    config.get_exporter.return_value = exporter if exporter is not None else _make_exporter()
+    config.list_leases.return_value = LeaseList(leases=list(leases), next_page_token=None)
+    return config
 
 
 def _patch_remote_config(config):
@@ -104,8 +116,7 @@ class TestDescribeExporter:
         self.runner = CliRunner()
 
     def test_pretty_output(self):
-        config = MagicMock()
-        config.get_exporter.return_value = _make_exporter()
+        config = _exporter_config()
         with _patch_remote_config(config):
             result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
         assert result.exit_code == 0, result.output
@@ -121,8 +132,8 @@ class TestDescribeExporter:
         config.get_exporter.assert_called_once_with("exporter-1")
 
     def test_pretty_output_with_lease(self):
-        config = MagicMock()
-        config.get_exporter.return_value = _make_exporter(lease=_make_lease())
+        # The lease comes from ListLeases, not from the exporter itself.
+        config = _exporter_config(leases=[_make_lease()])
         with _patch_remote_config(config):
             result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
         assert result.exit_code == 0, result.output
@@ -131,12 +142,20 @@ class TestDescribeExporter:
         assert "my-client" in result.output
         assert "In-Use" in result.output
         assert "0:30:00" in result.output
+        config.list_leases.assert_called_once_with(only_active=True)
+
+    def test_a_lease_on_another_exporter_is_not_reported(self):
+        config = _exporter_config(leases=[_make_lease(name="lease-2", exporter="exporter-2")])
+        with _patch_remote_config(config):
+            result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Lease:  <none>" in result.output
+        assert "lease-2" not in result.output
 
     def test_pretty_output_deprecated_labels(self):
         exporter = _make_exporter()
         exporter.deprecated_labels = {"old-key": "Use new-key instead"}
-        config = MagicMock()
-        config.get_exporter.return_value = exporter
+        config = _exporter_config(exporter)
         with _patch_remote_config(config):
             result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test"])
         assert result.exit_code == 0, result.output
@@ -144,8 +163,7 @@ class TestDescribeExporter:
         assert "old-key=Use new-key instead" in result.output
 
     def test_json_output(self):
-        config = MagicMock()
-        config.get_exporter.return_value = _make_exporter()
+        config = _exporter_config(leases=[_make_lease()])
         with _patch_remote_config(config):
             result = self.runner.invoke(describe, ["exporter", "exporter-1", "--client", "test", "-o", "json"])
         assert result.exit_code == 0, result.output
@@ -154,9 +172,10 @@ class TestDescribeExporter:
         assert data["namespace"] == "default"
         assert data["labels"] == {"board": "rpi4", "env": "test"}
         assert data["online"] is True
+        assert data["lease"]["name"] == "lease-1"
 
     def test_unknown_name(self):
-        config = MagicMock()
+        config = _exporter_config()
         config.get_exporter.side_effect = ConnectionError("exporter 'missing' not found")
         with _patch_remote_config(config):
             result = self.runner.invoke(describe, ["exporter", "missing", "--client", "test"])

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/jmp.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/jmp.py
@@ -10,6 +10,7 @@ from .completion import completion
 from .config import config
 from .create import create
 from .delete import delete
+from .describe import describe
 from .get import get
 from .login import login
 from .run import run
@@ -30,6 +31,7 @@ jmp.add_command(create)
 jmp.add_command(delete)
 jmp.add_command(update)
 jmp.add_command(get)
+jmp.add_command(describe)
 jmp.add_command(shell)
 jmp.add_command(run)
 jmp.add_command(login)


### PR DESCRIPTION
`jmp get` answers what exists; there was no way to ask about one of them in detail short of reading the raw object.

Adds `jmp describe exporter|lease|client <name>`, following `kubectl describe`: a readable summary by default, `-o json|yaml` for a machine. Describing an exporter reports the lease holding it, describing a lease reports its conditions, and describing a client reads the local config — so it works without a connection and says whether the token is still valid. The client description never emits token material.

Documented in the distributed mode guide, where a user first needs to know which exporters exist and what to select on, and from the lease troubleshooting entry in the testing guide. The man page picks the commands up from click.
