### PR TITLE
ci: add `uv lock --check` to catch stale lockfiles

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -167,6 +167,11 @@ jobs:
               "https://iad.mirror.rackspace.com/fedora/releases/${FEDORA_RELEASE}/Cloud/${arch}/images/Fedora-Cloud-Base-Generic-${FEDORA_CLOUD_VERSION}.${arch}.qcow2"
           done
 
+      - name: Verify uv.lock is up-to-date
+        working-directory: python
+        run: |
+          uv lock --check
+
       - name: Run pytest
         working-directory: python
         env:


### PR DESCRIPTION
## Problem

When `uv.lock` is regenerated locally with a different Python version than CI uses (e.g., local Python 3.13 via `.python-version` vs CI Python 3.14), package resolutions can differ. This leads to packages like Pillow resolving to older versions that lack `cp314` wheels, causing CI test failures with cryptic install errors.

This happened on #1068 — after a rebase, `uv lock` was run locally with Python 3.13, which resolved Pillow to 11.2.1 (no cp314 wheels) instead of 12.3.0 (has cp314 wheels), breaking the Python 3.14 CI job.

## Fix

Add a `uv lock --check` step before `Run pytest` in the CI workflow. This command verifies that the lockfile is consistent with the current `pyproject.toml` and Python version without modifying it. If the lockfile is stale or was generated with a different Python, the step fails early with a clear error message instead of proceeding to cryptic wheel installation failures.

## Notes

- `uv lock --check` is a read-only operation — it never modifies the lockfile
- This runs on every test matrix combination (all Python versions × all runners), so it will catch version-specific resolution mismatches
- The `.python-version` file is already in `.gitignore`, so this is the safety net for developers who have local overrides