### PR TITLE
common/storage: run fsync off the event loop

### DIFF
--- a/python/packages/jumpstarter/jumpstarter/common/storage.py
+++ b/python/packages/jumpstarter/jumpstarter/common/storage.py
@@ -3,7 +3,7 @@ import os
 from logging import Logger
 from typing import Literal
 
-from anyio import fail_after, sleep
+from anyio import fail_after, sleep, to_thread
 from anyio.abc import AnyByteStream
 from anyio.streams.file import FileReadStream, FileWriteStream
 
@@ -86,7 +86,7 @@ async def write_to_storage_device(
                     try:
                         if logger:
                             logger.info("fsyncing storage device {}, please wait".format(storage_device))
-                        os.fsync(file.fileno())
+                        await to_thread.run_sync(os.fsync, file.fileno())
                     except OSError as e:
                         if e.errno == errno.EIO:
                             await sleep(1)

--- a/python/packages/jumpstarter/jumpstarter/common/storage_test.py
+++ b/python/packages/jumpstarter/jumpstarter/common/storage_test.py
@@ -1,0 +1,66 @@
+import os
+import threading
+import time
+
+import pytest
+from anyio import create_memory_object_stream, move_on_after
+
+from .storage import write_to_storage_device
+
+
+@pytest.mark.asyncio
+async def test_write_to_storage_device_fsyncs_off_the_event_loop(tmp_path, monkeypatch):
+    # A blocking fsync holds the event loop for the whole flush. On an
+    # exporter that stalls keepalives and status polls, so a client flashing
+    # a multi-gigabyte image sees the connection go dead while the card is
+    # still being written. Assert the call lands on a worker thread.
+    device = tmp_path / "device"
+    device.write_bytes(b"\0" * 1024)
+
+    fsync_threads = []
+    real_fsync = os.fsync
+
+    def recording_fsync(fd):
+        fsync_threads.append(threading.current_thread())
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", recording_fsync)
+
+    send, receive = create_memory_object_stream(max_buffer_size=1)
+    await send.send(b"payload")
+    await send.aclose()
+
+    await write_to_storage_device(device, receive, leeway=0)
+
+    assert fsync_threads, "fsync was never called"
+    assert fsync_threads[0] is not threading.current_thread()
+
+
+@pytest.mark.asyncio
+async def test_write_to_storage_device_keeps_the_descriptor_open_for_fsync(tmp_path, monkeypatch):
+    # Cancelling mid-flush must not abandon the worker. The enclosing
+    # os.fdopen context closes the descriptor on the way out, so an abandoned
+    # worker would fsync a closed -- or recycled -- descriptor.
+    device = tmp_path / "device"
+    device.write_bytes(b"\0" * 1024)
+
+    observed = []
+
+    def slow_fsync(fd):
+        time.sleep(0.3)
+        try:
+            os.fstat(fd)
+            observed.append("open")
+        except OSError:
+            observed.append("closed")
+
+    monkeypatch.setattr(os, "fsync", slow_fsync)
+
+    send, receive = create_memory_object_stream(max_buffer_size=1)
+    await send.send(b"payload")
+    await send.aclose()
+
+    with move_on_after(0.1):
+        await write_to_storage_device(device, receive, leeway=0)
+
+    assert observed == ["open"]


### PR DESCRIPTION
write_to_storage_device calls os.fsync directly from a coroutine. That call blocks until the kernel has flushed every dirty page, which for a multi-gigabyte image on removable storage is minutes, and for all of that time the exporter's event loop cannot run: keepalive pings and GetStatus polls go unanswered.

A client flashing a 3.1 GB image therefore sees the transfer finish at page-cache speed and the connection then die while the card is still being written:

    transfer  77.5 MB/s 3.1/3.1 GB Elapsed: 0:00:40
    WARNING   GetStatus timed out 20 times consecutively, marking connection as lost
    Error: DriverCall 'write' failed with gRPC UNAVAILABLE: ping timeout

The write itself succeeds; only the connection is lost, because the client's status monitor gives up after roughly 100s while the flush is still in progress.

Run the fsync on a worker thread so the loop keeps serving. This also makes the surrounding fail_after(fsync_timeout) effective: anyio cannot interrupt a thread blocked in a syscall, so without abandon_on_cancel the scope cannot expire until the fsync has already returned, which is exactly when the budget no longer matters.