### PR TITLE
fix(operator): grant exporter-set controllers exporters/finalizers

### DIFF
--- a/controller/deploy/operator/internal/controller/jumpstarter/exporterset.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/exporterset.go
@@ -513,6 +513,16 @@ func exporterSetPolicyRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
+			// The per-exporter config Secret and the exporter Pod are both owned by
+			// their Exporter via SetControllerReference, which sets
+			// blockOwnerDeletion. The API server rejects an ownerReference carrying
+			// that flag unless the writer may update the owner's finalizers, so
+			// without this rule neither the Secret nor the Pod can be created.
+			APIGroups: []string{"jumpstarter.dev"},
+			Resources: []string{"exporters/finalizers"},
+			Verbs:     []string{"update"},
+		},
+		{
 			APIGroups: []string{"jumpstarter.dev"},
 			Resources: []string{"leases"},
 			Verbs:     []string{"get", "list", "watch"},

--- a/controller/deploy/operator/internal/controller/jumpstarter/exporterset_test.go
+++ b/controller/deploy/operator/internal/controller/jumpstarter/exporterset_test.go
@@ -192,6 +192,21 @@ var _ = Describe("exporterSetPolicyRules", func() {
 		Fail("no rule found granting full CRUD on exporters")
 	})
 
+	It("should grant update on exporters/finalizers", func() {
+		// The config Secret and the exporter Pod are both owned by their Exporter
+		// via SetControllerReference, which sets blockOwnerDeletion; the API server
+		// refuses that ownerReference unless the writer may update the owner's
+		// finalizers. Without this rule the controller creates neither object.
+		for _, rule := range rules {
+			if containsString(rule.APIGroups, "jumpstarter.dev") &&
+				containsString(rule.Resources, "exporters/finalizers") {
+				Expect(rule.Verbs).To(ContainElement("update"))
+				return
+			}
+		}
+		Fail("no rule found granting update on exporters/finalizers")
+	})
+
 	It("should grant read-only access on jumpstarter leases", func() {
 		for _, rule := range rules {
 			if containsString(rule.APIGroups, "jumpstarter.dev") &&


### PR DESCRIPTION
The exporter-set controller makes each Exporter the controller-owner of its config Secret and of its Pod via SetControllerReference, which sets blockOwnerDeletion on the ownerReference. The API server rejects such an ownerReference unless the writer may update the owner's finalizers, so with only the exporters rule the controller fails every reconcile with

  secrets "exporter-config-<exporter>" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on

and neither the Secret nor the Pod is ever created. The ExporterSet reports a degraded replica with no failed pods, which gives no hint at the cause.

It does not surface in the kind-based flows, which deploy the controller with broader permissions than the operator's namespaced Role.

The operator's own ClusterRole already grants jumpstarter.dev exporters/finalizers, so no additional privileges are needed to delegate it and the generated manifests are unchanged.