### PR TITLE
Don't reconnect the shell after the user exits

### DIFF
--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell.py
@@ -291,7 +291,35 @@ async def _cancel_if_connection_lost(monitor, coro):
     return result
 
 
-async def _run_shell_with_lease_async(lease, exporter_logs, config, command, cancel_scope):  # noqa: C901
+async def _run_shell_with_lease_async(lease, exporter_logs, config, command, cancel_scope):
+    """Run an interactive session, ignoring exporter loss that arrives after the shell exits.
+
+    The shell runs in a worker thread that anyio cannot cancel. If a
+    per-connection Dial fails while the user is at the prompt, the listener's
+    task group cancels the session, but the cancellation only lands once the
+    shell returns - discarding its exit code and making the caller's retry loop
+    reconnect the user into a fresh shell. Once the shell has exited the user
+    is done, so report its exit code instead.
+    """
+    exit_code = None  # recorded from inside the shell thread once it returns
+
+    def record_exit(code):
+        nonlocal exit_code
+        exit_code = code
+
+    try:
+        return await _run_shell_session(lease, exporter_logs, config, command, cancel_scope, record_exit)
+    except (BaseExceptionGroup, ExporterUnreachableError) as exc:
+        unreachable = (
+            find_exception_in_group(exc, ExporterUnreachableError) if isinstance(exc, BaseExceptionGroup) else exc
+        )
+        if unreachable is None or exit_code is None:
+            raise
+        logger.debug("Exporter unreachable after shell exit, not reconnecting: %s", unreachable)
+        return exit_code
+
+
+async def _run_shell_session(lease, exporter_logs, config, command, cancel_scope, on_shell_exit):  # noqa: C901
     """Run shell with lease context managers and wait for afterLease hook if logs enabled.
 
     When exporter_logs is enabled, this function will:
@@ -371,10 +399,16 @@ async def _run_shell_with_lease_async(lease, exporter_logs, config, command, can
                                 except Exception:
                                     logger.debug("Failed to fetch motd, continuing without it")
 
-                            # Run the shell command
-                            exit_code = await anyio.to_thread.run_sync(
-                                _run_shell_only, lease, config, command, path, motd
-                            )
+                            # Run the shell command. The exit code is reported from
+                            # inside the thread: run_sync is not cancellable, so if the
+                            # enclosing task group is already unwinding, the await below
+                            # raises instead of returning and the value would be lost.
+                            def _run_and_record():
+                                code = _run_shell_only(lease, config, command, path, motd)
+                                on_shell_exit(code)
+                                return code
+
+                            exit_code = await anyio.to_thread.run_sync(_run_and_record)
 
                             # Shell has exited. For auto-created leases (release=True), call
                             # EndSession to trigger afterLease hook while keeping log stream

--- a/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
+++ b/python/packages/jumpstarter-cli/jumpstarter_cli/shell_test.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import anyio
 import click
+import grpc
+import grpc.aio
 import pytest
 from jumpstarter_cli_common.exceptions import handle_exceptions_with_reauthentication
 
@@ -938,6 +940,75 @@ class TestRunShellWithLeaseAsync:
 
         assert exit_code == 0
         client.end_session_async.assert_called_once()
+
+    async def test_unreachable_after_shell_exit_returns_exit_code(self):
+        """An exporter lost while the user is at the prompt must not trigger a reconnect.
+
+        The failure surfaces from the listener task group, but the shell runs in
+        a thread that cannot be cancelled, so it only lands once the user exits.
+        By then the session is over and the exit code is the right answer.
+        """
+        monitor = _FakeStatusMonitor()
+        client = _build_fake_client(monitor, get_status_return=ExporterStatus.LEASE_READY)
+        lease = _make_shell_lease(release=True, lease_ended=False)
+        cancel_scope = Mock(cancel_called=False)
+
+        @asynccontextmanager
+        async def serve_unix_async():
+            # Mirrors TemporaryUnixListener: a connection handler that raises
+            # cancels the body and surfaces as a group at teardown.
+            async with anyio.create_task_group() as tg:
+
+                async def failing_handler():
+                    await anyio.sleep(0.05)
+                    raise ExporterUnreachableError("Per-connection Dial failed for test-exporter")
+
+                tg.start_soon(failing_handler)
+                yield "/tmp/fake.sock"
+
+        lease.serve_unix_async = serve_unix_async
+
+        def slow_shell(*_a, **_kw):
+            time.sleep(0.3)
+            return 42
+
+        @asynccontextmanager
+        async def fake_client_from_path(*_a, **_kw):
+            yield client
+
+        with (
+            patch("jumpstarter_cli.shell.client_from_path", side_effect=fake_client_from_path),
+            patch("jumpstarter_cli.shell._run_shell_only", side_effect=slow_shell),
+        ):
+            exit_code = await _run_shell_with_lease_async(lease, False, None, (), cancel_scope)
+
+        assert exit_code == 42
+
+    async def test_unreachable_before_shell_starts_propagates(self):
+        """An exporter that never answers must still reach the caller's retry loop."""
+        monitor = _FakeStatusMonitor()
+        client = _build_fake_client(monitor)
+        client.get_status_async.side_effect = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=None,
+            trailing_metadata=None,
+            details="exporter offline",
+        )
+        lease = _make_shell_lease(release=True, lease_ended=False)
+        cancel_scope = Mock(cancel_called=False)
+
+        @asynccontextmanager
+        async def fake_client_from_path(*_a, **_kw):
+            yield client
+
+        with (
+            patch("jumpstarter_cli.shell.client_from_path", side_effect=fake_client_from_path),
+            patch("jumpstarter_cli.shell._run_shell_only", return_value=0) as run_shell,
+        ):
+            with pytest.raises(ExporterUnreachableError):
+                await _run_shell_with_lease_async(lease, False, None, (), cancel_scope)
+
+        run_shell.assert_not_called()
 
     async def test_available_status_probe_with_lease_ended_race(self):
         """When lease expires during the probe (race condition), AVAILABLE

--- a/python/packages/jumpstarter/jumpstarter/client/lease.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease.py
@@ -411,13 +411,15 @@ class Lease(ContextManagerMixin, AsyncContextManagerMixin):
         await self._dial_with_retry()
 
         async def _tunnel_handler(stream):
+            # Retry transient failures: a single controller blip here would
+            # otherwise tear down the whole session, because this handler runs in
+            # the listener's task group. Only a persistently unreachable exporter
+            # should propagate and trigger the shell's reconnect path.
             try:
-                response = await self.controller.Dial(
-                    jumpstarter_pb2.DialRequest(lease_name=self.name)
-                )
-            except AioRpcError as e:
+                response = await self._dial_with_retry()
+            except ExporterUnreachableError as e:
                 raise ExporterUnreachableError(
-                    f"Per-connection Dial failed for {self.exporter_name}: {e.details()}"
+                    f"Per-connection Dial failed for {self.exporter_name}: {e}"
                 ) from e
             async with connect_router_stream(
                 response.router_endpoint,

--- a/python/packages/jumpstarter/jumpstarter/client/lease_test.py
+++ b/python/packages/jumpstarter/jumpstarter/client/lease_test.py
@@ -832,22 +832,13 @@ class TestServeUnixAsync:
         lease.grpc_options = {}
         lease.controller = Mock()
 
-        # Mock the readiness check
-        readiness_check_called = False
+        # Both the readiness check and the per-connection dial go through _dial_with_retry
+        dial_calls = 0
 
         async def mock_dial_with_retry():
-            nonlocal readiness_check_called
-            readiness_check_called = True
-
-        # Mock per-connection Dial
-        dial_call_count = 0
-
-        async def mock_dial(request):
-            nonlocal dial_call_count
-            dial_call_count += 1
+            nonlocal dial_calls
+            dial_calls += 1
             return Mock(router_endpoint="test-endpoint", router_token="test-token")
-
-        lease.controller.Dial = mock_dial
 
         # Mock connect_router_stream
         router_stream_calls = []
@@ -861,7 +852,7 @@ class TestServeUnixAsync:
             with patch("jumpstarter.client.lease.connect_router_stream", side_effect=mock_connect_router_stream):
                 async with lease.serve_unix_async() as socket_path:
                     # Readiness check should have been called
-                    assert readiness_check_called
+                    assert dial_calls == 1
 
                     # Connect to the Unix socket
                     async with await anyio.connect_unix(socket_path):
@@ -869,7 +860,7 @@ class TestServeUnixAsync:
                         await anyio.sleep(0.1)
 
         # Verify per-connection Dial was called
-        assert dial_call_count == 1
+        assert dial_calls == 2
 
         # Verify connect_router_stream was called with correct args
         assert len(router_stream_calls) == 1
@@ -881,7 +872,7 @@ class TestServeUnixAsync:
 
     @pytest.mark.anyio
     async def test_serve_unix_async_per_connection_dial_failure_wrapped(self):
-        """Per-connection Dial failure raises ExporterUnreachableError instead of raw AioRpcError."""
+        """A per-connection Dial that keeps failing raises ExporterUnreachableError."""
         from grpc import StatusCode
 
         lease = object.__new__(Lease)
@@ -890,13 +881,15 @@ class TestServeUnixAsync:
         lease.tls_config = Mock()
         lease.grpc_options = {}
         lease.controller = Mock()
+        lease.dial_timeout = 0.1
 
-        # Mock the readiness check
-        async def mock_dial_with_retry():
-            pass
+        # Readiness check succeeds, every per-connection Dial after it fails
+        calls = {"count": 0}
 
-        # Mock per-connection Dial to raise AioRpcError
-        async def mock_dial_failure(request):
+        async def mock_dial(request):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return Mock(router_endpoint="test-endpoint", router_token="test-token")
             raise AioRpcError(
                 code=StatusCode.UNAVAILABLE,
                 initial_metadata=None,
@@ -904,17 +897,62 @@ class TestServeUnixAsync:
                 details="exporter offline",
             )
 
-        lease.controller.Dial = mock_dial_failure
+        lease.controller.Dial = mock_dial
 
         # The ExceptionGroup surfaces when the TemporaryUnixListener task group
         # tears down, so pytest.raises must wrap the entire serve_unix_async block.
-        with patch.object(lease, "_dial_with_retry", side_effect=mock_dial_with_retry):
-            with pytest.raises(BaseExceptionGroup) as exc_info:
-                async with lease.serve_unix_async() as socket_path:
-                    async with await anyio.connect_unix(socket_path):
-                        await anyio.sleep(0.1)
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async with lease.serve_unix_async() as socket_path:
+                async with await anyio.connect_unix(socket_path):
+                    await anyio.sleep(1)
 
-            exceptions = exc_info.value.exceptions
-            assert len(exceptions) == 1
-            assert isinstance(exceptions[0], ExporterUnreachableError)
-            assert "Per-connection Dial failed" in str(exceptions[0])
+        exceptions = exc_info.value.exceptions
+        assert len(exceptions) == 1
+        assert isinstance(exceptions[0], ExporterUnreachableError)
+        assert "Per-connection Dial failed" in str(exceptions[0])
+        # It retried rather than giving up on the first failure
+        assert calls["count"] > 2
+
+    @pytest.mark.anyio
+    async def test_serve_unix_async_per_connection_dial_survives_transient_failure(self):
+        """A per-connection Dial blip is retried instead of tearing down the session."""
+        from grpc import StatusCode
+
+        lease = object.__new__(Lease)
+        lease.name = "test-lease"
+        lease.exporter_name = "test-exporter"
+        lease.tls_config = Mock()
+        lease.grpc_options = {}
+        lease.controller = Mock()
+        lease.dial_timeout = 5.0
+
+        calls = {"count": 0}
+
+        async def mock_dial(request):
+            calls["count"] += 1
+            # readiness check, then one blip, then success
+            if calls["count"] == 2:
+                raise AioRpcError(
+                    code=StatusCode.UNAVAILABLE,
+                    initial_metadata=None,
+                    trailing_metadata=None,
+                    details="transient",
+                )
+            return Mock(router_endpoint="test-endpoint", router_token="test-token")
+
+        lease.controller.Dial = mock_dial
+
+        router_stream_calls = []
+
+        @asynccontextmanager
+        async def mock_connect_router_stream(endpoint, token, stream, tls_config, grpc_options):
+            router_stream_calls.append(endpoint)
+            yield
+
+        with patch("jumpstarter.client.lease.connect_router_stream", side_effect=mock_connect_router_stream):
+            async with lease.serve_unix_async() as socket_path:
+                async with await anyio.connect_unix(socket_path):
+                    await anyio.sleep(1)
+
+        # The connection was served despite the blip
+        assert router_stream_calls == ["test-endpoint"]


### PR DESCRIPTION
Two paths could drop a user into a fresh, unwanted session after they exited the previous one.

A per-connection Dial runs every time something opens the lease's unix socket - a background port forward, a nested `j` invocation. It had no retry, so a single controller blip raised ExporterUnreachableError inside the listener's task group and tore down the whole session. Route it through _dial_with_retry with a tighter bound so transient failures are absorbed.

When that error does fire, it cancels the session, but the interactive shell runs in a worker thread that anyio cannot cancel. The cancellation is therefore delivered only once the user exits, which discards the shell's exit code and leaves the caller's retry loop seeing "the exporter died, reconnect" - so it released the lease and re-leased, landing the user in a new shell. Record the exit code from inside the thread and return it instead: once the shell has exited, the user is done and there is nothing to reconnect to.