### PR TITLE
fix: do not add a label for the exporter name

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/config/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/config/exporter.py
@@ -383,7 +383,7 @@ class ExporterConfigV1Alpha1(BaseModel):
         try:
             exporter = Exporter(
                 token=self.token or "",
-                labels={"jumpstarter.dev/name": self.metadata.name},
+                exporter_name=self.metadata.name,
                 channel_factory=dummy_channel_factory if standalone else channel_factory,
                 device_factory=ExporterConfigV1Alpha1DriverInstance(
                     type="jumpstarter_driver_composite.driver.Composite",

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter.py
@@ -198,6 +198,8 @@ class Exporter(AsyncContextManagerMixin, Metadata):
 
     # Public Configuration Fields
 
+    exporter_name: str = "unknown"
+
     channel_factory: Callable[[], Awaitable[grpc.aio.Channel]]
     """Factory function for creating gRPC channels to communicate with the controller.
 
@@ -1244,7 +1246,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         """Serve the exporter, handling leases until stopped."""
         # Set exporter identity before anything else so every log line (including
         # registration and telemetry setup) carries the correct exporter name.
-        set_log_context(exporter=self.name)
+        set_log_context(exporter=self.exporter_name)
         async with self.session():
             pass
         # Unbounded on purpose. The control-plane loop is the sole receiver AND,
@@ -1368,7 +1370,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         Extracted so tests can verify context propagation without duplicating
         this logic separately from _on_lease_acquired.
         """
-        log_ctx: dict[str, str] = {"lease_id": status.lease_name, "exporter": self.name}
+        log_ctx: dict[str, str] = {"lease_id": status.lease_name, "exporter": self.exporter_name}
         if status.context:
             log_ctx.update(status.context)
         return log_ctx
@@ -1441,7 +1443,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         # what actually drops the lease's log fields — a clear in handle_lease's
         # task would not reach the loop.
         clear_log_context()
-        set_log_context(exporter=self.name)
+        set_log_context(exporter=self.exporter_name)
         logger.debug("Ready for next lease")
 
         # Now that the slot is free, replay a stashed reassignment so the loop
@@ -1538,7 +1540,7 @@ class Exporter(AsyncContextManagerMixin, Metadata):
         self._standalone = True
         lease_scope = LeaseContext(lease_name="standalone", before_lease_hook=Event())
         self._lease_context = lease_scope
-        set_log_context(exporter=self.name, lease_id="standalone")
+        set_log_context(exporter=self.exporter_name, lease_id="standalone")
 
         with TemporarySocket() as hook_path:
             hook_path_str = str(hook_path)

--- a/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
+++ b/python/packages/jumpstarter/jumpstarter/exporter/exporter_test.py
@@ -63,7 +63,8 @@ def _make_base_exporter(**overrides):
         "_release_lease_unsupported": False,
         "hook_executor": None,
         "exit_on_lease_end": False,
-        "labels": {"jumpstarter.dev/name": "test-exporter"},
+        "labels": {},
+        "exporter_name": "test-exporter",
         "_last_completed_lease": None,
         "_pending_lease_status": None,
         "_control_tx": None,
@@ -1384,7 +1385,6 @@ class TestHandleLeaseConnections:
 
         lease_ctx = make_lease_context(lease_name="conn-lease")
         exporter = make_exporter(lease_ctx)
-        exporter.labels = {"jumpstarter.dev/name": "test-exporter"}
         exporter.tls = None
         exporter.grpc_options = []
         exporter._started = True
@@ -1445,7 +1445,6 @@ class TestHandleLeaseConnections:
 
         lease_ctx = make_lease_context(lease_name="fallback-lease")
         exporter = make_exporter(lease_ctx)
-        exporter.labels = {"jumpstarter.dev/name": "test-exporter"}
         exporter.tls = None
         exporter.grpc_options = []
         exporter._started = True
@@ -1647,7 +1646,6 @@ class TestHandleLeaseConnections:
 
         lease_ctx = make_lease_context(lease_name="stale-setup")
         exporter = make_exporter(lease_ctx)
-        exporter.labels = {"jumpstarter.dev/name": "test-exporter"}
         exporter.tls = None
         exporter.grpc_options = []
         exporter._started = True
@@ -2123,7 +2121,8 @@ class TestContextPropagation:
         exporter._standalone = False
         exporter._started = False
         exporter.hook_executor = None
-        exporter.labels = {"jumpstarter.dev/name": "lab-exporter-01"}
+        exporter.labels = {}
+        exporter.exporter_name = "lab-exporter-01"
         exporter._report_status = AsyncMock()
         exporter._request_lease_release = AsyncMock()
 


### PR DESCRIPTION
we should just use the name, no need to send a label that will be persisted to the k8s resource