### PR TITLE
fix(jumpstarter-mcp): pin mcp to <2.0.0 until 2.x migration

### DIFF
--- a/python/packages/jumpstarter-mcp/pyproject.toml
+++ b/python/packages/jumpstarter-mcp/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
   "jumpstarter",
   "jumpstarter-cli-common",
-  "mcp>=1.0.0",
+  "mcp>=1.0.0,<2.0.0",
   "anyio>=4.0.0",
   "click>=8.1.7.2",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3755,7 +3755,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7.2" },
     { name = "jumpstarter", editable = "packages/jumpstarter" },
     { name = "jumpstarter-cli-common", editable = "packages/jumpstarter-cli-common" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

`jmp mcp serve` crashes at startup on fresh installs because the dependency was declared as `mcp>=1.0.0`, which now resolves to mcp 2.x — where `mcp.server.fastmcp.FastMCP` has been removed:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x,
where FastMCP was renamed to MCPServer (from mcp.server.mcpserver import
MCPServer) and other APIs changed; see the migration guide at
https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver
or pin 'mcp<2' to keep running v1 code.
```

This pins the dependency to `mcp>=1.0.0,<2.0.0` so resolution stays on the 1.x API the server is written against (lock still resolves mcp 1.26.0).

The lockfile also picks up the `jumpstarter-driver-netsim` workspace package, which was missing from the previously stale lock.

Part of #1078

## Test plan

- [x] `uv lock` resolves cleanly with the pin
- [x] With mcp 1.x installed, `from mcp.server.fastmcp import FastMCP` works and `jmp mcp serve --help` starts
- [x] `make pkg-test-jumpstarter-mcp` (CI)

## Notes for the follow-up (mcp 2.x migration, #1078)

Not a drop-in rename — assessed against mcp 2.1.1:

1. `FastMCP` → `MCPServer` (`mcp.server.mcpserver`)
2. `mcp.get_context()` is gone; `_capture_session_for_notifications()` relies on `ctx.request_context.session` and needs rework
3. Log notifications: `Context.log` deprecated (SEP-2577), delivery is now per-request opt-in
4. Private `mcp._mcp_server` used in `run_server()` is `mcp._lowlevel_server` in 2.x
5. `stdio_server(stdout=...)` and `@mcp.tool()` still exist in 2.x